### PR TITLE
Add RefSeq Protein Accessions for Most Genes

### DIFF
--- a/model.xml
+++ b/model.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<sbml xmlns="http://www.sbml.org/sbml/level3/version1/core" xmlns:fbc="http://www.sbml.org/sbml/level3/version1/fbc/version2" sboTerm="SBO:0000624" level="3" version="1" fbc:required="false">
-  <model metaid="meta_hot1a3_genome.rast.mdl" fbc:strict="true">
+<sbml xmlns="http://www.sbml.org/sbml/level3/version1/core" xmlns:fbc="http://www.sbml.org/sbml/level3/version1/fbc/version2" metaid="meta_" sboTerm="SBO:0000624" level="3" version="1" fbc:required="false">
+  <model metaid="meta_" fbc:strict="true">
     <listOfUnitDefinitions>
       <unitDefinition id="mmol_per_gDW_per_hr">
         <listOfUnits>
@@ -18240,7 +18240,7 @@
           </rdf:RDF>
         </annotation>
       </species>
-      <species metaid="meta_M_cpd11462_c0" sboTerm="SBO:0000247" id="M_cpd11462_c0" name="mRNA [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="0" fbc:chemicalFormula="">
+      <species metaid="meta_M_cpd11462_c0" sboTerm="SBO:0000247" id="M_cpd11462_c0" name="mRNA [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="0">
         <annotation>
           <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
             <rdf:Description rdf:about="#meta_M_cpd11462_c0">
@@ -21746,7 +21746,7 @@
           </rdf:RDF>
         </annotation>
       </species>
-      <species metaid="meta_M_cpd11416_c0" sboTerm="SBO:0000247" id="M_cpd11416_c0" name="Biomass [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="0" fbc:chemicalFormula="">
+      <species metaid="meta_M_cpd11416_c0" sboTerm="SBO:0000247" id="M_cpd11416_c0" name="Biomass [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="0">
         <annotation>
           <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
             <rdf:Description rdf:about="#meta_M_cpd11416_c0">
@@ -58251,7 +58251,7 @@
           <fbc:geneProductRef fbc:geneProduct="G_ACZ81_RS12805"/>
         </fbc:geneProductAssociation>
       </reaction>
-      <reaction metaid="meta_R_rxn45996_c0" sboTerm="SBO:0000176" id="R_rxn45996_c0" name=" [c0]" reversible="true" fast="false" fbc:lowerFluxBound="cobra_default_lb" fbc:upperFluxBound="cobra_default_ub">
+      <reaction metaid="meta_R_rxn45996_c0" sboTerm="SBO:0000176" id="R_rxn45996_c0" name="[c0]" reversible="true" fast="false" fbc:lowerFluxBound="cobra_default_lb" fbc:upperFluxBound="cobra_default_ub">
         <annotation>
           <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
             <rdf:Description rdf:about="#meta_R_rxn45996_c0">
@@ -58309,7 +58309,7 @@
           <fbc:geneProductRef fbc:geneProduct="G_ACZ81_RS00480"/>
         </fbc:geneProductAssociation>
       </reaction>
-      <reaction metaid="meta_R_rxn42230_c0" sboTerm="SBO:0000176" id="R_rxn42230_c0" name=" [c0]" reversible="true" fast="false" fbc:lowerFluxBound="cobra_default_lb" fbc:upperFluxBound="cobra_default_ub">
+      <reaction metaid="meta_R_rxn42230_c0" sboTerm="SBO:0000176" id="R_rxn42230_c0" name="[c0]" reversible="true" fast="false" fbc:lowerFluxBound="cobra_default_lb" fbc:upperFluxBound="cobra_default_ub">
         <annotation>
           <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
             <rdf:Description rdf:about="#meta_R_rxn42230_c0">
@@ -59431,7 +59431,7 @@
           <fbc:geneProductRef fbc:geneProduct="G_ACZ81_RS00495"/>
         </fbc:geneProductAssociation>
       </reaction>
-      <reaction metaid="meta_R_rxn41896_c0" sboTerm="SBO:0000176" id="R_rxn41896_c0" name=" [c0]" reversible="true" fast="false" fbc:lowerFluxBound="cobra_default_lb" fbc:upperFluxBound="cobra_default_ub">
+      <reaction metaid="meta_R_rxn41896_c0" sboTerm="SBO:0000176" id="R_rxn41896_c0" name="[c0]" reversible="true" fast="false" fbc:lowerFluxBound="cobra_default_lb" fbc:upperFluxBound="cobra_default_ub">
         <annotation>
           <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
             <rdf:Description rdf:about="#meta_R_rxn41896_c0">
@@ -59572,7 +59572,7 @@
           <fbc:geneProductRef fbc:geneProduct="G_ACZ81_RS10885"/>
         </fbc:geneProductAssociation>
       </reaction>
-      <reaction metaid="meta_R_rxn44539_c0" sboTerm="SBO:0000176" id="R_rxn44539_c0" name=" [c0]" reversible="true" fast="false" fbc:lowerFluxBound="cobra_default_lb" fbc:upperFluxBound="cobra_default_ub">
+      <reaction metaid="meta_R_rxn44539_c0" sboTerm="SBO:0000176" id="R_rxn44539_c0" name="[c0]" reversible="true" fast="false" fbc:lowerFluxBound="cobra_default_lb" fbc:upperFluxBound="cobra_default_ub">
         <annotation>
           <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
             <rdf:Description rdf:about="#meta_R_rxn44539_c0">
@@ -59692,7 +59692,7 @@
           <fbc:geneProductRef fbc:geneProduct="G_ACZ81_RS13040"/>
         </fbc:geneProductAssociation>
       </reaction>
-      <reaction metaid="meta_R_rxn41452_c0" sboTerm="SBO:0000176" id="R_rxn41452_c0" name=" [c0]" reversible="true" fast="false" fbc:lowerFluxBound="cobra_default_lb" fbc:upperFluxBound="cobra_default_ub">
+      <reaction metaid="meta_R_rxn41452_c0" sboTerm="SBO:0000176" id="R_rxn41452_c0" name="[c0]" reversible="true" fast="false" fbc:lowerFluxBound="cobra_default_lb" fbc:upperFluxBound="cobra_default_ub">
         <annotation>
           <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
             <rdf:Description rdf:about="#meta_R_rxn41452_c0">
@@ -59805,7 +59805,7 @@
           <fbc:geneProductRef fbc:geneProduct="G_ACZ81_RS04880"/>
         </fbc:geneProductAssociation>
       </reaction>
-      <reaction metaid="meta_R_rxn46694_c0" sboTerm="SBO:0000176" id="R_rxn46694_c0" name=" [c0]" reversible="true" fast="false" fbc:lowerFluxBound="cobra_default_lb" fbc:upperFluxBound="cobra_default_ub">
+      <reaction metaid="meta_R_rxn46694_c0" sboTerm="SBO:0000176" id="R_rxn46694_c0" name="[c0]" reversible="true" fast="false" fbc:lowerFluxBound="cobra_default_lb" fbc:upperFluxBound="cobra_default_ub">
         <annotation>
           <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
             <rdf:Description rdf:about="#meta_R_rxn46694_c0">
@@ -59889,7 +59889,7 @@
           <fbc:geneProductRef fbc:geneProduct="G_ACZ81_RS11345"/>
         </fbc:geneProductAssociation>
       </reaction>
-      <reaction metaid="meta_R_rxn42709_c0" sboTerm="SBO:0000176" id="R_rxn42709_c0" name=" [c0]" reversible="false" fast="false" fbc:lowerFluxBound="cobra_0_bound" fbc:upperFluxBound="cobra_default_ub">
+      <reaction metaid="meta_R_rxn42709_c0" sboTerm="SBO:0000176" id="R_rxn42709_c0" name="[c0]" reversible="false" fast="false" fbc:lowerFluxBound="cobra_0_bound" fbc:upperFluxBound="cobra_default_ub">
         <annotation>
           <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
             <rdf:Description rdf:about="#meta_R_rxn42709_c0">
@@ -59976,7 +59976,7 @@
           <fbc:geneProductRef fbc:geneProduct="G_ACZ81_RS08460"/>
         </fbc:geneProductAssociation>
       </reaction>
-      <reaction metaid="meta_R_rxn41683_c0" sboTerm="SBO:0000176" id="R_rxn41683_c0" name=" [c0]" reversible="true" fast="false" fbc:lowerFluxBound="cobra_default_lb" fbc:upperFluxBound="cobra_default_ub">
+      <reaction metaid="meta_R_rxn41683_c0" sboTerm="SBO:0000176" id="R_rxn41683_c0" name="[c0]" reversible="true" fast="false" fbc:lowerFluxBound="cobra_default_lb" fbc:upperFluxBound="cobra_default_ub">
         <annotation>
           <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
             <rdf:Description rdf:about="#meta_R_rxn41683_c0">
@@ -60379,7 +60379,7 @@
           <fbc:geneProductRef fbc:geneProduct="G_ACZ81_RS02670"/>
         </fbc:geneProductAssociation>
       </reaction>
-      <reaction metaid="meta_R_rxn43581_c0" sboTerm="SBO:0000176" id="R_rxn43581_c0" name=" [c0]" reversible="true" fast="false" fbc:lowerFluxBound="cobra_default_lb" fbc:upperFluxBound="cobra_default_ub">
+      <reaction metaid="meta_R_rxn43581_c0" sboTerm="SBO:0000176" id="R_rxn43581_c0" name="[c0]" reversible="true" fast="false" fbc:lowerFluxBound="cobra_default_lb" fbc:upperFluxBound="cobra_default_ub">
         <annotation>
           <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
             <rdf:Description rdf:about="#meta_R_rxn43581_c0">
@@ -60520,7 +60520,7 @@
           <fbc:geneProductRef fbc:geneProduct="G_ACZ81_RS09285"/>
         </fbc:geneProductAssociation>
       </reaction>
-      <reaction metaid="meta_R_rxn43470_c0" sboTerm="SBO:0000176" id="R_rxn43470_c0" name=" [c0]" reversible="false" fast="false" fbc:lowerFluxBound="cobra_0_bound" fbc:upperFluxBound="cobra_default_ub">
+      <reaction metaid="meta_R_rxn43470_c0" sboTerm="SBO:0000176" id="R_rxn43470_c0" name="[c0]" reversible="false" fast="false" fbc:lowerFluxBound="cobra_0_bound" fbc:upperFluxBound="cobra_default_ub">
         <annotation>
           <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
             <rdf:Description rdf:about="#meta_R_rxn43470_c0">
@@ -61356,7 +61356,7 @@
           </fbc:and>
         </fbc:geneProductAssociation>
       </reaction>
-      <reaction metaid="meta_R_rxn41965_c0" sboTerm="SBO:0000176" id="R_rxn41965_c0" name=" [c0]" reversible="false" fast="false" fbc:lowerFluxBound="cobra_0_bound" fbc:upperFluxBound="cobra_default_ub">
+      <reaction metaid="meta_R_rxn41965_c0" sboTerm="SBO:0000176" id="R_rxn41965_c0" name="[c0]" reversible="false" fast="false" fbc:lowerFluxBound="cobra_0_bound" fbc:upperFluxBound="cobra_default_ub">
         <annotation>
           <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
             <rdf:Description rdf:about="#meta_R_rxn41965_c0">
@@ -62942,922 +62942,11806 @@
       </fbc:objective>
     </fbc:listOfObjectives>
     <fbc:listOfGeneProducts>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS09385" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS09385" fbc:name="ACZ81_RS09385" fbc:label="G_ACZ81_RS09385"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS03300" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS03300" fbc:name="ACZ81_RS03300" fbc:label="G_ACZ81_RS03300"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS17820" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS17820" fbc:name="ACZ81_RS17820" fbc:label="G_ACZ81_RS17820"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS00750" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS00750" fbc:name="ACZ81_RS00750" fbc:label="G_ACZ81_RS00750"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS14915" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS14915" fbc:name="ACZ81_RS14915" fbc:label="G_ACZ81_RS14915"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS10150" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS10150" fbc:name="ACZ81_RS10150" fbc:label="G_ACZ81_RS10150"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS10145" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS10145" fbc:name="ACZ81_RS10145" fbc:label="G_ACZ81_RS10145"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS08170" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS08170" fbc:name="ACZ81_RS08170" fbc:label="G_ACZ81_RS08170"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS00810" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS00810" fbc:name="ACZ81_RS00810" fbc:label="G_ACZ81_RS00810"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS13555" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS13555" fbc:name="ACZ81_RS13555" fbc:label="G_ACZ81_RS13555"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS10675" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS10675" fbc:name="ACZ81_RS10675" fbc:label="G_ACZ81_RS10675"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS11855" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS11855" fbc:name="ACZ81_RS11855" fbc:label="G_ACZ81_RS11855"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS14765" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS14765" fbc:name="ACZ81_RS14765" fbc:label="G_ACZ81_RS14765"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS12425" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS12425" fbc:name="ACZ81_RS12425" fbc:label="G_ACZ81_RS12425"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS12430" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS12430" fbc:name="ACZ81_RS12430" fbc:label="G_ACZ81_RS12430"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS12595" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS12595" fbc:name="ACZ81_RS12595" fbc:label="G_ACZ81_RS12595"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS11530" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS11530" fbc:name="ACZ81_RS11530" fbc:label="G_ACZ81_RS11530"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS16200" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS16200" fbc:name="ACZ81_RS16200" fbc:label="G_ACZ81_RS16200"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS12340" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS12340" fbc:name="ACZ81_RS12340" fbc:label="G_ACZ81_RS12340"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS03600" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS03600" fbc:name="ACZ81_RS03600" fbc:label="G_ACZ81_RS03600"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS03410" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS03410" fbc:name="ACZ81_RS03410" fbc:label="G_ACZ81_RS03410"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS05835" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS05835" fbc:name="ACZ81_RS05835" fbc:label="G_ACZ81_RS05835"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS13495" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS13495" fbc:name="ACZ81_RS13495" fbc:label="G_ACZ81_RS13495"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS19265" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS19265" fbc:name="ACZ81_RS19265" fbc:label="G_ACZ81_RS19265"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS12755" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS12755" fbc:name="ACZ81_RS12755" fbc:label="G_ACZ81_RS12755"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS07395" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS07395" fbc:name="ACZ81_RS07395" fbc:label="G_ACZ81_RS07395"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS14655" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS14655" fbc:name="ACZ81_RS14655" fbc:label="G_ACZ81_RS14655"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS17155" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS17155" fbc:name="ACZ81_RS17155" fbc:label="G_ACZ81_RS17155"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS14000" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS14000" fbc:name="ACZ81_RS14000" fbc:label="G_ACZ81_RS14000"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS17050" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS17050" fbc:name="ACZ81_RS17050" fbc:label="G_ACZ81_RS17050"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS02650" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS02650" fbc:name="ACZ81_RS02650" fbc:label="G_ACZ81_RS02650"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS08650" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS08650" fbc:name="ACZ81_RS08650" fbc:label="G_ACZ81_RS08650"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS06160" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS06160" fbc:name="ACZ81_RS06160" fbc:label="G_ACZ81_RS06160"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS09365" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS09365" fbc:name="ACZ81_RS09365" fbc:label="G_ACZ81_RS09365"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS08560" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS08560" fbc:name="ACZ81_RS08560" fbc:label="G_ACZ81_RS08560"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS02670" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS02670" fbc:name="ACZ81_RS02670" fbc:label="G_ACZ81_RS02670"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS03545" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS03545" fbc:name="ACZ81_RS03545" fbc:label="G_ACZ81_RS03545"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS09200" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS09200" fbc:name="ACZ81_RS09200" fbc:label="G_ACZ81_RS09200"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS09960" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS09960" fbc:name="ACZ81_RS09960" fbc:label="G_ACZ81_RS09960"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS12875" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS12875" fbc:name="ACZ81_RS12875" fbc:label="G_ACZ81_RS12875"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS01905" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS01905" fbc:name="ACZ81_RS01905" fbc:label="G_ACZ81_RS01905"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS14055" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS14055" fbc:name="ACZ81_RS14055" fbc:label="G_ACZ81_RS14055"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS13010" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS13010" fbc:name="ACZ81_RS13010" fbc:label="G_ACZ81_RS13010"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS04825" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS04825" fbc:name="ACZ81_RS04825" fbc:label="G_ACZ81_RS04825"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS15625" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS15625" fbc:name="ACZ81_RS15625" fbc:label="G_ACZ81_RS15625"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS15925" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS15925" fbc:name="ACZ81_RS15925" fbc:label="G_ACZ81_RS15925"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS10220" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS10220" fbc:name="ACZ81_RS10220" fbc:label="G_ACZ81_RS10220"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS11945" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS11945" fbc:name="ACZ81_RS11945" fbc:label="G_ACZ81_RS11945"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS08315" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS08315" fbc:name="ACZ81_RS08315" fbc:label="G_ACZ81_RS08315"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS17795" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS17795" fbc:name="ACZ81_RS17795" fbc:label="G_ACZ81_RS17795"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS06080" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS06080" fbc:name="ACZ81_RS06080" fbc:label="G_ACZ81_RS06080"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS06095" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS06095" fbc:name="ACZ81_RS06095" fbc:label="G_ACZ81_RS06095"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS09180" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS09180" fbc:name="ACZ81_RS09180" fbc:label="G_ACZ81_RS09180"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS16760" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS16760" fbc:name="ACZ81_RS16760" fbc:label="G_ACZ81_RS16760"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS00235" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS00235" fbc:name="ACZ81_RS00235" fbc:label="G_ACZ81_RS00235"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS17035" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS17035" fbc:name="ACZ81_RS17035" fbc:label="G_ACZ81_RS17035"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS19675" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS19675" fbc:name="ACZ81_RS19675" fbc:label="G_ACZ81_RS19675"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS09460" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS09460" fbc:name="ACZ81_RS09460" fbc:label="G_ACZ81_RS09460"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS12280" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS12280" fbc:name="ACZ81_RS12280" fbc:label="G_ACZ81_RS12280"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS02035" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS02035" fbc:name="ACZ81_RS02035" fbc:label="G_ACZ81_RS02035"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS15390" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS15390" fbc:name="ACZ81_RS15390" fbc:label="G_ACZ81_RS15390"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS12370" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS12370" fbc:name="ACZ81_RS12370" fbc:label="G_ACZ81_RS12370"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS04785" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS04785" fbc:name="ACZ81_RS04785" fbc:label="G_ACZ81_RS04785"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS12565" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS12565" fbc:name="ACZ81_RS12565" fbc:label="G_ACZ81_RS12565"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS06755" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS06755" fbc:name="ACZ81_RS06755" fbc:label="G_ACZ81_RS06755"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS19520" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS19520" fbc:name="ACZ81_RS19520" fbc:label="G_ACZ81_RS19520"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS03135" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS03135" fbc:name="ACZ81_RS03135" fbc:label="G_ACZ81_RS03135"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS04010" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS04010" fbc:name="ACZ81_RS04010" fbc:label="G_ACZ81_RS04010"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS02275" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS02275" fbc:name="ACZ81_RS02275" fbc:label="G_ACZ81_RS02275"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS10020" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS10020" fbc:name="ACZ81_RS10020" fbc:label="G_ACZ81_RS10020"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS14850" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS14850" fbc:name="ACZ81_RS14850" fbc:label="G_ACZ81_RS14850"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS06225" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS06225" fbc:name="ACZ81_RS06225" fbc:label="G_ACZ81_RS06225"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS02100" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS02100" fbc:name="ACZ81_RS02100" fbc:label="G_ACZ81_RS02100"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS16015" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS16015" fbc:name="ACZ81_RS16015" fbc:label="G_ACZ81_RS16015"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS12715" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS12715" fbc:name="ACZ81_RS12715" fbc:label="G_ACZ81_RS12715"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS18340" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS18340" fbc:name="ACZ81_RS18340" fbc:label="G_ACZ81_RS18340"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS03295" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS03295" fbc:name="ACZ81_RS03295" fbc:label="G_ACZ81_RS03295"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS13240" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS13240" fbc:name="ACZ81_RS13240" fbc:label="G_ACZ81_RS13240"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS13140" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS13140" fbc:name="ACZ81_RS13140" fbc:label="G_ACZ81_RS13140"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS06390" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS06390" fbc:name="ACZ81_RS06390" fbc:label="G_ACZ81_RS06390"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS12820" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS12820" fbc:name="ACZ81_RS12820" fbc:label="G_ACZ81_RS12820"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS10490" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS10490" fbc:name="ACZ81_RS10490" fbc:label="G_ACZ81_RS10490"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS09785" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS09785" fbc:name="ACZ81_RS09785" fbc:label="G_ACZ81_RS09785"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS09775" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS09775" fbc:name="ACZ81_RS09775" fbc:label="G_ACZ81_RS09775"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS09780" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS09780" fbc:name="ACZ81_RS09780" fbc:label="G_ACZ81_RS09780"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS09790" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS09790" fbc:name="ACZ81_RS09790" fbc:label="G_ACZ81_RS09790"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS19590" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS19590" fbc:name="ACZ81_RS19590" fbc:label="G_ACZ81_RS19590"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS15575" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS15575" fbc:name="ACZ81_RS15575" fbc:label="G_ACZ81_RS15575"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS04855" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS04855" fbc:name="ACZ81_RS04855" fbc:label="G_ACZ81_RS04855"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS19600" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS19600" fbc:name="ACZ81_RS19600" fbc:label="G_ACZ81_RS19600"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS10285" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS10285" fbc:name="ACZ81_RS10285" fbc:label="G_ACZ81_RS10285"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS04880" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS04880" fbc:name="ACZ81_RS04880" fbc:label="G_ACZ81_RS04880"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS13030" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS13030" fbc:name="ACZ81_RS13030" fbc:label="G_ACZ81_RS13030"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS01000" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS01000" fbc:name="ACZ81_RS01000" fbc:label="G_ACZ81_RS01000"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS01025" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS01025" fbc:name="ACZ81_RS01025" fbc:label="G_ACZ81_RS01025"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS18160" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS18160" fbc:name="ACZ81_RS18160" fbc:label="G_ACZ81_RS18160"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS01185" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS01185" fbc:name="ACZ81_RS01185" fbc:label="G_ACZ81_RS01185"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS06460" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS06460" fbc:name="ACZ81_RS06460" fbc:label="G_ACZ81_RS06460"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS15075" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS15075" fbc:name="ACZ81_RS15075" fbc:label="G_ACZ81_RS15075"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS11780" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS11780" fbc:name="ACZ81_RS11780" fbc:label="G_ACZ81_RS11780"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS15365" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS15365" fbc:name="ACZ81_RS15365" fbc:label="G_ACZ81_RS15365"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS18800" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS18800" fbc:name="ACZ81_RS18800" fbc:label="G_ACZ81_RS18800"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS19595" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS19595" fbc:name="ACZ81_RS19595" fbc:label="G_ACZ81_RS19595"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS10115" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS10115" fbc:name="ACZ81_RS10115" fbc:label="G_ACZ81_RS10115"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS16490" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS16490" fbc:name="ACZ81_RS16490" fbc:label="G_ACZ81_RS16490"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS03755" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS03755" fbc:name="ACZ81_RS03755" fbc:label="G_ACZ81_RS03755"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS14225" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS14225" fbc:name="ACZ81_RS14225" fbc:label="G_ACZ81_RS14225"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS03480" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS03480" fbc:name="ACZ81_RS03480" fbc:label="G_ACZ81_RS03480"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS00895" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS00895" fbc:name="ACZ81_RS00895" fbc:label="G_ACZ81_RS00895"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS03940" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS03940" fbc:name="ACZ81_RS03940" fbc:label="G_ACZ81_RS03940"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS09295" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS09295" fbc:name="ACZ81_RS09295" fbc:label="G_ACZ81_RS09295"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS09555" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS09555" fbc:name="ACZ81_RS09555" fbc:label="G_ACZ81_RS09555"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS04045" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS04045" fbc:name="ACZ81_RS04045" fbc:label="G_ACZ81_RS04045"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS10640" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS10640" fbc:name="ACZ81_RS10640" fbc:label="G_ACZ81_RS10640"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS00495" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS00495" fbc:name="ACZ81_RS00495" fbc:label="G_ACZ81_RS00495"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS01880" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS01880" fbc:name="ACZ81_RS01880" fbc:label="G_ACZ81_RS01880"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS17710" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS17710" fbc:name="ACZ81_RS17710" fbc:label="G_ACZ81_RS17710"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS11435" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS11435" fbc:name="ACZ81_RS11435" fbc:label="G_ACZ81_RS11435"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS10335" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS10335" fbc:name="ACZ81_RS10335" fbc:label="G_ACZ81_RS10335"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS03960" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS03960" fbc:name="ACZ81_RS03960" fbc:label="G_ACZ81_RS03960"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS07805" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS07805" fbc:name="ACZ81_RS07805" fbc:label="G_ACZ81_RS07805"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS07800" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS07800" fbc:name="ACZ81_RS07800" fbc:label="G_ACZ81_RS07800"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS04510" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS04510" fbc:name="ACZ81_RS04510" fbc:label="G_ACZ81_RS04510"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS06895" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS06895" fbc:name="ACZ81_RS06895" fbc:label="G_ACZ81_RS06895"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS06890" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS06890" fbc:name="ACZ81_RS06890" fbc:label="G_ACZ81_RS06890"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS07425" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS07425" fbc:name="ACZ81_RS07425" fbc:label="G_ACZ81_RS07425"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS09695" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS09695" fbc:name="ACZ81_RS09695" fbc:label="G_ACZ81_RS09695"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS00885" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS00885" fbc:name="ACZ81_RS00885" fbc:label="G_ACZ81_RS00885"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS07350" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS07350" fbc:name="ACZ81_RS07350" fbc:label="G_ACZ81_RS07350"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS03465" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS03465" fbc:name="ACZ81_RS03465" fbc:label="G_ACZ81_RS03465"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS15065" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS15065" fbc:name="ACZ81_RS15065" fbc:label="G_ACZ81_RS15065"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS09455" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS09455" fbc:name="ACZ81_RS09455" fbc:label="G_ACZ81_RS09455"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS06100" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS06100" fbc:name="ACZ81_RS06100" fbc:label="G_ACZ81_RS06100"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS08290" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS08290" fbc:name="ACZ81_RS08290" fbc:label="G_ACZ81_RS08290"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS13095" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS13095" fbc:name="ACZ81_RS13095" fbc:label="G_ACZ81_RS13095"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS08605" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS08605" fbc:name="ACZ81_RS08605" fbc:label="G_ACZ81_RS08605"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS02950" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS02950" fbc:name="ACZ81_RS02950" fbc:label="G_ACZ81_RS02950"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS05115" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS05115" fbc:name="ACZ81_RS05115" fbc:label="G_ACZ81_RS05115"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS08555" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS08555" fbc:name="ACZ81_RS08555" fbc:label="G_ACZ81_RS08555"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS12335" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS12335" fbc:name="ACZ81_RS12335" fbc:label="G_ACZ81_RS12335"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS08575" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS08575" fbc:name="ACZ81_RS08575" fbc:label="G_ACZ81_RS08575"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS04175" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS04175" fbc:name="ACZ81_RS04175" fbc:label="G_ACZ81_RS04175"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS18645" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS18645" fbc:name="ACZ81_RS18645" fbc:label="G_ACZ81_RS18645"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS08280" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS08280" fbc:name="ACZ81_RS08280" fbc:label="G_ACZ81_RS08280"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS02645" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS02645" fbc:name="ACZ81_RS02645" fbc:label="G_ACZ81_RS02645"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS06155" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS06155" fbc:name="ACZ81_RS06155" fbc:label="G_ACZ81_RS06155"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS08655" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS08655" fbc:name="ACZ81_RS08655" fbc:label="G_ACZ81_RS08655"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS11720" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS11720" fbc:name="ACZ81_RS11720" fbc:label="G_ACZ81_RS11720"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS10910" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS10910" fbc:name="ACZ81_RS10910" fbc:label="G_ACZ81_RS10910"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS06050" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS06050" fbc:name="ACZ81_RS06050" fbc:label="G_ACZ81_RS06050"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS13800" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS13800" fbc:name="ACZ81_RS13800" fbc:label="G_ACZ81_RS13800"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS09955" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS09955" fbc:name="ACZ81_RS09955" fbc:label="G_ACZ81_RS09955"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS09795" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS09795" fbc:name="ACZ81_RS09795" fbc:label="G_ACZ81_RS09795"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS08570" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS08570" fbc:name="ACZ81_RS08570" fbc:label="G_ACZ81_RS08570"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS05120" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS05120" fbc:name="ACZ81_RS05120" fbc:label="G_ACZ81_RS05120"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS02170" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS02170" fbc:name="ACZ81_RS02170" fbc:label="G_ACZ81_RS02170"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS04565" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS04565" fbc:name="ACZ81_RS04565" fbc:label="G_ACZ81_RS04565"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS16965" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS16965" fbc:name="ACZ81_RS16965" fbc:label="G_ACZ81_RS16965"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS19120" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS19120" fbc:name="ACZ81_RS19120" fbc:label="G_ACZ81_RS19120"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS19115" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS19115" fbc:name="ACZ81_RS19115" fbc:label="G_ACZ81_RS19115"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS01960" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS01960" fbc:name="ACZ81_RS01960" fbc:label="G_ACZ81_RS01960"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS06290" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS06290" fbc:name="ACZ81_RS06290" fbc:label="G_ACZ81_RS06290"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS10680" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS10680" fbc:name="ACZ81_RS10680" fbc:label="G_ACZ81_RS10680"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS17255" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS17255" fbc:name="ACZ81_RS17255" fbc:label="G_ACZ81_RS17255"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS07965" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS07965" fbc:name="ACZ81_RS07965" fbc:label="G_ACZ81_RS07965"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS06090" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS06090" fbc:name="ACZ81_RS06090" fbc:label="G_ACZ81_RS06090"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS08660" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS08660" fbc:name="ACZ81_RS08660" fbc:label="G_ACZ81_RS08660"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS11295" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS11295" fbc:name="ACZ81_RS11295" fbc:label="G_ACZ81_RS11295"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS14115" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS14115" fbc:name="ACZ81_RS14115" fbc:label="G_ACZ81_RS14115"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS10835" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS10835" fbc:name="ACZ81_RS10835" fbc:label="G_ACZ81_RS10835"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS03205" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS03205" fbc:name="ACZ81_RS03205" fbc:label="G_ACZ81_RS03205"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS00445" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS00445" fbc:name="ACZ81_RS00445" fbc:label="G_ACZ81_RS00445"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS13940" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS13940" fbc:name="ACZ81_RS13940" fbc:label="G_ACZ81_RS13940"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS11100" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS11100" fbc:name="ACZ81_RS11100" fbc:label="G_ACZ81_RS11100"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS00840" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS00840" fbc:name="ACZ81_RS00840" fbc:label="G_ACZ81_RS00840"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS00545" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS00545" fbc:name="ACZ81_RS00545" fbc:label="G_ACZ81_RS00545"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS03110" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS03110" fbc:name="ACZ81_RS03110" fbc:label="G_ACZ81_RS03110"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS03115" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS03115" fbc:name="ACZ81_RS03115" fbc:label="G_ACZ81_RS03115"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS18785" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS18785" fbc:name="ACZ81_RS18785" fbc:label="G_ACZ81_RS18785"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS05870" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS05870" fbc:name="ACZ81_RS05870" fbc:label="G_ACZ81_RS05870"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS14830" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS14830" fbc:name="ACZ81_RS14830" fbc:label="G_ACZ81_RS14830"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS14840" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS14840" fbc:name="ACZ81_RS14840" fbc:label="G_ACZ81_RS14840"/>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS09385" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS09385" fbc:name="ACZ81_RS09385" fbc:label="G_ACZ81_RS09385">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS09385">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_061485809.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS03300" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS03300" fbc:name="ACZ81_RS03300" fbc:label="G_ACZ81_RS03300">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS03300">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014948272.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS17820" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS17820" fbc:name="ACZ81_RS17820" fbc:label="G_ACZ81_RS17820">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS17820">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014951000.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS00750" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS00750" fbc:name="ACZ81_RS00750" fbc:label="G_ACZ81_RS00750">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS00750">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_061439009.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS14915" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS14915" fbc:name="ACZ81_RS14915" fbc:label="G_ACZ81_RS14915">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS14915">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014950459.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS10150" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS10150" fbc:name="ACZ81_RS10150" fbc:label="G_ACZ81_RS10150">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS10150">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_061485898.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS10145" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS10145" fbc:name="ACZ81_RS10145" fbc:label="G_ACZ81_RS10145">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS10145">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014976583.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS08170" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS08170" fbc:name="ACZ81_RS08170" fbc:label="G_ACZ81_RS08170">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS08170">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014949139.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS00810" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS00810" fbc:name="ACZ81_RS00810" fbc:label="G_ACZ81_RS00810">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS00810">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014947845.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS13555" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS13555" fbc:name="ACZ81_RS13555" fbc:label="G_ACZ81_RS13555">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS13555">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014950181.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS10675" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS10675" fbc:name="ACZ81_RS10675" fbc:label="G_ACZ81_RS10675">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS10675">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014976668.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS11855" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS11855" fbc:name="ACZ81_RS11855" fbc:label="G_ACZ81_RS11855">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS11855">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_061486981.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS14765" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS14765" fbc:name="ACZ81_RS14765" fbc:label="G_ACZ81_RS14765">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS14765">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_061486403.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS12425" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS12425" fbc:name="ACZ81_RS12425" fbc:label="G_ACZ81_RS12425">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS12425">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_061486098.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS12430" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS12430" fbc:name="ACZ81_RS12430" fbc:label="G_ACZ81_RS12430">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS12430">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_231513085.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS12595" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS12595" fbc:name="ACZ81_RS12595" fbc:label="G_ACZ81_RS12595">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS12595">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014950005.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS11530" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS11530" fbc:name="ACZ81_RS11530" fbc:label="G_ACZ81_RS11530">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS11530">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014949806.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS16200" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS16200" fbc:name="ACZ81_RS16200" fbc:label="G_ACZ81_RS16200">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS16200">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_061486550.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS12340" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS12340" fbc:name="ACZ81_RS12340" fbc:label="G_ACZ81_RS12340">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS12340">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_061486091.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS03600" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS03600" fbc:name="ACZ81_RS03600" fbc:label="G_ACZ81_RS03600">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS03600">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_061439588.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS03410" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS03410" fbc:name="ACZ81_RS03410" fbc:label="G_ACZ81_RS03410">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS03410">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_061439565.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS05835" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS05835" fbc:name="ACZ81_RS05835" fbc:label="G_ACZ81_RS05835">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS05835">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_081106069.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS13495" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS13495" fbc:name="ACZ81_RS13495" fbc:label="G_ACZ81_RS13495">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS13495">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_012519000.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS19265" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS19265" fbc:name="ACZ81_RS19265" fbc:label="G_ACZ81_RS19265">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS19265">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_061486814.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS12755" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS12755" fbc:name="ACZ81_RS12755" fbc:label="G_ACZ81_RS12755">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS12755">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_061486121.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS07395" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS07395" fbc:name="ACZ81_RS07395" fbc:label="G_ACZ81_RS07395">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS07395">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014949030.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS14655" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS14655" fbc:name="ACZ81_RS14655" fbc:label="G_ACZ81_RS14655">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS14655">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_061486392.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS17155" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS17155" fbc:name="ACZ81_RS17155" fbc:label="G_ACZ81_RS17155">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS17155">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_061486627.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS14000" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS14000" fbc:name="ACZ81_RS14000" fbc:label="G_ACZ81_RS14000">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS14000">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_061486295.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS17050" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS17050" fbc:name="ACZ81_RS17050" fbc:label="G_ACZ81_RS17050">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS17050">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_061486608.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS02650" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS02650" fbc:name="ACZ81_RS02650" fbc:label="G_ACZ81_RS02650">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS02650">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_061439376.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS08650" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS08650" fbc:name="ACZ81_RS08650" fbc:label="G_ACZ81_RS08650">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS08650">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014949230.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS06160" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS06160" fbc:name="ACZ81_RS06160" fbc:label="G_ACZ81_RS06160">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS06160">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_061486945.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS09365" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS09365" fbc:name="ACZ81_RS09365" fbc:label="G_ACZ81_RS09365">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS09365">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_061485808.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS08560" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS08560" fbc:name="ACZ81_RS08560" fbc:label="G_ACZ81_RS08560">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS08560">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014949213.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS02670" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS02670" fbc:name="ACZ81_RS02670" fbc:label="G_ACZ81_RS02670">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS02670">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014948150.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS03545" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS03545" fbc:name="ACZ81_RS03545" fbc:label="G_ACZ81_RS03545">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS03545">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_061439574.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS09200" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS09200" fbc:name="ACZ81_RS09200" fbc:label="G_ACZ81_RS09200">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS09200">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_061485794.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS09960" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS09960" fbc:name="ACZ81_RS09960" fbc:label="G_ACZ81_RS09960">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS09960">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_061485876.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS12875" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS12875" fbc:name="ACZ81_RS12875" fbc:label="G_ACZ81_RS12875">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS12875">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014950059.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS01905" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS01905" fbc:name="ACZ81_RS01905" fbc:label="G_ACZ81_RS01905">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS01905">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014978113.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS14055" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS14055" fbc:name="ACZ81_RS14055" fbc:label="G_ACZ81_RS14055">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS14055">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_061486309.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS13010" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS13010" fbc:name="ACZ81_RS13010" fbc:label="G_ACZ81_RS13010">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS13010">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014950085.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS04825" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS04825" fbc:name="ACZ81_RS04825" fbc:label="G_ACZ81_RS04825">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS04825">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014948551.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS15625" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS15625" fbc:name="ACZ81_RS15625" fbc:label="G_ACZ81_RS15625">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS15625">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014950602.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS15925" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS15925" fbc:name="ACZ81_RS15925" fbc:label="G_ACZ81_RS15925">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS15925">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_061486517.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS10220" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS10220" fbc:name="ACZ81_RS10220" fbc:label="G_ACZ81_RS10220">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS10220">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_061485903.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS11945" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS11945" fbc:name="ACZ81_RS11945" fbc:label="G_ACZ81_RS11945">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS11945">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_081106097.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS08315" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS08315" fbc:name="ACZ81_RS08315" fbc:label="G_ACZ81_RS08315">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS08315">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_061485653.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS17795" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS17795" fbc:name="ACZ81_RS17795" fbc:label="G_ACZ81_RS17795">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS17795">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_061486687.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS06080" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS06080" fbc:name="ACZ81_RS06080" fbc:label="G_ACZ81_RS06080">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS06080">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_061485175.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS06095" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS06095" fbc:name="ACZ81_RS06095" fbc:label="G_ACZ81_RS06095">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS06095">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014948797.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS09180" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS09180" fbc:name="ACZ81_RS09180" fbc:label="G_ACZ81_RS09180">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS09180">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_061485792.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS16760" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS16760" fbc:name="ACZ81_RS16760" fbc:label="G_ACZ81_RS16760">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS16760">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014950808.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS00235" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS00235" fbc:name="ACZ81_RS00235" fbc:label="G_ACZ81_RS00235">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS00235">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_061438895.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS17035" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS17035" fbc:name="ACZ81_RS17035" fbc:label="G_ACZ81_RS17035">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS17035">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_061486605.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS19675" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS19675" fbc:name="ACZ81_RS19675" fbc:label="G_ACZ81_RS19675">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS19675">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014951417.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS09460" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS09460" fbc:name="ACZ81_RS09460" fbc:label="G_ACZ81_RS09460">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS09460">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014949381.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS12280" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS12280" fbc:name="ACZ81_RS12280" fbc:label="G_ACZ81_RS12280">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS12280">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_061486084.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS02035" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS02035" fbc:name="ACZ81_RS02035" fbc:label="G_ACZ81_RS02035">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS02035">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014975490.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS15390" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS15390" fbc:name="ACZ81_RS15390" fbc:label="G_ACZ81_RS15390">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS15390">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014950553.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS12370" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS12370" fbc:name="ACZ81_RS12370" fbc:label="G_ACZ81_RS12370">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS12370">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014949960.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS04785" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS04785" fbc:name="ACZ81_RS04785" fbc:label="G_ACZ81_RS04785">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS04785">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_061484984.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS12565" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS12565" fbc:name="ACZ81_RS12565" fbc:label="G_ACZ81_RS12565">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS12565">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014949999.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS06755" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS06755" fbc:name="ACZ81_RS06755" fbc:label="G_ACZ81_RS06755">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS06755">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_061485312.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS19520" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS19520" fbc:name="ACZ81_RS19520" fbc:label="G_ACZ81_RS19520">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS19520">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014951376.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS03135" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS03135" fbc:name="ACZ81_RS03135" fbc:label="G_ACZ81_RS03135">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS03135">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_061439519.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS04010" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS04010" fbc:name="ACZ81_RS04010" fbc:label="G_ACZ81_RS04010">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS04010">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_039224606.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS02275" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS02275" fbc:name="ACZ81_RS02275" fbc:label="G_ACZ81_RS02275">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS02275">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_061439275.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS10020" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS10020" fbc:name="ACZ81_RS10020" fbc:label="G_ACZ81_RS10020">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS10020">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014949508.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS14850" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS14850" fbc:name="ACZ81_RS14850" fbc:label="G_ACZ81_RS14850">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS14850">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_203229272.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS06225" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS06225" fbc:name="ACZ81_RS06225" fbc:label="G_ACZ81_RS06225">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS06225">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_061485207.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS02100" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS02100" fbc:name="ACZ81_RS02100" fbc:label="G_ACZ81_RS02100">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS02100">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_061439251.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS16015" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS16015" fbc:name="ACZ81_RS16015" fbc:label="G_ACZ81_RS16015">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS16015">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_020744244.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS12715" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS12715" fbc:name="ACZ81_RS12715" fbc:label="G_ACZ81_RS12715">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS12715">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_061486115.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS18340" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS18340" fbc:name="ACZ81_RS18340" fbc:label="G_ACZ81_RS18340">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS18340">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_061486734.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS03295" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS03295" fbc:name="ACZ81_RS03295" fbc:label="G_ACZ81_RS03295">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS03295">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014948271.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS13240" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS13240" fbc:name="ACZ81_RS13240" fbc:label="G_ACZ81_RS13240">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS13240">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014977011.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS13140" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS13140" fbc:name="ACZ81_RS13140" fbc:label="G_ACZ81_RS13140">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS13140">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_061486150.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS06390" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS06390" fbc:name="ACZ81_RS06390" fbc:label="G_ACZ81_RS06390">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS06390">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_061485244.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS12820" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS12820" fbc:name="ACZ81_RS12820" fbc:label="G_ACZ81_RS12820">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS12820">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014950051.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS10490" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS10490" fbc:name="ACZ81_RS10490" fbc:label="G_ACZ81_RS10490">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS10490">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014949608.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS09785" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS09785" fbc:name="ACZ81_RS09785" fbc:label="G_ACZ81_RS09785">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS09785">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014949447.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS09775" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS09775" fbc:name="ACZ81_RS09775" fbc:label="G_ACZ81_RS09775">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS09775">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014949445.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS09780" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS09780" fbc:name="ACZ81_RS09780" fbc:label="G_ACZ81_RS09780">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS09780">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014949446.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS09790" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS09790" fbc:name="ACZ81_RS09790" fbc:label="G_ACZ81_RS09790">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS09790">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_012518362.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS19590" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS19590" fbc:name="ACZ81_RS19590" fbc:label="G_ACZ81_RS19590">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS19590">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014951390.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS15575" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS15575" fbc:name="ACZ81_RS15575" fbc:label="G_ACZ81_RS15575">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS15575">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_061486484.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS04855" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS04855" fbc:name="ACZ81_RS04855" fbc:label="G_ACZ81_RS04855">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS04855">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014948557.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS19600" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS19600" fbc:name="ACZ81_RS19600" fbc:label="G_ACZ81_RS19600">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS19600">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_061486847.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS10285" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS10285" fbc:name="ACZ81_RS10285" fbc:label="G_ACZ81_RS10285">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS10285">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014949559.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS04880" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS04880" fbc:name="ACZ81_RS04880" fbc:label="G_ACZ81_RS04880">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS04880">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014948562.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS13030" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS13030" fbc:name="ACZ81_RS13030" fbc:label="G_ACZ81_RS13030">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS13030">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014950089.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS01000" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS01000" fbc:name="ACZ81_RS01000" fbc:label="G_ACZ81_RS01000">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS01000">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_061439044.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS01025" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS01025" fbc:name="ACZ81_RS01025" fbc:label="G_ACZ81_RS01025">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS01025">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_061439048.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS18160" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS18160" fbc:name="ACZ81_RS18160" fbc:label="G_ACZ81_RS18160">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS18160">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_039229281.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS01185" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS01185" fbc:name="ACZ81_RS01185" fbc:label="G_ACZ81_RS01185">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS01185">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_061439102.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS06460" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS06460" fbc:name="ACZ81_RS06460" fbc:label="G_ACZ81_RS06460">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS06460">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_061485250.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS15075" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS15075" fbc:name="ACZ81_RS15075" fbc:label="G_ACZ81_RS15075">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS15075">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014950490.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS11780" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS11780" fbc:name="ACZ81_RS11780" fbc:label="G_ACZ81_RS11780">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS11780">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_061486040.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS15365" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS15365" fbc:name="ACZ81_RS15365" fbc:label="G_ACZ81_RS15365">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS15365">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014950548.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS18800" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS18800" fbc:name="ACZ81_RS18800" fbc:label="G_ACZ81_RS18800">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS18800">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_061486771.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS19595" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS19595" fbc:name="ACZ81_RS19595" fbc:label="G_ACZ81_RS19595">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS19595">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_061486846.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS10115" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS10115" fbc:name="ACZ81_RS10115" fbc:label="G_ACZ81_RS10115">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS10115">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_061485894.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS16490" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS16490" fbc:name="ACZ81_RS16490" fbc:label="G_ACZ81_RS16490">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS16490">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_061486569.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS03755" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS03755" fbc:name="ACZ81_RS03755" fbc:label="G_ACZ81_RS03755">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS03755">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_061094262.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS14225" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS14225" fbc:name="ACZ81_RS14225" fbc:label="G_ACZ81_RS14225">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS14225">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_061486333.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS03480" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS03480" fbc:name="ACZ81_RS03480" fbc:label="G_ACZ81_RS03480">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS03480">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_061439572.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS00895" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS00895" fbc:name="ACZ81_RS00895" fbc:label="G_ACZ81_RS00895">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS00895">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014947861.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS03940" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS03940" fbc:name="ACZ81_RS03940" fbc:label="G_ACZ81_RS03940">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS03940">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014948384.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS09295" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS09295" fbc:name="ACZ81_RS09295" fbc:label="G_ACZ81_RS09295">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS09295">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014949348.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS09555" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS09555" fbc:name="ACZ81_RS09555" fbc:label="G_ACZ81_RS09555">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS09555">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_061485830.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS04045" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS04045" fbc:name="ACZ81_RS04045" fbc:label="G_ACZ81_RS04045">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS04045">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014948404.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS10640" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS10640" fbc:name="ACZ81_RS10640" fbc:label="G_ACZ81_RS10640">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS10640">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_039234640.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS00495" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS00495" fbc:name="ACZ81_RS00495" fbc:label="G_ACZ81_RS00495">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS00495">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_061438946.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS01880" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS01880" fbc:name="ACZ81_RS01880" fbc:label="G_ACZ81_RS01880">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS01880">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014948016.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS17710" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS17710" fbc:name="ACZ81_RS17710" fbc:label="G_ACZ81_RS17710">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS17710">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014950980.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS11435" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS11435" fbc:name="ACZ81_RS11435" fbc:label="G_ACZ81_RS11435">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS11435">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014949790.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS10335" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS10335" fbc:name="ACZ81_RS10335" fbc:label="G_ACZ81_RS10335">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS10335">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014976618.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS03960" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS03960" fbc:name="ACZ81_RS03960" fbc:label="G_ACZ81_RS03960">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS03960">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014948387.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS07805" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS07805" fbc:name="ACZ81_RS07805" fbc:label="G_ACZ81_RS07805">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS07805">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_061485527.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS07800" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS07800" fbc:name="ACZ81_RS07800" fbc:label="G_ACZ81_RS07800">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS07800">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_061485525.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS04510" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS04510" fbc:name="ACZ81_RS04510" fbc:label="G_ACZ81_RS04510">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS04510">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014948475.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS06895" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS06895" fbc:name="ACZ81_RS06895" fbc:label="G_ACZ81_RS06895">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS06895">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014976090.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS06890" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS06890" fbc:name="ACZ81_RS06890" fbc:label="G_ACZ81_RS06890">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS06890">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_049586837.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS07425" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS07425" fbc:name="ACZ81_RS07425" fbc:label="G_ACZ81_RS07425">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS07425">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014949036.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS09695" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS09695" fbc:name="ACZ81_RS09695" fbc:label="G_ACZ81_RS09695">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS09695">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_061485849.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS00885" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS00885" fbc:name="ACZ81_RS00885" fbc:label="G_ACZ81_RS00885">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS00885">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_081106052.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS07350" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS07350" fbc:name="ACZ81_RS07350" fbc:label="G_ACZ81_RS07350">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS07350">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_061485402.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS03465" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS03465" fbc:name="ACZ81_RS03465" fbc:label="G_ACZ81_RS03465">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS03465">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014948303.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS15065" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS15065" fbc:name="ACZ81_RS15065" fbc:label="G_ACZ81_RS15065">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS15065">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_061486434.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS09455" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS09455" fbc:name="ACZ81_RS09455" fbc:label="G_ACZ81_RS09455">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS09455">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_061486965.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS06100" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS06100" fbc:name="ACZ81_RS06100" fbc:label="G_ACZ81_RS06100">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS06100">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_061485177.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS08290" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS08290" fbc:name="ACZ81_RS08290" fbc:label="G_ACZ81_RS08290">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS08290">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_081106080.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS13095" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS13095" fbc:name="ACZ81_RS13095" fbc:label="G_ACZ81_RS13095">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS13095">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014979782.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS08605" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS08605" fbc:name="ACZ81_RS08605" fbc:label="G_ACZ81_RS08605">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS08605">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_039229648.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS02950" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS02950" fbc:name="ACZ81_RS02950" fbc:label="G_ACZ81_RS02950">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS02950">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_061439460.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS05115" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS05115" fbc:name="ACZ81_RS05115" fbc:label="G_ACZ81_RS05115">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS05115">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014975894.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS08555" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS08555" fbc:name="ACZ81_RS08555" fbc:label="G_ACZ81_RS08555">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS08555">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014949212.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS12335" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS12335" fbc:name="ACZ81_RS12335" fbc:label="G_ACZ81_RS12335">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS12335">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014949953.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS08575" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS08575" fbc:name="ACZ81_RS08575" fbc:label="G_ACZ81_RS08575">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS08575">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_039229651.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS04175" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS04175" fbc:name="ACZ81_RS04175" fbc:label="G_ACZ81_RS04175">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS04175">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_061484824.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS18645" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS18645" fbc:name="ACZ81_RS18645" fbc:label="G_ACZ81_RS18645">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS18645">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_061486760.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS08280" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS08280" fbc:name="ACZ81_RS08280" fbc:label="G_ACZ81_RS08280">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS08280">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014949162.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS02645" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS02645" fbc:name="ACZ81_RS02645" fbc:label="G_ACZ81_RS02645">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS02645">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_061439374.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS06155" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS06155" fbc:name="ACZ81_RS06155" fbc:label="G_ACZ81_RS06155">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS06155">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014948809.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS08655" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS08655" fbc:name="ACZ81_RS08655" fbc:label="G_ACZ81_RS08655">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS08655">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014949231.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS11720" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS11720" fbc:name="ACZ81_RS11720" fbc:label="G_ACZ81_RS11720">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS11720">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_039234854.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS10910" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS10910" fbc:name="ACZ81_RS10910" fbc:label="G_ACZ81_RS10910">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS10910">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_061485961.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS06050" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS06050" fbc:name="ACZ81_RS06050" fbc:label="G_ACZ81_RS06050">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS06050">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014948790.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS13800" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS13800" fbc:name="ACZ81_RS13800" fbc:label="G_ACZ81_RS13800">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS13800">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_061486234.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS09955" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS09955" fbc:name="ACZ81_RS09955" fbc:label="G_ACZ81_RS09955">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS09955">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_061485875.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS09795" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS09795" fbc:name="ACZ81_RS09795" fbc:label="G_ACZ81_RS09795">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS09795">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_061485858.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS08570" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS08570" fbc:name="ACZ81_RS08570" fbc:label="G_ACZ81_RS08570">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS08570">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_012518211.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS05120" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS05120" fbc:name="ACZ81_RS05120" fbc:label="G_ACZ81_RS05120">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS05120">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014975895.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS02170" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS02170" fbc:name="ACZ81_RS02170" fbc:label="G_ACZ81_RS02170">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS02170">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_061439267.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS04565" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS04565" fbc:name="ACZ81_RS04565" fbc:label="G_ACZ81_RS04565">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS04565">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_061484942.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS16965" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS16965" fbc:name="ACZ81_RS16965" fbc:label="G_ACZ81_RS16965">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS16965">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_061486597.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS19120" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS19120" fbc:name="ACZ81_RS19120" fbc:label="G_ACZ81_RS19120">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS19120">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014999996.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS19115" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS19115" fbc:name="ACZ81_RS19115" fbc:label="G_ACZ81_RS19115">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS19115">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_039221534.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS01960" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS01960" fbc:name="ACZ81_RS01960" fbc:label="G_ACZ81_RS01960">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS01960">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014948032.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS06290" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS06290" fbc:name="ACZ81_RS06290" fbc:label="G_ACZ81_RS06290">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS06290">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_061094610.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS10680" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS10680" fbc:name="ACZ81_RS10680" fbc:label="G_ACZ81_RS10680">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS10680">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014976669.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS17255" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS17255" fbc:name="ACZ81_RS17255" fbc:label="G_ACZ81_RS17255">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS17255">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014950903.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS07965" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS07965" fbc:name="ACZ81_RS07965" fbc:label="G_ACZ81_RS07965">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS07965">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_061485566.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS06090" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS06090" fbc:name="ACZ81_RS06090" fbc:label="G_ACZ81_RS06090">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS06090">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014948796.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS08660" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS08660" fbc:name="ACZ81_RS08660" fbc:label="G_ACZ81_RS08660">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS08660">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_061485703.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS11295" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS11295" fbc:name="ACZ81_RS11295" fbc:label="G_ACZ81_RS11295">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS11295">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014949762.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS14115" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS14115" fbc:name="ACZ81_RS14115" fbc:label="G_ACZ81_RS14115">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS14115">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_061486318.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS10835" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS10835" fbc:name="ACZ81_RS10835" fbc:label="G_ACZ81_RS10835">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS10835">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014976690.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS03205" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS03205" fbc:name="ACZ81_RS03205" fbc:label="G_ACZ81_RS03205">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS03205">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_061439539.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS00445" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS00445" fbc:name="ACZ81_RS00445" fbc:label="G_ACZ81_RS00445">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS00445">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_061438935.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS13940" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS13940" fbc:name="ACZ81_RS13940" fbc:label="G_ACZ81_RS13940">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS13940">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014950257.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS11100" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS11100" fbc:name="ACZ81_RS11100" fbc:label="G_ACZ81_RS11100">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS11100">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_061485986.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS00840" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS00840" fbc:name="ACZ81_RS00840" fbc:label="G_ACZ81_RS00840">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS00840">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014947850.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS00545" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS00545" fbc:name="ACZ81_RS00545" fbc:label="G_ACZ81_RS00545">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS00545">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_039226917.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS03110" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS03110" fbc:name="ACZ81_RS03110" fbc:label="G_ACZ81_RS03110">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS03110">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_061439511.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS03115" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS03115" fbc:name="ACZ81_RS03115" fbc:label="G_ACZ81_RS03115">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS03115">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014975661.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS18785" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS18785" fbc:name="ACZ81_RS18785" fbc:label="G_ACZ81_RS18785">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS18785">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_061486769.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS05870" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS05870" fbc:name="ACZ81_RS05870" fbc:label="G_ACZ81_RS05870">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS05870">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_061485147.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS14830" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS14830" fbc:name="ACZ81_RS14830" fbc:label="G_ACZ81_RS14830">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS14830">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_061486411.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS14840" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS14840" fbc:name="ACZ81_RS14840" fbc:label="G_ACZ81_RS14840">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS14840">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_061486413.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
       <fbc:geneProduct metaid="meta_G_ACZ81_RS20365" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS20365" fbc:name="ACZ81_RS20365" fbc:label="G_ACZ81_RS20365"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS14835" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS14835" fbc:name="ACZ81_RS14835" fbc:label="G_ACZ81_RS14835"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS15370" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS15370" fbc:name="ACZ81_RS15370" fbc:label="G_ACZ81_RS15370"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS00520" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS00520" fbc:name="ACZ81_RS00520" fbc:label="G_ACZ81_RS00520"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS07130" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS07130" fbc:name="ACZ81_RS07130" fbc:label="G_ACZ81_RS07130"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS02180" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS02180" fbc:name="ACZ81_RS02180" fbc:label="G_ACZ81_RS02180"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS07385" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS07385" fbc:name="ACZ81_RS07385" fbc:label="G_ACZ81_RS07385"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS11765" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS11765" fbc:name="ACZ81_RS11765" fbc:label="G_ACZ81_RS11765"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS14700" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS14700" fbc:name="ACZ81_RS14700" fbc:label="G_ACZ81_RS14700"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS11845" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS11845" fbc:name="ACZ81_RS11845" fbc:label="G_ACZ81_RS11845"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS12705" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS12705" fbc:name="ACZ81_RS12705" fbc:label="G_ACZ81_RS12705"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS19620" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS19620" fbc:name="ACZ81_RS19620" fbc:label="G_ACZ81_RS19620"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS11725" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS11725" fbc:name="ACZ81_RS11725" fbc:label="G_ACZ81_RS11725"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS13565" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS13565" fbc:name="ACZ81_RS13565" fbc:label="G_ACZ81_RS13565"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS07450" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS07450" fbc:name="ACZ81_RS07450" fbc:label="G_ACZ81_RS07450"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS18495" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS18495" fbc:name="ACZ81_RS18495" fbc:label="G_ACZ81_RS18495"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS10255" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS10255" fbc:name="ACZ81_RS10255" fbc:label="G_ACZ81_RS10255"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS11850" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS11850" fbc:name="ACZ81_RS11850" fbc:label="G_ACZ81_RS11850"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS00515" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS00515" fbc:name="ACZ81_RS00515" fbc:label="G_ACZ81_RS00515"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS06280" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS06280" fbc:name="ACZ81_RS06280" fbc:label="G_ACZ81_RS06280"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS11020" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS11020" fbc:name="ACZ81_RS11020" fbc:label="G_ACZ81_RS11020"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS12490" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS12490" fbc:name="ACZ81_RS12490" fbc:label="G_ACZ81_RS12490"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS14780" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS14780" fbc:name="ACZ81_RS14780" fbc:label="G_ACZ81_RS14780"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS12780" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS12780" fbc:name="ACZ81_RS12780" fbc:label="G_ACZ81_RS12780"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS03760" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS03760" fbc:name="ACZ81_RS03760" fbc:label="G_ACZ81_RS03760"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS06635" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS06635" fbc:name="ACZ81_RS06635" fbc:label="G_ACZ81_RS06635"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS01955" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS01955" fbc:name="ACZ81_RS01955" fbc:label="G_ACZ81_RS01955"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS11240" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS11240" fbc:name="ACZ81_RS11240" fbc:label="G_ACZ81_RS11240"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS08230" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS08230" fbc:name="ACZ81_RS08230" fbc:label="G_ACZ81_RS08230"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS16715" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS16715" fbc:name="ACZ81_RS16715" fbc:label="G_ACZ81_RS16715"/>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS14835" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS14835" fbc:name="ACZ81_RS14835" fbc:label="G_ACZ81_RS14835">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS14835">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_061486412.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS15370" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS15370" fbc:name="ACZ81_RS15370" fbc:label="G_ACZ81_RS15370">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS15370">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_061486466.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS00520" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS00520" fbc:name="ACZ81_RS00520" fbc:label="G_ACZ81_RS00520">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS00520">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014947801.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS07130" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS07130" fbc:name="ACZ81_RS07130" fbc:label="G_ACZ81_RS07130">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS07130">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014948987.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS02180" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS02180" fbc:name="ACZ81_RS02180" fbc:label="G_ACZ81_RS02180">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS02180">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_039231034.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS07385" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS07385" fbc:name="ACZ81_RS07385" fbc:label="G_ACZ81_RS07385">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS07385">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_061485412.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS11765" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS11765" fbc:name="ACZ81_RS11765" fbc:label="G_ACZ81_RS11765">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS11765">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014949855.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS14700" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS14700" fbc:name="ACZ81_RS14700" fbc:label="G_ACZ81_RS14700">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS14700">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_061486399.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS11845" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS11845" fbc:name="ACZ81_RS11845" fbc:label="G_ACZ81_RS11845">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS11845">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014976831.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS12705" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS12705" fbc:name="ACZ81_RS12705" fbc:label="G_ACZ81_RS12705">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS12705">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014950027.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS19620" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS19620" fbc:name="ACZ81_RS19620" fbc:label="G_ACZ81_RS19620">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS19620">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014951396.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS11725" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS11725" fbc:name="ACZ81_RS11725" fbc:label="G_ACZ81_RS11725">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS11725">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014976817.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS13565" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS13565" fbc:name="ACZ81_RS13565" fbc:label="G_ACZ81_RS13565">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS13565">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014950183.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS07450" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS07450" fbc:name="ACZ81_RS07450" fbc:label="G_ACZ81_RS07450">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS07450">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_081106073.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS18495" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS18495" fbc:name="ACZ81_RS18495" fbc:label="G_ACZ81_RS18495">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS18495">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_061486745.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS10255" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS10255" fbc:name="ACZ81_RS10255" fbc:label="G_ACZ81_RS10255">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS10255">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_061485906.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS11850" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS11850" fbc:name="ACZ81_RS11850" fbc:label="G_ACZ81_RS11850">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS11850">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_061486980.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS00515" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS00515" fbc:name="ACZ81_RS00515" fbc:label="G_ACZ81_RS00515">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS00515">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_061438954.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS06280" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS06280" fbc:name="ACZ81_RS06280" fbc:label="G_ACZ81_RS06280">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS06280">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_061485220.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS11020" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS11020" fbc:name="ACZ81_RS11020" fbc:label="G_ACZ81_RS11020">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS11020">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_230598867.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS12490" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS12490" fbc:name="ACZ81_RS12490" fbc:label="G_ACZ81_RS12490">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS12490">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014976911.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS14780" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS14780" fbc:name="ACZ81_RS14780" fbc:label="G_ACZ81_RS14780">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS14780">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014950432.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS12780" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS12780" fbc:name="ACZ81_RS12780" fbc:label="G_ACZ81_RS12780">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS12780">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014950043.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS03760" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS03760" fbc:name="ACZ81_RS03760" fbc:label="G_ACZ81_RS03760">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS03760">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014948348.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS06635" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS06635" fbc:name="ACZ81_RS06635" fbc:label="G_ACZ81_RS06635">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS06635">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014948899.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS01955" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS01955" fbc:name="ACZ81_RS01955" fbc:label="G_ACZ81_RS01955">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS01955">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_039231079.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS11240" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS11240" fbc:name="ACZ81_RS11240" fbc:label="G_ACZ81_RS11240">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS11240">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014976750.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS08230" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS08230" fbc:name="ACZ81_RS08230" fbc:label="G_ACZ81_RS08230">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS08230">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014976266.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS16715" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS16715" fbc:name="ACZ81_RS16715" fbc:label="G_ACZ81_RS16715">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS16715">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_061486585.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
       <fbc:geneProduct metaid="meta_G_ACZ81_RS20710" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS20710" fbc:name="ACZ81_RS20710" fbc:label="G_ACZ81_RS20710"/>
       <fbc:geneProduct metaid="meta_G_ACZ81_RS20210" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS20210" fbc:name="ACZ81_RS20210" fbc:label="G_ACZ81_RS20210"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS10400" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS10400" fbc:name="ACZ81_RS10400" fbc:label="G_ACZ81_RS10400"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS08145" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS08145" fbc:name="ACZ81_RS08145" fbc:label="G_ACZ81_RS08145"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS13050" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS13050" fbc:name="ACZ81_RS13050" fbc:label="G_ACZ81_RS13050"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS02475" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS02475" fbc:name="ACZ81_RS02475" fbc:label="G_ACZ81_RS02475"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS02040" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS02040" fbc:name="ACZ81_RS02040" fbc:label="G_ACZ81_RS02040"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS10170" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS10170" fbc:name="ACZ81_RS10170" fbc:label="G_ACZ81_RS10170"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS12720" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS12720" fbc:name="ACZ81_RS12720" fbc:label="G_ACZ81_RS12720"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS07495" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS07495" fbc:name="ACZ81_RS07495" fbc:label="G_ACZ81_RS07495"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS17040" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS17040" fbc:name="ACZ81_RS17040" fbc:label="G_ACZ81_RS17040"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS13705" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS13705" fbc:name="ACZ81_RS13705" fbc:label="G_ACZ81_RS13705"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS17435" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS17435" fbc:name="ACZ81_RS17435" fbc:label="G_ACZ81_RS17435"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS08955" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS08955" fbc:name="ACZ81_RS08955" fbc:label="G_ACZ81_RS08955"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS15785" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS15785" fbc:name="ACZ81_RS15785" fbc:label="G_ACZ81_RS15785"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS07295" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS07295" fbc:name="ACZ81_RS07295" fbc:label="G_ACZ81_RS07295"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS02770" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS02770" fbc:name="ACZ81_RS02770" fbc:label="G_ACZ81_RS02770"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS01595" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS01595" fbc:name="ACZ81_RS01595" fbc:label="G_ACZ81_RS01595"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS07000" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS07000" fbc:name="ACZ81_RS07000" fbc:label="G_ACZ81_RS07000"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS04860" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS04860" fbc:name="ACZ81_RS04860" fbc:label="G_ACZ81_RS04860"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS14715" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS14715" fbc:name="ACZ81_RS14715" fbc:label="G_ACZ81_RS14715"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS03930" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS03930" fbc:name="ACZ81_RS03930" fbc:label="G_ACZ81_RS03930"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS19750" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS19750" fbc:name="ACZ81_RS19750" fbc:label="G_ACZ81_RS19750"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS18145" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS18145" fbc:name="ACZ81_RS18145" fbc:label="G_ACZ81_RS18145"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS18665" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS18665" fbc:name="ACZ81_RS18665" fbc:label="G_ACZ81_RS18665"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS09925" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS09925" fbc:name="ACZ81_RS09925" fbc:label="G_ACZ81_RS09925"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS00890" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS00890" fbc:name="ACZ81_RS00890" fbc:label="G_ACZ81_RS00890"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS03495" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS03495" fbc:name="ACZ81_RS03495" fbc:label="G_ACZ81_RS03495"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS15990" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS15990" fbc:name="ACZ81_RS15990" fbc:label="G_ACZ81_RS15990"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS02375" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS02375" fbc:name="ACZ81_RS02375" fbc:label="G_ACZ81_RS02375"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS06990" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS06990" fbc:name="ACZ81_RS06990" fbc:label="G_ACZ81_RS06990"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS06915" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS06915" fbc:name="ACZ81_RS06915" fbc:label="G_ACZ81_RS06915"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS06910" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS06910" fbc:name="ACZ81_RS06910" fbc:label="G_ACZ81_RS06910"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS04710" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS04710" fbc:name="ACZ81_RS04710" fbc:label="G_ACZ81_RS04710"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS02135" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS02135" fbc:name="ACZ81_RS02135" fbc:label="G_ACZ81_RS02135"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS14235" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS14235" fbc:name="ACZ81_RS14235" fbc:label="G_ACZ81_RS14235"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS08565" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS08565" fbc:name="ACZ81_RS08565" fbc:label="G_ACZ81_RS08565"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS07020" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS07020" fbc:name="ACZ81_RS07020" fbc:label="G_ACZ81_RS07020"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS12710" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS12710" fbc:name="ACZ81_RS12710" fbc:label="G_ACZ81_RS12710"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS19230" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS19230" fbc:name="ACZ81_RS19230" fbc:label="G_ACZ81_RS19230"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS01825" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS01825" fbc:name="ACZ81_RS01825" fbc:label="G_ACZ81_RS01825"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS02395" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS02395" fbc:name="ACZ81_RS02395" fbc:label="G_ACZ81_RS02395"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS07895" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS07895" fbc:name="ACZ81_RS07895" fbc:label="G_ACZ81_RS07895"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS11015" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS11015" fbc:name="ACZ81_RS11015" fbc:label="G_ACZ81_RS11015"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS09175" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS09175" fbc:name="ACZ81_RS09175" fbc:label="G_ACZ81_RS09175"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS01820" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS01820" fbc:name="ACZ81_RS01820" fbc:label="G_ACZ81_RS01820"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS13425" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS13425" fbc:name="ACZ81_RS13425" fbc:label="G_ACZ81_RS13425"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS14495" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS14495" fbc:name="ACZ81_RS14495" fbc:label="G_ACZ81_RS14495"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS08140" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS08140" fbc:name="ACZ81_RS08140" fbc:label="G_ACZ81_RS08140"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS02405" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS02405" fbc:name="ACZ81_RS02405" fbc:label="G_ACZ81_RS02405"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS12690" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS12690" fbc:name="ACZ81_RS12690" fbc:label="G_ACZ81_RS12690"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS00760" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS00760" fbc:name="ACZ81_RS00760" fbc:label="G_ACZ81_RS00760"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS10155" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS10155" fbc:name="ACZ81_RS10155" fbc:label="G_ACZ81_RS10155"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS17970" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS17970" fbc:name="ACZ81_RS17970" fbc:label="G_ACZ81_RS17970"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS16055" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS16055" fbc:name="ACZ81_RS16055" fbc:label="G_ACZ81_RS16055"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS17225" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS17225" fbc:name="ACZ81_RS17225" fbc:label="G_ACZ81_RS17225"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS07490" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS07490" fbc:name="ACZ81_RS07490" fbc:label="G_ACZ81_RS07490"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS14230" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS14230" fbc:name="ACZ81_RS14230" fbc:label="G_ACZ81_RS14230"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS14240" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS14240" fbc:name="ACZ81_RS14240" fbc:label="G_ACZ81_RS14240"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS15445" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS15445" fbc:name="ACZ81_RS15445" fbc:label="G_ACZ81_RS15445"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS11050" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS11050" fbc:name="ACZ81_RS11050" fbc:label="G_ACZ81_RS11050"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS15295" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS15295" fbc:name="ACZ81_RS15295" fbc:label="G_ACZ81_RS15295"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS07885" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS07885" fbc:name="ACZ81_RS07885" fbc:label="G_ACZ81_RS07885"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS10180" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS10180" fbc:name="ACZ81_RS10180" fbc:label="G_ACZ81_RS10180"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS11375" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS11375" fbc:name="ACZ81_RS11375" fbc:label="G_ACZ81_RS11375"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS00080" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS00080" fbc:name="ACZ81_RS00080" fbc:label="G_ACZ81_RS00080"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS00085" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS00085" fbc:name="ACZ81_RS00085" fbc:label="G_ACZ81_RS00085"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS18250" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS18250" fbc:name="ACZ81_RS18250" fbc:label="G_ACZ81_RS18250"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS10695" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS10695" fbc:name="ACZ81_RS10695" fbc:label="G_ACZ81_RS10695"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS08260" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS08260" fbc:name="ACZ81_RS08260" fbc:label="G_ACZ81_RS08260"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS13385" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS13385" fbc:name="ACZ81_RS13385" fbc:label="G_ACZ81_RS13385"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS03750" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS03750" fbc:name="ACZ81_RS03750" fbc:label="G_ACZ81_RS03750"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS10760" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS10760" fbc:name="ACZ81_RS10760" fbc:label="G_ACZ81_RS10760"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS09945" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS09945" fbc:name="ACZ81_RS09945" fbc:label="G_ACZ81_RS09945"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS15830" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS15830" fbc:name="ACZ81_RS15830" fbc:label="G_ACZ81_RS15830"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS02780" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS02780" fbc:name="ACZ81_RS02780" fbc:label="G_ACZ81_RS02780"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS04850" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS04850" fbc:name="ACZ81_RS04850" fbc:label="G_ACZ81_RS04850"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS14180" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS14180" fbc:name="ACZ81_RS14180" fbc:label="G_ACZ81_RS14180"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS13685" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS13685" fbc:name="ACZ81_RS13685" fbc:label="G_ACZ81_RS13685"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS18105" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS18105" fbc:name="ACZ81_RS18105" fbc:label="G_ACZ81_RS18105"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS12965" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS12965" fbc:name="ACZ81_RS12965" fbc:label="G_ACZ81_RS12965"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS04025" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS04025" fbc:name="ACZ81_RS04025" fbc:label="G_ACZ81_RS04025"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS04030" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS04030" fbc:name="ACZ81_RS04030" fbc:label="G_ACZ81_RS04030"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS03355" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS03355" fbc:name="ACZ81_RS03355" fbc:label="G_ACZ81_RS03355"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS04035" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS04035" fbc:name="ACZ81_RS04035" fbc:label="G_ACZ81_RS04035"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS13655" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS13655" fbc:name="ACZ81_RS13655" fbc:label="G_ACZ81_RS13655"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS04690" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS04690" fbc:name="ACZ81_RS04690" fbc:label="G_ACZ81_RS04690"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS10270" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS10270" fbc:name="ACZ81_RS10270" fbc:label="G_ACZ81_RS10270"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS03160" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS03160" fbc:name="ACZ81_RS03160" fbc:label="G_ACZ81_RS03160"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS17855" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS17855" fbc:name="ACZ81_RS17855" fbc:label="G_ACZ81_RS17855"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS18070" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS18070" fbc:name="ACZ81_RS18070" fbc:label="G_ACZ81_RS18070"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS06700" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS06700" fbc:name="ACZ81_RS06700" fbc:label="G_ACZ81_RS06700"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS06840" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS06840" fbc:name="ACZ81_RS06840" fbc:label="G_ACZ81_RS06840"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS18465" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS18465" fbc:name="ACZ81_RS18465" fbc:label="G_ACZ81_RS18465"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS00590" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS00590" fbc:name="ACZ81_RS00590" fbc:label="G_ACZ81_RS00590"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS17020" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS17020" fbc:name="ACZ81_RS17020" fbc:label="G_ACZ81_RS17020"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS05435" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS05435" fbc:name="ACZ81_RS05435" fbc:label="G_ACZ81_RS05435"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS09020" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS09020" fbc:name="ACZ81_RS09020" fbc:label="G_ACZ81_RS09020"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS09800" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS09800" fbc:name="ACZ81_RS09800" fbc:label="G_ACZ81_RS09800"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS12305" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS12305" fbc:name="ACZ81_RS12305" fbc:label="G_ACZ81_RS12305"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS06525" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS06525" fbc:name="ACZ81_RS06525" fbc:label="G_ACZ81_RS06525"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS16730" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS16730" fbc:name="ACZ81_RS16730" fbc:label="G_ACZ81_RS16730"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS17700" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS17700" fbc:name="ACZ81_RS17700" fbc:label="G_ACZ81_RS17700"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS15290" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS15290" fbc:name="ACZ81_RS15290" fbc:label="G_ACZ81_RS15290"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS13260" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS13260" fbc:name="ACZ81_RS13260" fbc:label="G_ACZ81_RS13260"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS09395" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS09395" fbc:name="ACZ81_RS09395" fbc:label="G_ACZ81_RS09395"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS03955" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS03955" fbc:name="ACZ81_RS03955" fbc:label="G_ACZ81_RS03955"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS08640" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS08640" fbc:name="ACZ81_RS08640" fbc:label="G_ACZ81_RS08640"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS15550" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS15550" fbc:name="ACZ81_RS15550" fbc:label="G_ACZ81_RS15550"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS02270" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS02270" fbc:name="ACZ81_RS02270" fbc:label="G_ACZ81_RS02270"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS12285" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS12285" fbc:name="ACZ81_RS12285" fbc:label="G_ACZ81_RS12285"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS04905" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS04905" fbc:name="ACZ81_RS04905" fbc:label="G_ACZ81_RS04905"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS13410" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS13410" fbc:name="ACZ81_RS13410" fbc:label="G_ACZ81_RS13410"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS16280" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS16280" fbc:name="ACZ81_RS16280" fbc:label="G_ACZ81_RS16280"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS00285" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS00285" fbc:name="ACZ81_RS00285" fbc:label="G_ACZ81_RS00285"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS15415" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS15415" fbc:name="ACZ81_RS15415" fbc:label="G_ACZ81_RS15415"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS12740" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS12740" fbc:name="ACZ81_RS12740" fbc:label="G_ACZ81_RS12740"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS11890" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS11890" fbc:name="ACZ81_RS11890" fbc:label="G_ACZ81_RS11890"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS11735" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS11735" fbc:name="ACZ81_RS11735" fbc:label="G_ACZ81_RS11735"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS03125" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS03125" fbc:name="ACZ81_RS03125" fbc:label="G_ACZ81_RS03125"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS02910" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS02910" fbc:name="ACZ81_RS02910" fbc:label="G_ACZ81_RS02910"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS17055" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS17055" fbc:name="ACZ81_RS17055" fbc:label="G_ACZ81_RS17055"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS01625" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS01625" fbc:name="ACZ81_RS01625" fbc:label="G_ACZ81_RS01625"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS05480" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS05480" fbc:name="ACZ81_RS05480" fbc:label="G_ACZ81_RS05480"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS00535" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS00535" fbc:name="ACZ81_RS00535" fbc:label="G_ACZ81_RS00535"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS03575" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS03575" fbc:name="ACZ81_RS03575" fbc:label="G_ACZ81_RS03575"/>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS10400" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS10400" fbc:name="ACZ81_RS10400" fbc:label="G_ACZ81_RS10400">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS10400">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_061485917.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS08145" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS08145" fbc:name="ACZ81_RS08145" fbc:label="G_ACZ81_RS08145">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS08145">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_061485619.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS13050" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS13050" fbc:name="ACZ81_RS13050" fbc:label="G_ACZ81_RS13050">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS13050">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014950092.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS02475" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS02475" fbc:name="ACZ81_RS02475" fbc:label="G_ACZ81_RS02475">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS02475">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_061439323.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS02040" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS02040" fbc:name="ACZ81_RS02040" fbc:label="G_ACZ81_RS02040">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS02040">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_061439243.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS10170" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS10170" fbc:name="ACZ81_RS10170" fbc:label="G_ACZ81_RS10170">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS10170">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014949536.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS12720" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS12720" fbc:name="ACZ81_RS12720" fbc:label="G_ACZ81_RS12720">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS12720">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_061486116.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS07495" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS07495" fbc:name="ACZ81_RS07495" fbc:label="G_ACZ81_RS07495">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS07495">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_061485438.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS17040" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS17040" fbc:name="ACZ81_RS17040" fbc:label="G_ACZ81_RS17040">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS17040">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_061486606.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS13705" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS13705" fbc:name="ACZ81_RS13705" fbc:label="G_ACZ81_RS13705">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS13705">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_061486205.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS17435" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS17435" fbc:name="ACZ81_RS17435" fbc:label="G_ACZ81_RS17435">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS17435">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014977536.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS08955" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS08955" fbc:name="ACZ81_RS08955" fbc:label="G_ACZ81_RS08955">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS08955">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_061485763.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS15785" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS15785" fbc:name="ACZ81_RS15785" fbc:label="G_ACZ81_RS15785">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS15785">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014977336.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS07295" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS07295" fbc:name="ACZ81_RS07295" fbc:label="G_ACZ81_RS07295">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS07295">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014949012.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS02770" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS02770" fbc:name="ACZ81_RS02770" fbc:label="G_ACZ81_RS02770">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS02770">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_061439403.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS01595" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS01595" fbc:name="ACZ81_RS01595" fbc:label="G_ACZ81_RS01595">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS01595">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_061439201.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS07000" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS07000" fbc:name="ACZ81_RS07000" fbc:label="G_ACZ81_RS07000">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS07000">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_230962242.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS04860" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS04860" fbc:name="ACZ81_RS04860" fbc:label="G_ACZ81_RS04860">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS04860">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014978553.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS14715" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS14715" fbc:name="ACZ81_RS14715" fbc:label="G_ACZ81_RS14715">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS14715">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_061486401.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS03930" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS03930" fbc:name="ACZ81_RS03930" fbc:label="G_ACZ81_RS03930">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS03930">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014948382.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS19750" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS19750" fbc:name="ACZ81_RS19750" fbc:label="G_ACZ81_RS19750">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS19750">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_039228851.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS18145" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS18145" fbc:name="ACZ81_RS18145" fbc:label="G_ACZ81_RS18145">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS18145">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_061486717.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS18665" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS18665" fbc:name="ACZ81_RS18665" fbc:label="G_ACZ81_RS18665">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS18665">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_061486763.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS09925" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS09925" fbc:name="ACZ81_RS09925" fbc:label="G_ACZ81_RS09925">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS09925">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_061485870.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS00890" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS00890" fbc:name="ACZ81_RS00890" fbc:label="G_ACZ81_RS00890">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS00890">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014947860.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS03495" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS03495" fbc:name="ACZ81_RS03495" fbc:label="G_ACZ81_RS03495">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS03495">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014975694.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS15990" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS15990" fbc:name="ACZ81_RS15990" fbc:label="G_ACZ81_RS15990">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS15990">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014950684.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS02375" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS02375" fbc:name="ACZ81_RS02375" fbc:label="G_ACZ81_RS02375">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS02375">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_061439300.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS06990" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS06990" fbc:name="ACZ81_RS06990" fbc:label="G_ACZ81_RS06990">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS06990">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014948959.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS06915" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS06915" fbc:name="ACZ81_RS06915" fbc:label="G_ACZ81_RS06915">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS06915">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_061485334.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS06910" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS06910" fbc:name="ACZ81_RS06910" fbc:label="G_ACZ81_RS06910">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS06910">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_049586830.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS04710" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS04710" fbc:name="ACZ81_RS04710" fbc:label="G_ACZ81_RS04710">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS04710">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_061484968.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS02135" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS02135" fbc:name="ACZ81_RS02135" fbc:label="G_ACZ81_RS02135">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS02135">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_049588317.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS14235" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS14235" fbc:name="ACZ81_RS14235" fbc:label="G_ACZ81_RS14235">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS14235">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_061486335.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS08565" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS08565" fbc:name="ACZ81_RS08565" fbc:label="G_ACZ81_RS08565">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS08565">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014976326.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS07020" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS07020" fbc:name="ACZ81_RS07020" fbc:label="G_ACZ81_RS07020">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS07020">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014997928.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS12710" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS12710" fbc:name="ACZ81_RS12710" fbc:label="G_ACZ81_RS12710">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS12710">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014950028.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS19230" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS19230" fbc:name="ACZ81_RS19230" fbc:label="G_ACZ81_RS19230">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS19230">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014951296.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS01825" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS01825" fbc:name="ACZ81_RS01825" fbc:label="G_ACZ81_RS01825">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS01825">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014948005.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS02395" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS02395" fbc:name="ACZ81_RS02395" fbc:label="G_ACZ81_RS02395">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS02395">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_061439304.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS07895" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS07895" fbc:name="ACZ81_RS07895" fbc:label="G_ACZ81_RS07895">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS07895">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_061485549.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS11015" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS11015" fbc:name="ACZ81_RS11015" fbc:label="G_ACZ81_RS11015">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS11015">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_061485978.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS09175" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS09175" fbc:name="ACZ81_RS09175" fbc:label="G_ACZ81_RS09175">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS09175">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_061485791.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS01820" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS01820" fbc:name="ACZ81_RS01820" fbc:label="G_ACZ81_RS01820">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS01820">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014948004.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS13425" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS13425" fbc:name="ACZ81_RS13425" fbc:label="G_ACZ81_RS13425">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS13425">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014950157.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS14495" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS14495" fbc:name="ACZ81_RS14495" fbc:label="G_ACZ81_RS14495">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS14495">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_061486372.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS08140" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS08140" fbc:name="ACZ81_RS08140" fbc:label="G_ACZ81_RS08140">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS08140">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_061485617.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS02405" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS02405" fbc:name="ACZ81_RS02405" fbc:label="G_ACZ81_RS02405">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS02405">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_061439306.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS12690" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS12690" fbc:name="ACZ81_RS12690" fbc:label="G_ACZ81_RS12690">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS12690">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_061486987.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS00760" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS00760" fbc:name="ACZ81_RS00760" fbc:label="G_ACZ81_RS00760">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS00760">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014947836.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS10155" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS10155" fbc:name="ACZ81_RS10155" fbc:label="G_ACZ81_RS10155">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS10155">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_061485899.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS17970" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS17970" fbc:name="ACZ81_RS17970" fbc:label="G_ACZ81_RS17970">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS17970">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_061486704.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS16055" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS16055" fbc:name="ACZ81_RS16055" fbc:label="G_ACZ81_RS16055">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS16055">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_061486533.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS17225" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS17225" fbc:name="ACZ81_RS17225" fbc:label="G_ACZ81_RS17225">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS17225">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_061486641.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS07490" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS07490" fbc:name="ACZ81_RS07490" fbc:label="G_ACZ81_RS07490">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS07490">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014949049.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS14230" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS14230" fbc:name="ACZ81_RS14230" fbc:label="G_ACZ81_RS14230">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS14230">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_061486334.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS14240" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS14240" fbc:name="ACZ81_RS14240" fbc:label="G_ACZ81_RS14240">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS14240">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_061486336.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS15445" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS15445" fbc:name="ACZ81_RS15445" fbc:label="G_ACZ81_RS15445">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS15445">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_061486474.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS11050" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS11050" fbc:name="ACZ81_RS11050" fbc:label="G_ACZ81_RS11050">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS11050">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_081106090.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS15295" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS15295" fbc:name="ACZ81_RS15295" fbc:label="G_ACZ81_RS15295">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS15295">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_061486459.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS07885" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS07885" fbc:name="ACZ81_RS07885" fbc:label="G_ACZ81_RS07885">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS07885">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_061485545.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS10180" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS10180" fbc:name="ACZ81_RS10180" fbc:label="G_ACZ81_RS10180">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS10180">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_232375932.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS11375" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS11375" fbc:name="ACZ81_RS11375" fbc:label="G_ACZ81_RS11375">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS11375">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_061486014.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS00080" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS00080" fbc:name="ACZ81_RS00080" fbc:label="G_ACZ81_RS00080">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS00080">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014947725.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS00085" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS00085" fbc:name="ACZ81_RS00085" fbc:label="G_ACZ81_RS00085">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS00085">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014947726.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS18250" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS18250" fbc:name="ACZ81_RS18250" fbc:label="G_ACZ81_RS18250">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS18250">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_061486729.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS10695" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS10695" fbc:name="ACZ81_RS10695" fbc:label="G_ACZ81_RS10695">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS10695">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014949647.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS08260" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS08260" fbc:name="ACZ81_RS08260" fbc:label="G_ACZ81_RS08260">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS08260">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_061485639.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS13385" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS13385" fbc:name="ACZ81_RS13385" fbc:label="G_ACZ81_RS13385">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS13385">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_061486168.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS03750" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS03750" fbc:name="ACZ81_RS03750" fbc:label="G_ACZ81_RS03750">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS03750">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014948346.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS10760" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS10760" fbc:name="ACZ81_RS10760" fbc:label="G_ACZ81_RS10760">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS10760">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_061485944.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS09945" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS09945" fbc:name="ACZ81_RS09945" fbc:label="G_ACZ81_RS09945">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS09945">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_061485873.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS15830" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS15830" fbc:name="ACZ81_RS15830" fbc:label="G_ACZ81_RS15830">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS15830">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_049588165.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS02780" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS02780" fbc:name="ACZ81_RS02780" fbc:label="G_ACZ81_RS02780">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS02780">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_061439404.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS04850" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS04850" fbc:name="ACZ81_RS04850" fbc:label="G_ACZ81_RS04850">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS04850">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014978552.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS14180" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS14180" fbc:name="ACZ81_RS14180" fbc:label="G_ACZ81_RS14180">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS14180">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_061486325.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS13685" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS13685" fbc:name="ACZ81_RS13685" fbc:label="G_ACZ81_RS13685">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS13685">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_061486199.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS18105" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS18105" fbc:name="ACZ81_RS18105" fbc:label="G_ACZ81_RS18105">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS18105">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014951053.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS12965" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS12965" fbc:name="ACZ81_RS12965" fbc:label="G_ACZ81_RS12965">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS12965">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_061486140.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS04025" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS04025" fbc:name="ACZ81_RS04025" fbc:label="G_ACZ81_RS04025">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS04025">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_061484792.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS04030" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS04030" fbc:name="ACZ81_RS04030" fbc:label="G_ACZ81_RS04030">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS04030">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_061484794.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS03355" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS03355" fbc:name="ACZ81_RS03355" fbc:label="G_ACZ81_RS03355">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS03355">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_081106058.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS04035" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS04035" fbc:name="ACZ81_RS04035" fbc:label="G_ACZ81_RS04035">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS04035">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_061484797.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS13655" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS13655" fbc:name="ACZ81_RS13655" fbc:label="G_ACZ81_RS13655">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS13655">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_061486191.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS04690" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS04690" fbc:name="ACZ81_RS04690" fbc:label="G_ACZ81_RS04690">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS04690">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_061484965.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS10270" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS10270" fbc:name="ACZ81_RS10270" fbc:label="G_ACZ81_RS10270">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS10270">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_061485909.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS03160" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS03160" fbc:name="ACZ81_RS03160" fbc:label="G_ACZ81_RS03160">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS03160">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_061439531.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS17855" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS17855" fbc:name="ACZ81_RS17855" fbc:label="G_ACZ81_RS17855">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS17855">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_039226809.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS18070" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS18070" fbc:name="ACZ81_RS18070" fbc:label="G_ACZ81_RS18070">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS18070">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_061486708.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS06700" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS06700" fbc:name="ACZ81_RS06700" fbc:label="G_ACZ81_RS06700">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS06700">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_061485304.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS06840" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS06840" fbc:name="ACZ81_RS06840" fbc:label="G_ACZ81_RS06840">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS06840">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_061485322.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS18465" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS18465" fbc:name="ACZ81_RS18465" fbc:label="G_ACZ81_RS18465">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS18465">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_061486740.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS00590" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS00590" fbc:name="ACZ81_RS00590" fbc:label="G_ACZ81_RS00590">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS00590">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_039226913.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS17020" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS17020" fbc:name="ACZ81_RS17020" fbc:label="G_ACZ81_RS17020">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS17020">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014950852.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS05435" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS05435" fbc:name="ACZ81_RS05435" fbc:label="G_ACZ81_RS05435">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS05435">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014948676.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS09020" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS09020" fbc:name="ACZ81_RS09020" fbc:label="G_ACZ81_RS09020">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS09020">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_061485774.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS09800" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS09800" fbc:name="ACZ81_RS09800" fbc:label="G_ACZ81_RS09800">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS09800">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_061485859.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS12305" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS12305" fbc:name="ACZ81_RS12305" fbc:label="G_ACZ81_RS12305">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS12305">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014979671.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS06525" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS06525" fbc:name="ACZ81_RS06525" fbc:label="G_ACZ81_RS06525">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS06525">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014948878.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS16730" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS16730" fbc:name="ACZ81_RS16730" fbc:label="G_ACZ81_RS16730">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS16730">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014950802.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS17700" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS17700" fbc:name="ACZ81_RS17700" fbc:label="G_ACZ81_RS17700">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS17700">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014950978.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS15290" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS15290" fbc:name="ACZ81_RS15290" fbc:label="G_ACZ81_RS15290">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS15290">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_039218892.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS13260" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS13260" fbc:name="ACZ81_RS13260" fbc:label="G_ACZ81_RS13260">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS13260">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014950132.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS09395" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS09395" fbc:name="ACZ81_RS09395" fbc:label="G_ACZ81_RS09395">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS09395">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_039229431.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS03955" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS03955" fbc:name="ACZ81_RS03955" fbc:label="G_ACZ81_RS03955">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS03955">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014948386.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS08640" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS08640" fbc:name="ACZ81_RS08640" fbc:label="G_ACZ81_RS08640">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS08640">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014949228.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS15550" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS15550" fbc:name="ACZ81_RS15550" fbc:label="G_ACZ81_RS15550">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS15550">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014950588.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS02270" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS02270" fbc:name="ACZ81_RS02270" fbc:label="G_ACZ81_RS02270">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS02270">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_039225046.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS12285" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS12285" fbc:name="ACZ81_RS12285" fbc:label="G_ACZ81_RS12285">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS12285">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014949945.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS04905" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS04905" fbc:name="ACZ81_RS04905" fbc:label="G_ACZ81_RS04905">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS04905">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014948567.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS13410" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS13410" fbc:name="ACZ81_RS13410" fbc:label="G_ACZ81_RS13410">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS13410">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_039231566.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS16280" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS16280" fbc:name="ACZ81_RS16280" fbc:label="G_ACZ81_RS16280">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS16280">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_049588677.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS00285" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS00285" fbc:name="ACZ81_RS00285" fbc:label="G_ACZ81_RS00285">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS00285">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_061438900.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS15415" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS15415" fbc:name="ACZ81_RS15415" fbc:label="G_ACZ81_RS15415">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS15415">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_061486470.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS12740" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS12740" fbc:name="ACZ81_RS12740" fbc:label="G_ACZ81_RS12740">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS12740">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_061486118.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS11890" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS11890" fbc:name="ACZ81_RS11890" fbc:label="G_ACZ81_RS11890">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS11890">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014976837.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS11735" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS11735" fbc:name="ACZ81_RS11735" fbc:label="G_ACZ81_RS11735">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS11735">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014949849.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS03125" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS03125" fbc:name="ACZ81_RS03125" fbc:label="G_ACZ81_RS03125">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS03125">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_061439515.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS02910" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS02910" fbc:name="ACZ81_RS02910" fbc:label="G_ACZ81_RS02910">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS02910">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_061439437.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS17055" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS17055" fbc:name="ACZ81_RS17055" fbc:label="G_ACZ81_RS17055">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS17055">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_061486609.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS01625" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS01625" fbc:name="ACZ81_RS01625" fbc:label="G_ACZ81_RS01625">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS01625">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_061439204.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS05480" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS05480" fbc:name="ACZ81_RS05480" fbc:label="G_ACZ81_RS05480">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS05480">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014948685.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS00535" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS00535" fbc:name="ACZ81_RS00535" fbc:label="G_ACZ81_RS00535">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS00535">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_061438956.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS03575" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS03575" fbc:name="ACZ81_RS03575" fbc:label="G_ACZ81_RS03575">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS03575">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_081106061.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
       <fbc:geneProduct metaid="meta_G_ACZ81_RS17610" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS17610" fbc:name="ACZ81_RS17610" fbc:label="G_ACZ81_RS17610"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS18845" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS18845" fbc:name="ACZ81_RS18845" fbc:label="G_ACZ81_RS18845"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS13025" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS13025" fbc:name="ACZ81_RS13025" fbc:label="G_ACZ81_RS13025"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS09130" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS09130" fbc:name="ACZ81_RS09130" fbc:label="G_ACZ81_RS09130"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS11185" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS11185" fbc:name="ACZ81_RS11185" fbc:label="G_ACZ81_RS11185"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS06320" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS06320" fbc:name="ACZ81_RS06320" fbc:label="G_ACZ81_RS06320"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS04730" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS04730" fbc:name="ACZ81_RS04730" fbc:label="G_ACZ81_RS04730"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS18815" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS18815" fbc:name="ACZ81_RS18815" fbc:label="G_ACZ81_RS18815"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS01840" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS01840" fbc:name="ACZ81_RS01840" fbc:label="G_ACZ81_RS01840"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS14590" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS14590" fbc:name="ACZ81_RS14590" fbc:label="G_ACZ81_RS14590"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS00145" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS00145" fbc:name="ACZ81_RS00145" fbc:label="G_ACZ81_RS00145"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS15425" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS15425" fbc:name="ACZ81_RS15425" fbc:label="G_ACZ81_RS15425"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS16765" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS16765" fbc:name="ACZ81_RS16765" fbc:label="G_ACZ81_RS16765"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS12215" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS12215" fbc:name="ACZ81_RS12215" fbc:label="G_ACZ81_RS12215"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS16725" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS16725" fbc:name="ACZ81_RS16725" fbc:label="G_ACZ81_RS16725"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS14570" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS14570" fbc:name="ACZ81_RS14570" fbc:label="G_ACZ81_RS14570"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS12265" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS12265" fbc:name="ACZ81_RS12265" fbc:label="G_ACZ81_RS12265"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS02740" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS02740" fbc:name="ACZ81_RS02740" fbc:label="G_ACZ81_RS02740"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS03565" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS03565" fbc:name="ACZ81_RS03565" fbc:label="G_ACZ81_RS03565"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS02790" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS02790" fbc:name="ACZ81_RS02790" fbc:label="G_ACZ81_RS02790"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS12730" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS12730" fbc:name="ACZ81_RS12730" fbc:label="G_ACZ81_RS12730"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS04195" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS04195" fbc:name="ACZ81_RS04195" fbc:label="G_ACZ81_RS04195"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS14480" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS14480" fbc:name="ACZ81_RS14480" fbc:label="G_ACZ81_RS14480"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS05420" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS05420" fbc:name="ACZ81_RS05420" fbc:label="G_ACZ81_RS05420"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS12250" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS12250" fbc:name="ACZ81_RS12250" fbc:label="G_ACZ81_RS12250"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS09805" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS09805" fbc:name="ACZ81_RS09805" fbc:label="G_ACZ81_RS09805"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS09810" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS09810" fbc:name="ACZ81_RS09810" fbc:label="G_ACZ81_RS09810"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS10250" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS10250" fbc:name="ACZ81_RS10250" fbc:label="G_ACZ81_RS10250"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS12345" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS12345" fbc:name="ACZ81_RS12345" fbc:label="G_ACZ81_RS12345"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS00320" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS00320" fbc:name="ACZ81_RS00320" fbc:label="G_ACZ81_RS00320"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS04160" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS04160" fbc:name="ACZ81_RS04160" fbc:label="G_ACZ81_RS04160"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS19360" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS19360" fbc:name="ACZ81_RS19360" fbc:label="G_ACZ81_RS19360"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS05505" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS05505" fbc:name="ACZ81_RS05505" fbc:label="G_ACZ81_RS05505"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS02420" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS02420" fbc:name="ACZ81_RS02420" fbc:label="G_ACZ81_RS02420"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS01200" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS01200" fbc:name="ACZ81_RS01200" fbc:label="G_ACZ81_RS01200"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS13960" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS13960" fbc:name="ACZ81_RS13960" fbc:label="G_ACZ81_RS13960"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS01575" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS01575" fbc:name="ACZ81_RS01575" fbc:label="G_ACZ81_RS01575"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS17080" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS17080" fbc:name="ACZ81_RS17080" fbc:label="G_ACZ81_RS17080"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS00340" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS00340" fbc:name="ACZ81_RS00340" fbc:label="G_ACZ81_RS00340"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS07145" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS07145" fbc:name="ACZ81_RS07145" fbc:label="G_ACZ81_RS07145"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS05890" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS05890" fbc:name="ACZ81_RS05890" fbc:label="G_ACZ81_RS05890"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS14985" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS14985" fbc:name="ACZ81_RS14985" fbc:label="G_ACZ81_RS14985"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS14650" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS14650" fbc:name="ACZ81_RS14650" fbc:label="G_ACZ81_RS14650"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS10085" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS10085" fbc:name="ACZ81_RS10085" fbc:label="G_ACZ81_RS10085"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS10090" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS10090" fbc:name="ACZ81_RS10090" fbc:label="G_ACZ81_RS10090"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS18890" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS18890" fbc:name="ACZ81_RS18890" fbc:label="G_ACZ81_RS18890"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS11325" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS11325" fbc:name="ACZ81_RS11325" fbc:label="G_ACZ81_RS11325"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS11410" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS11410" fbc:name="ACZ81_RS11410" fbc:label="G_ACZ81_RS11410"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS18585" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS18585" fbc:name="ACZ81_RS18585" fbc:label="G_ACZ81_RS18585"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS06950" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS06950" fbc:name="ACZ81_RS06950" fbc:label="G_ACZ81_RS06950"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS04890" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS04890" fbc:name="ACZ81_RS04890" fbc:label="G_ACZ81_RS04890"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS11380" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS11380" fbc:name="ACZ81_RS11380" fbc:label="G_ACZ81_RS11380"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS10510" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS10510" fbc:name="ACZ81_RS10510" fbc:label="G_ACZ81_RS10510"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS11065" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS11065" fbc:name="ACZ81_RS11065" fbc:label="G_ACZ81_RS11065"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS15060" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS15060" fbc:name="ACZ81_RS15060" fbc:label="G_ACZ81_RS15060"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS01900" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS01900" fbc:name="ACZ81_RS01900" fbc:label="G_ACZ81_RS01900"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS12165" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS12165" fbc:name="ACZ81_RS12165" fbc:label="G_ACZ81_RS12165"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS03030" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS03030" fbc:name="ACZ81_RS03030" fbc:label="G_ACZ81_RS03030"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS08425" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS08425" fbc:name="ACZ81_RS08425" fbc:label="G_ACZ81_RS08425"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS02160" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS02160" fbc:name="ACZ81_RS02160" fbc:label="G_ACZ81_RS02160"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS07315" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS07315" fbc:name="ACZ81_RS07315" fbc:label="G_ACZ81_RS07315"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS03945" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS03945" fbc:name="ACZ81_RS03945" fbc:label="G_ACZ81_RS03945"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS02370" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS02370" fbc:name="ACZ81_RS02370" fbc:label="G_ACZ81_RS02370"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS05345" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS05345" fbc:name="ACZ81_RS05345" fbc:label="G_ACZ81_RS05345"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS02065" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS02065" fbc:name="ACZ81_RS02065" fbc:label="G_ACZ81_RS02065"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS09425" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS09425" fbc:name="ACZ81_RS09425" fbc:label="G_ACZ81_RS09425"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS11250" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS11250" fbc:name="ACZ81_RS11250" fbc:label="G_ACZ81_RS11250"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS11880" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS11880" fbc:name="ACZ81_RS11880" fbc:label="G_ACZ81_RS11880"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS05865" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS05865" fbc:name="ACZ81_RS05865" fbc:label="G_ACZ81_RS05865"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS17685" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS17685" fbc:name="ACZ81_RS17685" fbc:label="G_ACZ81_RS17685"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS18455" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS18455" fbc:name="ACZ81_RS18455" fbc:label="G_ACZ81_RS18455"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS05390" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS05390" fbc:name="ACZ81_RS05390" fbc:label="G_ACZ81_RS05390"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS00270" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS00270" fbc:name="ACZ81_RS00270" fbc:label="G_ACZ81_RS00270"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS13270" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS13270" fbc:name="ACZ81_RS13270" fbc:label="G_ACZ81_RS13270"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS03275" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS03275" fbc:name="ACZ81_RS03275" fbc:label="G_ACZ81_RS03275"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS10600" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS10600" fbc:name="ACZ81_RS10600" fbc:label="G_ACZ81_RS10600"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS07955" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS07955" fbc:name="ACZ81_RS07955" fbc:label="G_ACZ81_RS07955"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS02680" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS02680" fbc:name="ACZ81_RS02680" fbc:label="G_ACZ81_RS02680"/>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS18845" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS18845" fbc:name="ACZ81_RS18845" fbc:label="G_ACZ81_RS18845">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS18845">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014951234.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS13025" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS13025" fbc:name="ACZ81_RS13025" fbc:label="G_ACZ81_RS13025">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS13025">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014950088.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS09130" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS09130" fbc:name="ACZ81_RS09130" fbc:label="G_ACZ81_RS09130">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS09130">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014949316.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS11185" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS11185" fbc:name="ACZ81_RS11185" fbc:label="G_ACZ81_RS11185">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS11185">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_061485995.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS06320" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS06320" fbc:name="ACZ81_RS06320" fbc:label="G_ACZ81_RS06320">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS06320">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_197044398.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS04730" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS04730" fbc:name="ACZ81_RS04730" fbc:label="G_ACZ81_RS04730">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS04730">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014975843.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS18815" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS18815" fbc:name="ACZ81_RS18815" fbc:label="G_ACZ81_RS18815">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS18815">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014951198.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS01840" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS01840" fbc:name="ACZ81_RS01840" fbc:label="G_ACZ81_RS01840">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS01840">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014948008.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS14590" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS14590" fbc:name="ACZ81_RS14590" fbc:label="G_ACZ81_RS14590">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS14590">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014950385.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS00145" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS00145" fbc:name="ACZ81_RS00145" fbc:label="G_ACZ81_RS00145">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS00145">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_061438874.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS15425" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS15425" fbc:name="ACZ81_RS15425" fbc:label="G_ACZ81_RS15425">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS15425">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_061486472.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS16765" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS16765" fbc:name="ACZ81_RS16765" fbc:label="G_ACZ81_RS16765">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS16765">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014950809.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS12215" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS12215" fbc:name="ACZ81_RS12215" fbc:label="G_ACZ81_RS12215">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS12215">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_061486079.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS16725" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS16725" fbc:name="ACZ81_RS16725" fbc:label="G_ACZ81_RS16725">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS16725">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014977467.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS14570" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS14570" fbc:name="ACZ81_RS14570" fbc:label="G_ACZ81_RS14570">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS14570">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_061486382.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS12265" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS12265" fbc:name="ACZ81_RS12265" fbc:label="G_ACZ81_RS12265">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS12265">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014949941.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS02740" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS02740" fbc:name="ACZ81_RS02740" fbc:label="G_ACZ81_RS02740">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS02740">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014948162.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS03565" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS03565" fbc:name="ACZ81_RS03565" fbc:label="G_ACZ81_RS03565">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS03565">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_061439577.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS02790" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS02790" fbc:name="ACZ81_RS02790" fbc:label="G_ACZ81_RS02790">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS02790">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_039224442.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS12730" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS12730" fbc:name="ACZ81_RS12730" fbc:label="G_ACZ81_RS12730">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS12730">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_039222817.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS04195" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS04195" fbc:name="ACZ81_RS04195" fbc:label="G_ACZ81_RS04195">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS04195">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_061484833.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS14480" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS14480" fbc:name="ACZ81_RS14480" fbc:label="G_ACZ81_RS14480">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS14480">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_061486369.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS05420" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS05420" fbc:name="ACZ81_RS05420" fbc:label="G_ACZ81_RS05420">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS05420">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_061485071.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS12250" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS12250" fbc:name="ACZ81_RS12250" fbc:label="G_ACZ81_RS12250">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS12250">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_061486081.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS09805" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS09805" fbc:name="ACZ81_RS09805" fbc:label="G_ACZ81_RS09805">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS09805">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014949450.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS09810" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS09810" fbc:name="ACZ81_RS09810" fbc:label="G_ACZ81_RS09810">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS09810">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_012518366.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS10250" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS10250" fbc:name="ACZ81_RS10250" fbc:label="G_ACZ81_RS10250">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS10250">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014949552.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS12345" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS12345" fbc:name="ACZ81_RS12345" fbc:label="G_ACZ81_RS12345">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS12345">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_061486092.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS00320" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS00320" fbc:name="ACZ81_RS00320" fbc:label="G_ACZ81_RS00320">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS00320">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014947767.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS04160" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS04160" fbc:name="ACZ81_RS04160" fbc:label="G_ACZ81_RS04160">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS04160">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_061486934.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS19360" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS19360" fbc:name="ACZ81_RS19360" fbc:label="G_ACZ81_RS19360">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS19360">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014951321.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS05505" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS05505" fbc:name="ACZ81_RS05505" fbc:label="G_ACZ81_RS05505">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS05505">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_061485081.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS02420" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS02420" fbc:name="ACZ81_RS02420" fbc:label="G_ACZ81_RS02420">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS02420">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_081106055.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS01200" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS01200" fbc:name="ACZ81_RS01200" fbc:label="G_ACZ81_RS01200">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS01200">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_061439104.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS13960" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS13960" fbc:name="ACZ81_RS13960" fbc:label="G_ACZ81_RS13960">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS13960">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014950261.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS01575" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS01575" fbc:name="ACZ81_RS01575" fbc:label="G_ACZ81_RS01575">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS01575">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_061439199.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS17080" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS17080" fbc:name="ACZ81_RS17080" fbc:label="G_ACZ81_RS17080">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS17080">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_081106115.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS00340" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS00340" fbc:name="ACZ81_RS00340" fbc:label="G_ACZ81_RS00340">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS00340">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_061438908.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS07145" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS07145" fbc:name="ACZ81_RS07145" fbc:label="G_ACZ81_RS07145">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS07145">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014948990.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS05890" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS05890" fbc:name="ACZ81_RS05890" fbc:label="G_ACZ81_RS05890">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS05890">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014948764.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS14985" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS14985" fbc:name="ACZ81_RS14985" fbc:label="G_ACZ81_RS14985">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS14985">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_049586032.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS14650" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS14650" fbc:name="ACZ81_RS14650" fbc:label="G_ACZ81_RS14650">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS14650">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_061486391.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS10085" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS10085" fbc:name="ACZ81_RS10085" fbc:label="G_ACZ81_RS10085">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS10085">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_061485891.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS10090" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS10090" fbc:name="ACZ81_RS10090" fbc:label="G_ACZ81_RS10090">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS10090">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_061485892.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS18890" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS18890" fbc:name="ACZ81_RS18890" fbc:label="G_ACZ81_RS18890">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS18890">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014951242.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS11325" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS11325" fbc:name="ACZ81_RS11325" fbc:label="G_ACZ81_RS11325">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS11325">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_061486009.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS11410" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS11410" fbc:name="ACZ81_RS11410" fbc:label="G_ACZ81_RS11410">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS11410">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_061486975.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS18585" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS18585" fbc:name="ACZ81_RS18585" fbc:label="G_ACZ81_RS18585">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS18585">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014951146.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS06950" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS06950" fbc:name="ACZ81_RS06950" fbc:label="G_ACZ81_RS06950">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS06950">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_061485347.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS04890" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS04890" fbc:name="ACZ81_RS04890" fbc:label="G_ACZ81_RS04890">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS04890">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014978555.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS11380" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS11380" fbc:name="ACZ81_RS11380" fbc:label="G_ACZ81_RS11380">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS11380">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_061486015.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS10510" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS10510" fbc:name="ACZ81_RS10510" fbc:label="G_ACZ81_RS10510">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS10510">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_061485924.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS11065" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS11065" fbc:name="ACZ81_RS11065" fbc:label="G_ACZ81_RS11065">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS11065">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014949721.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS15060" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS15060" fbc:name="ACZ81_RS15060" fbc:label="G_ACZ81_RS15060">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS15060">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014950486.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS01900" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS01900" fbc:name="ACZ81_RS01900" fbc:label="G_ACZ81_RS01900">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS01900">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014948020.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS12165" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS12165" fbc:name="ACZ81_RS12165" fbc:label="G_ACZ81_RS12165">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS12165">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_061486073.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS03030" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS03030" fbc:name="ACZ81_RS03030" fbc:label="G_ACZ81_RS03030">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS03030">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_061439488.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS08425" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS08425" fbc:name="ACZ81_RS08425" fbc:label="G_ACZ81_RS08425">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS08425">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014949187.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS02160" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS02160" fbc:name="ACZ81_RS02160" fbc:label="G_ACZ81_RS02160">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS02160">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_061439265.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS07315" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS07315" fbc:name="ACZ81_RS07315" fbc:label="G_ACZ81_RS07315">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS07315">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_061485394.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS03945" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS03945" fbc:name="ACZ81_RS03945" fbc:label="G_ACZ81_RS03945">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS03945">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_061484790.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS02370" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS02370" fbc:name="ACZ81_RS02370" fbc:label="G_ACZ81_RS02370">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS02370">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014948109.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS05345" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS05345" fbc:name="ACZ81_RS05345" fbc:label="G_ACZ81_RS05345">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS05345">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014948664.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS02065" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS02065" fbc:name="ACZ81_RS02065" fbc:label="G_ACZ81_RS02065">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS02065">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014948054.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS09425" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS09425" fbc:name="ACZ81_RS09425" fbc:label="G_ACZ81_RS09425">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS09425">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_061485813.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS11250" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS11250" fbc:name="ACZ81_RS11250" fbc:label="G_ACZ81_RS11250">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS11250">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_061486001.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS11880" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS11880" fbc:name="ACZ81_RS11880" fbc:label="G_ACZ81_RS11880">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS11880">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_039225321.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS05865" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS05865" fbc:name="ACZ81_RS05865" fbc:label="G_ACZ81_RS05865">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS05865">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014948759.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS17685" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS17685" fbc:name="ACZ81_RS17685" fbc:label="G_ACZ81_RS17685">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS17685">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014977577.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS18455" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS18455" fbc:name="ACZ81_RS18455" fbc:label="G_ACZ81_RS18455">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS18455">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014951120.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS05390" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS05390" fbc:name="ACZ81_RS05390" fbc:label="G_ACZ81_RS05390">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS05390">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_061485069.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS00270" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS00270" fbc:name="ACZ81_RS00270" fbc:label="G_ACZ81_RS00270">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS00270">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_012516577.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS13270" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS13270" fbc:name="ACZ81_RS13270" fbc:label="G_ACZ81_RS13270">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS13270">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014950134.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS03275" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS03275" fbc:name="ACZ81_RS03275" fbc:label="G_ACZ81_RS03275">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS03275">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_012517258.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS10600" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS10600" fbc:name="ACZ81_RS10600" fbc:label="G_ACZ81_RS10600">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS10600">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_061485931.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS07955" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS07955" fbc:name="ACZ81_RS07955" fbc:label="G_ACZ81_RS07955">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS07955">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_012518091.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS02680" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS02680" fbc:name="ACZ81_RS02680" fbc:label="G_ACZ81_RS02680">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS02680">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_012517170.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
       <fbc:geneProduct metaid="meta_G_ACZ81_RS20695" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS20695" fbc:name="ACZ81_RS20695" fbc:label="G_ACZ81_RS20695"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS17310" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS17310" fbc:name="ACZ81_RS17310" fbc:label="G_ACZ81_RS17310"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS01685" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS01685" fbc:name="ACZ81_RS01685" fbc:label="G_ACZ81_RS01685"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS06385" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS06385" fbc:name="ACZ81_RS06385" fbc:label="G_ACZ81_RS06385"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS06625" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS06625" fbc:name="ACZ81_RS06625" fbc:label="G_ACZ81_RS06625"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS18010" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS18010" fbc:name="ACZ81_RS18010" fbc:label="G_ACZ81_RS18010"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS17305" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS17305" fbc:name="ACZ81_RS17305" fbc:label="G_ACZ81_RS17305"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS18025" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS18025" fbc:name="ACZ81_RS18025" fbc:label="G_ACZ81_RS18025"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS08100" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS08100" fbc:name="ACZ81_RS08100" fbc:label="G_ACZ81_RS08100"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS17325" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS17325" fbc:name="ACZ81_RS17325" fbc:label="G_ACZ81_RS17325"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS06270" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS06270" fbc:name="ACZ81_RS06270" fbc:label="G_ACZ81_RS06270"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS17335" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS17335" fbc:name="ACZ81_RS17335" fbc:label="G_ACZ81_RS17335"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS06785" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS06785" fbc:name="ACZ81_RS06785" fbc:label="G_ACZ81_RS06785"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS15405" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS15405" fbc:name="ACZ81_RS15405" fbc:label="G_ACZ81_RS15405"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS08545" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS08545" fbc:name="ACZ81_RS08545" fbc:label="G_ACZ81_RS08545"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS01660" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS01660" fbc:name="ACZ81_RS01660" fbc:label="G_ACZ81_RS01660"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS19940" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS19940" fbc:name="ACZ81_RS19940" fbc:label="G_ACZ81_RS19940"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS04830" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS04830" fbc:name="ACZ81_RS04830" fbc:label="G_ACZ81_RS04830"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS05810" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS05810" fbc:name="ACZ81_RS05810" fbc:label="G_ACZ81_RS05810"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS12170" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS12170" fbc:name="ACZ81_RS12170" fbc:label="G_ACZ81_RS12170"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS09340" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS09340" fbc:name="ACZ81_RS09340" fbc:label="G_ACZ81_RS09340"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS15615" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS15615" fbc:name="ACZ81_RS15615" fbc:label="G_ACZ81_RS15615"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS01705" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS01705" fbc:name="ACZ81_RS01705" fbc:label="G_ACZ81_RS01705"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS17290" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS17290" fbc:name="ACZ81_RS17290" fbc:label="G_ACZ81_RS17290"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS03660" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS03660" fbc:name="ACZ81_RS03660" fbc:label="G_ACZ81_RS03660"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS17340" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS17340" fbc:name="ACZ81_RS17340" fbc:label="G_ACZ81_RS17340"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS12125" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS12125" fbc:name="ACZ81_RS12125" fbc:label="G_ACZ81_RS12125"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS03655" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS03655" fbc:name="ACZ81_RS03655" fbc:label="G_ACZ81_RS03655"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS01920" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS01920" fbc:name="ACZ81_RS01920" fbc:label="G_ACZ81_RS01920"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS08105" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS08105" fbc:name="ACZ81_RS08105" fbc:label="G_ACZ81_RS08105"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS01695" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS01695" fbc:name="ACZ81_RS01695" fbc:label="G_ACZ81_RS01695"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS17345" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS17345" fbc:name="ACZ81_RS17345" fbc:label="G_ACZ81_RS17345"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS01680" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS01680" fbc:name="ACZ81_RS01680" fbc:label="G_ACZ81_RS01680"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS07290" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS07290" fbc:name="ACZ81_RS07290" fbc:label="G_ACZ81_RS07290"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS07945" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS07945" fbc:name="ACZ81_RS07945" fbc:label="G_ACZ81_RS07945"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS01700" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS01700" fbc:name="ACZ81_RS01700" fbc:label="G_ACZ81_RS01700"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS01665" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS01665" fbc:name="ACZ81_RS01665" fbc:label="G_ACZ81_RS01665"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS05705" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS05705" fbc:name="ACZ81_RS05705" fbc:label="G_ACZ81_RS05705"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS17350" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS17350" fbc:name="ACZ81_RS17350" fbc:label="G_ACZ81_RS17350"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS00035" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS00035" fbc:name="ACZ81_RS00035" fbc:label="G_ACZ81_RS00035"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS18030" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS18030" fbc:name="ACZ81_RS18030" fbc:label="G_ACZ81_RS18030"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS17315" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS17315" fbc:name="ACZ81_RS17315" fbc:label="G_ACZ81_RS17315"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS17320" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS17320" fbc:name="ACZ81_RS17320" fbc:label="G_ACZ81_RS17320"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS17280" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS17280" fbc:name="ACZ81_RS17280" fbc:label="G_ACZ81_RS17280"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS17295" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS17295" fbc:name="ACZ81_RS17295" fbc:label="G_ACZ81_RS17295"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS01675" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS01675" fbc:name="ACZ81_RS01675" fbc:label="G_ACZ81_RS01675"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS02675" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS02675" fbc:name="ACZ81_RS02675" fbc:label="G_ACZ81_RS02675"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS18005" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS18005" fbc:name="ACZ81_RS18005" fbc:label="G_ACZ81_RS18005"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS17270" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS17270" fbc:name="ACZ81_RS17270" fbc:label="G_ACZ81_RS17270"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS00095" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS00095" fbc:name="ACZ81_RS00095" fbc:label="G_ACZ81_RS00095"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS04910" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS04910" fbc:name="ACZ81_RS04910" fbc:label="G_ACZ81_RS04910"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS18445" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS18445" fbc:name="ACZ81_RS18445" fbc:label="G_ACZ81_RS18445"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS00265" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS00265" fbc:name="ACZ81_RS00265" fbc:label="G_ACZ81_RS00265"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS01655" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS01655" fbc:name="ACZ81_RS01655" fbc:label="G_ACZ81_RS01655"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS06255" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS06255" fbc:name="ACZ81_RS06255" fbc:label="G_ACZ81_RS06255"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS01690" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS01690" fbc:name="ACZ81_RS01690" fbc:label="G_ACZ81_RS01690"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS17285" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS17285" fbc:name="ACZ81_RS17285" fbc:label="G_ACZ81_RS17285"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS13255" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS13255" fbc:name="ACZ81_RS13255" fbc:label="G_ACZ81_RS13255"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS13470" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS13470" fbc:name="ACZ81_RS13470" fbc:label="G_ACZ81_RS13470"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS17330" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS17330" fbc:name="ACZ81_RS17330" fbc:label="G_ACZ81_RS17330"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS18035" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS18035" fbc:name="ACZ81_RS18035" fbc:label="G_ACZ81_RS18035"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS18450" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS18450" fbc:name="ACZ81_RS18450" fbc:label="G_ACZ81_RS18450"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS00030" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS00030" fbc:name="ACZ81_RS00030" fbc:label="G_ACZ81_RS00030"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS01670" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS01670" fbc:name="ACZ81_RS01670" fbc:label="G_ACZ81_RS01670"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS18040" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS18040" fbc:name="ACZ81_RS18040" fbc:label="G_ACZ81_RS18040"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS07960" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS07960" fbc:name="ACZ81_RS07960" fbc:label="G_ACZ81_RS07960"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS08785" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS08785" fbc:name="ACZ81_RS08785" fbc:label="G_ACZ81_RS08785"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS04670" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS04670" fbc:name="ACZ81_RS04670" fbc:label="G_ACZ81_RS04670"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS08625" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS08625" fbc:name="ACZ81_RS08625" fbc:label="G_ACZ81_RS08625"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS07230" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS07230" fbc:name="ACZ81_RS07230" fbc:label="G_ACZ81_RS07230"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS05125" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS05125" fbc:name="ACZ81_RS05125" fbc:label="G_ACZ81_RS05125"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS00335" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS00335" fbc:name="ACZ81_RS00335" fbc:label="G_ACZ81_RS00335"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS02055" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS02055" fbc:name="ACZ81_RS02055" fbc:label="G_ACZ81_RS02055"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS14790" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS14790" fbc:name="ACZ81_RS14790" fbc:label="G_ACZ81_RS14790"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS07135" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS07135" fbc:name="ACZ81_RS07135" fbc:label="G_ACZ81_RS07135"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS04015" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS04015" fbc:name="ACZ81_RS04015" fbc:label="G_ACZ81_RS04015"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS15465" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS15465" fbc:name="ACZ81_RS15465" fbc:label="G_ACZ81_RS15465"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS17045" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS17045" fbc:name="ACZ81_RS17045" fbc:label="G_ACZ81_RS17045"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS04590" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS04590" fbc:name="ACZ81_RS04590" fbc:label="G_ACZ81_RS04590"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS07865" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS07865" fbc:name="ACZ81_RS07865" fbc:label="G_ACZ81_RS07865"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS19350" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS19350" fbc:name="ACZ81_RS19350" fbc:label="G_ACZ81_RS19350"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS09935" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS09935" fbc:name="ACZ81_RS09935" fbc:label="G_ACZ81_RS09935"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS16060" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS16060" fbc:name="ACZ81_RS16060" fbc:label="G_ACZ81_RS16060"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS12895" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS12895" fbc:name="ACZ81_RS12895" fbc:label="G_ACZ81_RS12895"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS14565" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS14565" fbc:name="ACZ81_RS14565" fbc:label="G_ACZ81_RS14565"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS16570" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS16570" fbc:name="ACZ81_RS16570" fbc:label="G_ACZ81_RS16570"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS16920" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS16920" fbc:name="ACZ81_RS16920" fbc:label="G_ACZ81_RS16920"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS02015" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS02015" fbc:name="ACZ81_RS02015" fbc:label="G_ACZ81_RS02015"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS11995" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS11995" fbc:name="ACZ81_RS11995" fbc:label="G_ACZ81_RS11995"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS16130" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS16130" fbc:name="ACZ81_RS16130" fbc:label="G_ACZ81_RS16130"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS12725" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS12725" fbc:name="ACZ81_RS12725" fbc:label="G_ACZ81_RS12725"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS12735" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS12735" fbc:name="ACZ81_RS12735" fbc:label="G_ACZ81_RS12735"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS11745" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS11745" fbc:name="ACZ81_RS11745" fbc:label="G_ACZ81_RS11745"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS14585" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS14585" fbc:name="ACZ81_RS14585" fbc:label="G_ACZ81_RS14585"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS10750" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS10750" fbc:name="ACZ81_RS10750" fbc:label="G_ACZ81_RS10750"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS14670" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS14670" fbc:name="ACZ81_RS14670" fbc:label="G_ACZ81_RS14670"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS18315" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS18315" fbc:name="ACZ81_RS18315" fbc:label="G_ACZ81_RS18315"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS15335" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS15335" fbc:name="ACZ81_RS15335" fbc:label="G_ACZ81_RS15335"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS11895" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS11895" fbc:name="ACZ81_RS11895" fbc:label="G_ACZ81_RS11895"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS13830" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS13830" fbc:name="ACZ81_RS13830" fbc:label="G_ACZ81_RS13830"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS01925" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS01925" fbc:name="ACZ81_RS01925" fbc:label="G_ACZ81_RS01925"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS04555" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS04555" fbc:name="ACZ81_RS04555" fbc:label="G_ACZ81_RS04555"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS04550" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS04550" fbc:name="ACZ81_RS04550" fbc:label="G_ACZ81_RS04550"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS04560" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS04560" fbc:name="ACZ81_RS04560" fbc:label="G_ACZ81_RS04560"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS13980" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS13980" fbc:name="ACZ81_RS13980" fbc:label="G_ACZ81_RS13980"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS14680" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS14680" fbc:name="ACZ81_RS14680" fbc:label="G_ACZ81_RS14680"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS04635" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS04635" fbc:name="ACZ81_RS04635" fbc:label="G_ACZ81_RS04635"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS04625" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS04625" fbc:name="ACZ81_RS04625" fbc:label="G_ACZ81_RS04625"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS04620" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS04620" fbc:name="ACZ81_RS04620" fbc:label="G_ACZ81_RS04620"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS04630" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS04630" fbc:name="ACZ81_RS04630" fbc:label="G_ACZ81_RS04630"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS14995" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS14995" fbc:name="ACZ81_RS14995" fbc:label="G_ACZ81_RS14995"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS16400" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS16400" fbc:name="ACZ81_RS16400" fbc:label="G_ACZ81_RS16400"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS10190" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS10190" fbc:name="ACZ81_RS10190" fbc:label="G_ACZ81_RS10190"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS07015" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS07015" fbc:name="ACZ81_RS07015" fbc:label="G_ACZ81_RS07015"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS04580" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS04580" fbc:name="ACZ81_RS04580" fbc:label="G_ACZ81_RS04580"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS06085" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS06085" fbc:name="ACZ81_RS06085" fbc:label="G_ACZ81_RS06085"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS19370" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS19370" fbc:name="ACZ81_RS19370" fbc:label="G_ACZ81_RS19370"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS03710" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS03710" fbc:name="ACZ81_RS03710" fbc:label="G_ACZ81_RS03710"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS03550" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS03550" fbc:name="ACZ81_RS03550" fbc:label="G_ACZ81_RS03550"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS14760" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS14760" fbc:name="ACZ81_RS14760" fbc:label="G_ACZ81_RS14760"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS19200" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS19200" fbc:name="ACZ81_RS19200" fbc:label="G_ACZ81_RS19200"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS01630" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS01630" fbc:name="ACZ81_RS01630" fbc:label="G_ACZ81_RS01630"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS14950" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS14950" fbc:name="ACZ81_RS14950" fbc:label="G_ACZ81_RS14950"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS08840" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS08840" fbc:name="ACZ81_RS08840" fbc:label="G_ACZ81_RS08840"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS08845" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS08845" fbc:name="ACZ81_RS08845" fbc:label="G_ACZ81_RS08845"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS02310" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS02310" fbc:name="ACZ81_RS02310" fbc:label="G_ACZ81_RS02310"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS19680" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS19680" fbc:name="ACZ81_RS19680" fbc:label="G_ACZ81_RS19680"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS13675" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS13675" fbc:name="ACZ81_RS13675" fbc:label="G_ACZ81_RS13675"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS14895" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS14895" fbc:name="ACZ81_RS14895" fbc:label="G_ACZ81_RS14895"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS11835" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS11835" fbc:name="ACZ81_RS11835" fbc:label="G_ACZ81_RS11835"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS17380" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS17380" fbc:name="ACZ81_RS17380" fbc:label="G_ACZ81_RS17380"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS03845" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS03845" fbc:name="ACZ81_RS03845" fbc:label="G_ACZ81_RS03845"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS10825" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS10825" fbc:name="ACZ81_RS10825" fbc:label="G_ACZ81_RS10825"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS07170" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS07170" fbc:name="ACZ81_RS07170" fbc:label="G_ACZ81_RS07170"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS14485" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS14485" fbc:name="ACZ81_RS14485" fbc:label="G_ACZ81_RS14485"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS04155" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS04155" fbc:name="ACZ81_RS04155" fbc:label="G_ACZ81_RS04155"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS13055" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS13055" fbc:name="ACZ81_RS13055" fbc:label="G_ACZ81_RS13055"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS00845" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS00845" fbc:name="ACZ81_RS00845" fbc:label="G_ACZ81_RS00845"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS07115" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS07115" fbc:name="ACZ81_RS07115" fbc:label="G_ACZ81_RS07115"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS02940" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS02940" fbc:name="ACZ81_RS02940" fbc:label="G_ACZ81_RS02940"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS18205" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS18205" fbc:name="ACZ81_RS18205" fbc:label="G_ACZ81_RS18205"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS11335" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS11335" fbc:name="ACZ81_RS11335" fbc:label="G_ACZ81_RS11335"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS11705" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS11705" fbc:name="ACZ81_RS11705" fbc:label="G_ACZ81_RS11705"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS07880" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS07880" fbc:name="ACZ81_RS07880" fbc:label="G_ACZ81_RS07880"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS08250" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS08250" fbc:name="ACZ81_RS08250" fbc:label="G_ACZ81_RS08250"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS06660" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS06660" fbc:name="ACZ81_RS06660" fbc:label="G_ACZ81_RS06660"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS01895" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS01895" fbc:name="ACZ81_RS01895" fbc:label="G_ACZ81_RS01895"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS19210" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS19210" fbc:name="ACZ81_RS19210" fbc:label="G_ACZ81_RS19210"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS07090" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS07090" fbc:name="ACZ81_RS07090" fbc:label="G_ACZ81_RS07090"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS13670" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS13670" fbc:name="ACZ81_RS13670" fbc:label="G_ACZ81_RS13670"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS07085" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS07085" fbc:name="ACZ81_RS07085" fbc:label="G_ACZ81_RS07085"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS06900" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS06900" fbc:name="ACZ81_RS06900" fbc:label="G_ACZ81_RS06900"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS13080" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS13080" fbc:name="ACZ81_RS13080" fbc:label="G_ACZ81_RS13080"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS05490" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS05490" fbc:name="ACZ81_RS05490" fbc:label="G_ACZ81_RS05490"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS12575" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS12575" fbc:name="ACZ81_RS12575" fbc:label="G_ACZ81_RS12575"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS15350" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS15350" fbc:name="ACZ81_RS15350" fbc:label="G_ACZ81_RS15350"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS12310" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS12310" fbc:name="ACZ81_RS12310" fbc:label="G_ACZ81_RS12310"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS13035" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS13035" fbc:name="ACZ81_RS13035" fbc:label="G_ACZ81_RS13035"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS10705" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS10705" fbc:name="ACZ81_RS10705" fbc:label="G_ACZ81_RS10705"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS10700" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS10700" fbc:name="ACZ81_RS10700" fbc:label="G_ACZ81_RS10700"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS02425" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS02425" fbc:name="ACZ81_RS02425" fbc:label="G_ACZ81_RS02425"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS17085" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS17085" fbc:name="ACZ81_RS17085" fbc:label="G_ACZ81_RS17085"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS09420" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS09420" fbc:name="ACZ81_RS09420" fbc:label="G_ACZ81_RS09420"/>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS17310" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS17310" fbc:name="ACZ81_RS17310" fbc:label="G_ACZ81_RS17310">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS17310">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014950907.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS01685" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS01685" fbc:name="ACZ81_RS01685" fbc:label="G_ACZ81_RS01685">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS01685">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014947977.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS06385" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS06385" fbc:name="ACZ81_RS06385" fbc:label="G_ACZ81_RS06385">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS06385">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_061486948.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS06625" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS06625" fbc:name="ACZ81_RS06625" fbc:label="G_ACZ81_RS06625">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS06625">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014948897.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS18010" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS18010" fbc:name="ACZ81_RS18010" fbc:label="G_ACZ81_RS18010">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS18010">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014951037.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS17305" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS17305" fbc:name="ACZ81_RS17305" fbc:label="G_ACZ81_RS17305">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS17305">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014950906.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS18025" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS18025" fbc:name="ACZ81_RS18025" fbc:label="G_ACZ81_RS18025">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS18025">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_015068303.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS08100" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS08100" fbc:name="ACZ81_RS08100" fbc:label="G_ACZ81_RS08100">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS08100">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_012518127.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS17325" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS17325" fbc:name="ACZ81_RS17325" fbc:label="G_ACZ81_RS17325">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS17325">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014950909.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS06270" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS06270" fbc:name="ACZ81_RS06270" fbc:label="G_ACZ81_RS06270">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS06270">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_024015986.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS17335" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS17335" fbc:name="ACZ81_RS17335" fbc:label="G_ACZ81_RS17335">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS17335">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014950910.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS06785" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS06785" fbc:name="ACZ81_RS06785" fbc:label="G_ACZ81_RS06785">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS06785">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014948924.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS15405" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS15405" fbc:name="ACZ81_RS15405" fbc:label="G_ACZ81_RS15405">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS15405">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014950559.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS08545" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS08545" fbc:name="ACZ81_RS08545" fbc:label="G_ACZ81_RS08545">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS08545">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_012518206.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS01660" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS01660" fbc:name="ACZ81_RS01660" fbc:label="G_ACZ81_RS01660">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS01660">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014947975.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS19940" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS19940" fbc:name="ACZ81_RS19940" fbc:label="G_ACZ81_RS19940">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS19940">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014290886.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS04830" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS04830" fbc:name="ACZ81_RS04830" fbc:label="G_ACZ81_RS04830">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS04830">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014948552.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS05810" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS05810" fbc:name="ACZ81_RS05810" fbc:label="G_ACZ81_RS05810">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS05810">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014948748.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS12170" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS12170" fbc:name="ACZ81_RS12170" fbc:label="G_ACZ81_RS12170">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS12170">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_061486074.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS09340" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS09340" fbc:name="ACZ81_RS09340" fbc:label="G_ACZ81_RS09340">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS09340">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_061485804.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS15615" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS15615" fbc:name="ACZ81_RS15615" fbc:label="G_ACZ81_RS15615">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS15615">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_061486487.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS01705" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS01705" fbc:name="ACZ81_RS01705" fbc:label="G_ACZ81_RS01705">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS01705">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014975444.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS17290" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS17290" fbc:name="ACZ81_RS17290" fbc:label="G_ACZ81_RS17290">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS17290">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_012519216.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS03660" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS03660" fbc:name="ACZ81_RS03660" fbc:label="G_ACZ81_RS03660">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS03660">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014975723.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS17340" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS17340" fbc:name="ACZ81_RS17340" fbc:label="G_ACZ81_RS17340">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS17340">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014950911.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS12125" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS12125" fbc:name="ACZ81_RS12125" fbc:label="G_ACZ81_RS12125">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS12125">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014976866.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS03655" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS03655" fbc:name="ACZ81_RS03655" fbc:label="G_ACZ81_RS03655">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS03655">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014948329.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS01920" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS01920" fbc:name="ACZ81_RS01920" fbc:label="G_ACZ81_RS01920">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS01920">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_061439226.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS08105" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS08105" fbc:name="ACZ81_RS08105" fbc:label="G_ACZ81_RS08105">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS08105">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014976247.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS01695" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS01695" fbc:name="ACZ81_RS01695" fbc:label="G_ACZ81_RS01695">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS01695">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014947979.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS17345" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS17345" fbc:name="ACZ81_RS17345" fbc:label="G_ACZ81_RS17345">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS17345">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014950912.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS01680" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS01680" fbc:name="ACZ81_RS01680" fbc:label="G_ACZ81_RS01680">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS01680">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_012516961.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS07290" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS07290" fbc:name="ACZ81_RS07290" fbc:label="G_ACZ81_RS07290">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS07290">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014976150.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS07945" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS07945" fbc:name="ACZ81_RS07945" fbc:label="G_ACZ81_RS07945">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS07945">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014976220.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS01700" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS01700" fbc:name="ACZ81_RS01700" fbc:label="G_ACZ81_RS01700">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS01700">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014947980.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS01665" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS01665" fbc:name="ACZ81_RS01665" fbc:label="G_ACZ81_RS01665">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS01665">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_012516958.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS05705" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS05705" fbc:name="ACZ81_RS05705" fbc:label="G_ACZ81_RS05705">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS05705">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014948727.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS17350" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS17350" fbc:name="ACZ81_RS17350" fbc:label="G_ACZ81_RS17350">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS17350">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_012519228.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS00035" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS00035" fbc:name="ACZ81_RS00035" fbc:label="G_ACZ81_RS00035">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS00035">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014947716.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS18030" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS18030" fbc:name="ACZ81_RS18030" fbc:label="G_ACZ81_RS18030">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS18030">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014951041.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS17315" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS17315" fbc:name="ACZ81_RS17315" fbc:label="G_ACZ81_RS17315">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS17315">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_012519221.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS17320" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS17320" fbc:name="ACZ81_RS17320" fbc:label="G_ACZ81_RS17320">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS17320">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014950908.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS17280" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS17280" fbc:name="ACZ81_RS17280" fbc:label="G_ACZ81_RS17280">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS17280">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_012519214.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS17295" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS17295" fbc:name="ACZ81_RS17295" fbc:label="G_ACZ81_RS17295">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS17295">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_012519217.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS01675" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS01675" fbc:name="ACZ81_RS01675" fbc:label="G_ACZ81_RS01675">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS01675">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_061439206.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS02675" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS02675" fbc:name="ACZ81_RS02675" fbc:label="G_ACZ81_RS02675">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS02675">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_012517169.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS18005" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS18005" fbc:name="ACZ81_RS18005" fbc:label="G_ACZ81_RS18005">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS18005">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014951036.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS17270" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS17270" fbc:name="ACZ81_RS17270" fbc:label="G_ACZ81_RS17270">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS17270">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_012519212.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS00095" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS00095" fbc:name="ACZ81_RS00095" fbc:label="G_ACZ81_RS00095">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS00095">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_061438871.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS04910" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS04910" fbc:name="ACZ81_RS04910" fbc:label="G_ACZ81_RS04910">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS04910">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_061484993.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS18445" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS18445" fbc:name="ACZ81_RS18445" fbc:label="G_ACZ81_RS18445">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS18445">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_012519953.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS00265" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS00265" fbc:name="ACZ81_RS00265" fbc:label="G_ACZ81_RS00265">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS00265">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014947757.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS01655" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS01655" fbc:name="ACZ81_RS01655" fbc:label="G_ACZ81_RS01655">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS01655">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_010179497.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS06255" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS06255" fbc:name="ACZ81_RS06255" fbc:label="G_ACZ81_RS06255">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS06255">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014948832.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS01690" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS01690" fbc:name="ACZ81_RS01690" fbc:label="G_ACZ81_RS01690">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS01690">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014947978.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS17285" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS17285" fbc:name="ACZ81_RS17285" fbc:label="G_ACZ81_RS17285">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS17285">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_012519215.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS13255" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS13255" fbc:name="ACZ81_RS13255" fbc:label="G_ACZ81_RS13255">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS13255">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_061486159.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS13470" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS13470" fbc:name="ACZ81_RS13470" fbc:label="G_ACZ81_RS13470">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS13470">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_075177060.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS17330" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS17330" fbc:name="ACZ81_RS17330" fbc:label="G_ACZ81_RS17330">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS17330">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_012519224.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS18035" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS18035" fbc:name="ACZ81_RS18035" fbc:label="G_ACZ81_RS18035">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS18035">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014951042.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS18450" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS18450" fbc:name="ACZ81_RS18450" fbc:label="G_ACZ81_RS18450">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS18450">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_012519954.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS00030" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS00030" fbc:name="ACZ81_RS00030" fbc:label="G_ACZ81_RS00030">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS00030">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_061438859.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS01670" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS01670" fbc:name="ACZ81_RS01670" fbc:label="G_ACZ81_RS01670">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS01670">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_012516959.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS18040" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS18040" fbc:name="ACZ81_RS18040" fbc:label="G_ACZ81_RS18040">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS18040">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014951043.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS07960" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS07960" fbc:name="ACZ81_RS07960" fbc:label="G_ACZ81_RS07960">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS07960">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_012518092.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS08785" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS08785" fbc:name="ACZ81_RS08785" fbc:label="G_ACZ81_RS08785">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS08785">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_012518257.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS04670" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS04670" fbc:name="ACZ81_RS04670" fbc:label="G_ACZ81_RS04670">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS04670">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014997536.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS08625" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS08625" fbc:name="ACZ81_RS08625" fbc:label="G_ACZ81_RS08625">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS08625">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014949225.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS07230" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS07230" fbc:name="ACZ81_RS07230" fbc:label="G_ACZ81_RS07230">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS07230">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_061485388.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS05125" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS05125" fbc:name="ACZ81_RS05125" fbc:label="G_ACZ81_RS05125">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS05125">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014975896.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS00335" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS00335" fbc:name="ACZ81_RS00335" fbc:label="G_ACZ81_RS00335">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS00335">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014975276.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS02055" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS02055" fbc:name="ACZ81_RS02055" fbc:label="G_ACZ81_RS02055">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS02055">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_039231060.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS14790" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS14790" fbc:name="ACZ81_RS14790" fbc:label="G_ACZ81_RS14790">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS14790">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_061486406.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS07135" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS07135" fbc:name="ACZ81_RS07135" fbc:label="G_ACZ81_RS07135">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS07135">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014948988.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS04015" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS04015" fbc:name="ACZ81_RS04015" fbc:label="G_ACZ81_RS04015">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS04015">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014948398.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS15465" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS15465" fbc:name="ACZ81_RS15465" fbc:label="G_ACZ81_RS15465">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS15465">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_061486477.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS17045" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS17045" fbc:name="ACZ81_RS17045" fbc:label="G_ACZ81_RS17045">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS17045">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_061486607.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS04590" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS04590" fbc:name="ACZ81_RS04590" fbc:label="G_ACZ81_RS04590">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS04590">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_061484949.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS07865" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS07865" fbc:name="ACZ81_RS07865" fbc:label="G_ACZ81_RS07865">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS07865">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_061485539.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS19350" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS19350" fbc:name="ACZ81_RS19350" fbc:label="G_ACZ81_RS19350">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS19350">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_061486825.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS09935" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS09935" fbc:name="ACZ81_RS09935" fbc:label="G_ACZ81_RS09935">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS09935">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_061485871.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS16060" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS16060" fbc:name="ACZ81_RS16060" fbc:label="G_ACZ81_RS16060">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS16060">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_061486534.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS12895" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS12895" fbc:name="ACZ81_RS12895" fbc:label="G_ACZ81_RS12895">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS12895">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_061486132.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS14565" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS14565" fbc:name="ACZ81_RS14565" fbc:label="G_ACZ81_RS14565">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS14565">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014950380.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS16570" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS16570" fbc:name="ACZ81_RS16570" fbc:label="G_ACZ81_RS16570">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS16570">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_061486580.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS16920" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS16920" fbc:name="ACZ81_RS16920" fbc:label="G_ACZ81_RS16920">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS16920">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_273070703.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS02015" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS02015" fbc:name="ACZ81_RS02015" fbc:label="G_ACZ81_RS02015">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS02015">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014975484.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS11995" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS11995" fbc:name="ACZ81_RS11995" fbc:label="G_ACZ81_RS11995">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS11995">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_041693780.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS16130" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS16130" fbc:name="ACZ81_RS16130" fbc:label="G_ACZ81_RS16130">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS16130">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_061486539.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS12725" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS12725" fbc:name="ACZ81_RS12725" fbc:label="G_ACZ81_RS12725">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS12725">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_061486117.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS12735" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS12735" fbc:name="ACZ81_RS12735" fbc:label="G_ACZ81_RS12735">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS12735">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014950033.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS11745" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS11745" fbc:name="ACZ81_RS11745" fbc:label="G_ACZ81_RS11745">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS11745">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014949851.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS14585" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS14585" fbc:name="ACZ81_RS14585" fbc:label="G_ACZ81_RS14585">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS14585">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_061486385.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS10750" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS10750" fbc:name="ACZ81_RS10750" fbc:label="G_ACZ81_RS10750">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS10750">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014949658.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS14670" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS14670" fbc:name="ACZ81_RS14670" fbc:label="G_ACZ81_RS14670">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS14670">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_061486394.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS18315" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS18315" fbc:name="ACZ81_RS18315" fbc:label="G_ACZ81_RS18315">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS18315">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014951095.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS15335" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS15335" fbc:name="ACZ81_RS15335" fbc:label="G_ACZ81_RS15335">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS15335">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014950542.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS11895" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS11895" fbc:name="ACZ81_RS11895" fbc:label="G_ACZ81_RS11895">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS11895">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_061486047.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS13830" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS13830" fbc:name="ACZ81_RS13830" fbc:label="G_ACZ81_RS13830">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS13830">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_061486247.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS01925" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS01925" fbc:name="ACZ81_RS01925" fbc:label="G_ACZ81_RS01925">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS01925">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014978117.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS04555" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS04555" fbc:name="ACZ81_RS04555" fbc:label="G_ACZ81_RS04555">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS04555">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_061094370.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS04550" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS04550" fbc:name="ACZ81_RS04550" fbc:label="G_ACZ81_RS04550">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS04550">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014948483.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS04560" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS04560" fbc:name="ACZ81_RS04560" fbc:label="G_ACZ81_RS04560">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS04560">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_061484939.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS13980" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS13980" fbc:name="ACZ81_RS13980" fbc:label="G_ACZ81_RS13980">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS13980">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014950265.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS14680" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS14680" fbc:name="ACZ81_RS14680" fbc:label="G_ACZ81_RS14680">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS14680">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_061486396.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS04635" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS04635" fbc:name="ACZ81_RS04635" fbc:label="G_ACZ81_RS04635">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS04635">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_061484955.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS04625" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS04625" fbc:name="ACZ81_RS04625" fbc:label="G_ACZ81_RS04625">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS04625">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014948512.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS04620" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS04620" fbc:name="ACZ81_RS04620" fbc:label="G_ACZ81_RS04620">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS04620">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_061484953.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS04630" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS04630" fbc:name="ACZ81_RS04630" fbc:label="G_ACZ81_RS04630">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS04630">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014948513.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS14995" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS14995" fbc:name="ACZ81_RS14995" fbc:label="G_ACZ81_RS14995">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS14995">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_061486426.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS16400" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS16400" fbc:name="ACZ81_RS16400" fbc:label="G_ACZ81_RS16400">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS16400">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014950741.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS10190" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS10190" fbc:name="ACZ81_RS10190" fbc:label="G_ACZ81_RS10190">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS10190">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014949540.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS07015" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS07015" fbc:name="ACZ81_RS07015" fbc:label="G_ACZ81_RS07015">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS07015">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_061485362.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS04580" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS04580" fbc:name="ACZ81_RS04580" fbc:label="G_ACZ81_RS04580">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS04580">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014978516.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS06085" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS06085" fbc:name="ACZ81_RS06085" fbc:label="G_ACZ81_RS06085">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS06085">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014975999.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS19370" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS19370" fbc:name="ACZ81_RS19370" fbc:label="G_ACZ81_RS19370">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS19370">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_061486826.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS03710" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS03710" fbc:name="ACZ81_RS03710" fbc:label="G_ACZ81_RS03710">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS03710">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_061439594.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS03550" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS03550" fbc:name="ACZ81_RS03550" fbc:label="G_ACZ81_RS03550">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS03550">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014948318.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS14760" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS14760" fbc:name="ACZ81_RS14760" fbc:label="G_ACZ81_RS14760">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS14760">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014950428.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS19200" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS19200" fbc:name="ACZ81_RS19200" fbc:label="G_ACZ81_RS19200">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS19200">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_061487019.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS01630" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS01630" fbc:name="ACZ81_RS01630" fbc:label="G_ACZ81_RS01630">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS01630">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014947970.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS14950" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS14950" fbc:name="ACZ81_RS14950" fbc:label="G_ACZ81_RS14950">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS14950">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_061486421.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS08840" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS08840" fbc:name="ACZ81_RS08840" fbc:label="G_ACZ81_RS08840">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS08840">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014949268.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS08845" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS08845" fbc:name="ACZ81_RS08845" fbc:label="G_ACZ81_RS08845">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS08845">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_061485746.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS02310" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS02310" fbc:name="ACZ81_RS02310" fbc:label="G_ACZ81_RS02310">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS02310">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014948098.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS19680" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS19680" fbc:name="ACZ81_RS19680" fbc:label="G_ACZ81_RS19680">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS19680">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014980757.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS13675" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS13675" fbc:name="ACZ81_RS13675" fbc:label="G_ACZ81_RS13675">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS13675">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014950205.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS14895" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS14895" fbc:name="ACZ81_RS14895" fbc:label="G_ACZ81_RS14895">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS14895">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_061486418.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS11835" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS11835" fbc:name="ACZ81_RS11835" fbc:label="G_ACZ81_RS11835">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS11835">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_061486042.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS17380" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS17380" fbc:name="ACZ81_RS17380" fbc:label="G_ACZ81_RS17380">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS17380">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_061486647.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS03845" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS03845" fbc:name="ACZ81_RS03845" fbc:label="G_ACZ81_RS03845">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS03845">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_061484771.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS10825" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS10825" fbc:name="ACZ81_RS10825" fbc:label="G_ACZ81_RS10825">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS10825">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014979424.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS07170" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS07170" fbc:name="ACZ81_RS07170" fbc:label="G_ACZ81_RS07170">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS07170">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_061485382.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS14485" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS14485" fbc:name="ACZ81_RS14485" fbc:label="G_ACZ81_RS14485">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS14485">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_061486370.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS04155" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS04155" fbc:name="ACZ81_RS04155" fbc:label="G_ACZ81_RS04155">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS04155">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_061484820.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS13055" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS13055" fbc:name="ACZ81_RS13055" fbc:label="G_ACZ81_RS13055">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS13055">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014950093.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS00845" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS00845" fbc:name="ACZ81_RS00845" fbc:label="G_ACZ81_RS00845">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS00845">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014977968.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS07115" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS07115" fbc:name="ACZ81_RS07115" fbc:label="G_ACZ81_RS07115">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS07115">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014976126.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS02940" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS02940" fbc:name="ACZ81_RS02940" fbc:label="G_ACZ81_RS02940">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS02940">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_049587314.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS18205" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS18205" fbc:name="ACZ81_RS18205" fbc:label="G_ACZ81_RS18205">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS18205">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014951072.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS11335" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS11335" fbc:name="ACZ81_RS11335" fbc:label="G_ACZ81_RS11335">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS11335">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_061486011.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS11705" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS11705" fbc:name="ACZ81_RS11705" fbc:label="G_ACZ81_RS11705">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS11705">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014976813.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS07880" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS07880" fbc:name="ACZ81_RS07880" fbc:label="G_ACZ81_RS07880">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS07880">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_061485543.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS08250" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS08250" fbc:name="ACZ81_RS08250" fbc:label="G_ACZ81_RS08250">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS08250">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014976270.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS06660" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS06660" fbc:name="ACZ81_RS06660" fbc:label="G_ACZ81_RS06660">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS06660">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_039227342.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS01895" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS01895" fbc:name="ACZ81_RS01895" fbc:label="G_ACZ81_RS01895">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS01895">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_061439222.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS19210" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS19210" fbc:name="ACZ81_RS19210" fbc:label="G_ACZ81_RS19210">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS19210">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_061486808.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS07090" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS07090" fbc:name="ACZ81_RS07090" fbc:label="G_ACZ81_RS07090">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS07090">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_061485378.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS13670" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS13670" fbc:name="ACZ81_RS13670" fbc:label="G_ACZ81_RS13670">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS13670">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014950204.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS07085" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS07085" fbc:name="ACZ81_RS07085" fbc:label="G_ACZ81_RS07085">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS07085">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014948979.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS06900" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS06900" fbc:name="ACZ81_RS06900" fbc:label="G_ACZ81_RS06900">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS06900">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_061485332.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS13080" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS13080" fbc:name="ACZ81_RS13080" fbc:label="G_ACZ81_RS13080">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS13080">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_061486989.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS05490" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS05490" fbc:name="ACZ81_RS05490" fbc:label="G_ACZ81_RS05490">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS05490">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_061485077.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS12575" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS12575" fbc:name="ACZ81_RS12575" fbc:label="G_ACZ81_RS12575">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS12575">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_061486106.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS15350" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS15350" fbc:name="ACZ81_RS15350" fbc:label="G_ACZ81_RS15350">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS15350">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_061486465.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS12310" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS12310" fbc:name="ACZ81_RS12310" fbc:label="G_ACZ81_RS12310">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS12310">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_061486088.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS13035" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS13035" fbc:name="ACZ81_RS13035" fbc:label="G_ACZ81_RS13035">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS13035">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014950090.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS10705" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS10705" fbc:name="ACZ81_RS10705" fbc:label="G_ACZ81_RS10705">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS10705">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014949649.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS10700" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS10700" fbc:name="ACZ81_RS10700" fbc:label="G_ACZ81_RS10700">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS10700">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014949648.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS02425" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS02425" fbc:name="ACZ81_RS02425" fbc:label="G_ACZ81_RS02425">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS02425">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_061439312.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS17085" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS17085" fbc:name="ACZ81_RS17085" fbc:label="G_ACZ81_RS17085">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS17085">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_061486615.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS09420" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS09420" fbc:name="ACZ81_RS09420" fbc:label="G_ACZ81_RS09420">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS09420">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_061485812.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
       <fbc:geneProduct metaid="meta_G_ACZ81_RS20180" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS20180" fbc:name="ACZ81_RS20180" fbc:label="G_ACZ81_RS20180"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS15345" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS15345" fbc:name="ACZ81_RS15345" fbc:label="G_ACZ81_RS15345"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS04105" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS04105" fbc:name="ACZ81_RS04105" fbc:label="G_ACZ81_RS04105"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS08205" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS08205" fbc:name="ACZ81_RS08205" fbc:label="G_ACZ81_RS08205"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS15340" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS15340" fbc:name="ACZ81_RS15340" fbc:label="G_ACZ81_RS15340"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS15720" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS15720" fbc:name="ACZ81_RS15720" fbc:label="G_ACZ81_RS15720"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS09325" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS09325" fbc:name="ACZ81_RS09325" fbc:label="G_ACZ81_RS09325"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS08270" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS08270" fbc:name="ACZ81_RS08270" fbc:label="G_ACZ81_RS08270"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS13040" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS13040" fbc:name="ACZ81_RS13040" fbc:label="G_ACZ81_RS13040"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS17515" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS17515" fbc:name="ACZ81_RS17515" fbc:label="G_ACZ81_RS17515"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS12435" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS12435" fbc:name="ACZ81_RS12435" fbc:label="G_ACZ81_RS12435"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS16850" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS16850" fbc:name="ACZ81_RS16850" fbc:label="G_ACZ81_RS16850"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS01845" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS01845" fbc:name="ACZ81_RS01845" fbc:label="G_ACZ81_RS01845"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS03310" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS03310" fbc:name="ACZ81_RS03310" fbc:label="G_ACZ81_RS03310"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS12900" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS12900" fbc:name="ACZ81_RS12900" fbc:label="G_ACZ81_RS12900"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS10630" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS10630" fbc:name="ACZ81_RS10630" fbc:label="G_ACZ81_RS10630"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS11750" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS11750" fbc:name="ACZ81_RS11750" fbc:label="G_ACZ81_RS11750"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS09940" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS09940" fbc:name="ACZ81_RS09940" fbc:label="G_ACZ81_RS09940"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS14855" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS14855" fbc:name="ACZ81_RS14855" fbc:label="G_ACZ81_RS14855"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS11035" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS11035" fbc:name="ACZ81_RS11035" fbc:label="G_ACZ81_RS11035"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS14735" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS14735" fbc:name="ACZ81_RS14735" fbc:label="G_ACZ81_RS14735"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS15040" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS15040" fbc:name="ACZ81_RS15040" fbc:label="G_ACZ81_RS15040"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS16960" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS16960" fbc:name="ACZ81_RS16960" fbc:label="G_ACZ81_RS16960"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS12115" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS12115" fbc:name="ACZ81_RS12115" fbc:label="G_ACZ81_RS12115"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS01995" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS01995" fbc:name="ACZ81_RS01995" fbc:label="G_ACZ81_RS01995"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS03560" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS03560" fbc:name="ACZ81_RS03560" fbc:label="G_ACZ81_RS03560"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS10130" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS10130" fbc:name="ACZ81_RS10130" fbc:label="G_ACZ81_RS10130"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS15485" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS15485" fbc:name="ACZ81_RS15485" fbc:label="G_ACZ81_RS15485"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS09705" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS09705" fbc:name="ACZ81_RS09705" fbc:label="G_ACZ81_RS09705"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS02230" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS02230" fbc:name="ACZ81_RS02230" fbc:label="G_ACZ81_RS02230"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS18265" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS18265" fbc:name="ACZ81_RS18265" fbc:label="G_ACZ81_RS18265"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS02225" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS02225" fbc:name="ACZ81_RS02225" fbc:label="G_ACZ81_RS02225"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS15055" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS15055" fbc:name="ACZ81_RS15055" fbc:label="G_ACZ81_RS15055"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS06905" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS06905" fbc:name="ACZ81_RS06905" fbc:label="G_ACZ81_RS06905"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS14140" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS14140" fbc:name="ACZ81_RS14140" fbc:label="G_ACZ81_RS14140"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS01835" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS01835" fbc:name="ACZ81_RS01835" fbc:label="G_ACZ81_RS01835"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS18820" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS18820" fbc:name="ACZ81_RS18820" fbc:label="G_ACZ81_RS18820"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS08370" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS08370" fbc:name="ACZ81_RS08370" fbc:label="G_ACZ81_RS08370"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS11875" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS11875" fbc:name="ACZ81_RS11875" fbc:label="G_ACZ81_RS11875"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS16970" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS16970" fbc:name="ACZ81_RS16970" fbc:label="G_ACZ81_RS16970"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS00130" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS00130" fbc:name="ACZ81_RS00130" fbc:label="G_ACZ81_RS00130"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS18540" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS18540" fbc:name="ACZ81_RS18540" fbc:label="G_ACZ81_RS18540"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS08255" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS08255" fbc:name="ACZ81_RS08255" fbc:label="G_ACZ81_RS08255"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS08265" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS08265" fbc:name="ACZ81_RS08265" fbc:label="G_ACZ81_RS08265"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS06930" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS06930" fbc:name="ACZ81_RS06930" fbc:label="G_ACZ81_RS06930"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS04900" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS04900" fbc:name="ACZ81_RS04900" fbc:label="G_ACZ81_RS04900"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS00010" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS00010" fbc:name="ACZ81_RS00010" fbc:label="G_ACZ81_RS00010"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS16795" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS16795" fbc:name="ACZ81_RS16795" fbc:label="G_ACZ81_RS16795"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS03265" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS03265" fbc:name="ACZ81_RS03265" fbc:label="G_ACZ81_RS03265"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS15620" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS15620" fbc:name="ACZ81_RS15620" fbc:label="G_ACZ81_RS15620"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS16190" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS16190" fbc:name="ACZ81_RS16190" fbc:label="G_ACZ81_RS16190"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS06935" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS06935" fbc:name="ACZ81_RS06935" fbc:label="G_ACZ81_RS06935"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS12815" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS12815" fbc:name="ACZ81_RS12815" fbc:label="G_ACZ81_RS12815"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS19150" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS19150" fbc:name="ACZ81_RS19150" fbc:label="G_ACZ81_RS19150"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS00005" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS00005" fbc:name="ACZ81_RS00005" fbc:label="G_ACZ81_RS00005"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS17680" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS17680" fbc:name="ACZ81_RS17680" fbc:label="G_ACZ81_RS17680"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS09330" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS09330" fbc:name="ACZ81_RS09330" fbc:label="G_ACZ81_RS09330"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS08595" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS08595" fbc:name="ACZ81_RS08595" fbc:label="G_ACZ81_RS08595"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS08440" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS08440" fbc:name="ACZ81_RS08440" fbc:label="G_ACZ81_RS08440"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS10690" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS10690" fbc:name="ACZ81_RS10690" fbc:label="G_ACZ81_RS10690"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS08380" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS08380" fbc:name="ACZ81_RS08380" fbc:label="G_ACZ81_RS08380"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS00985" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS00985" fbc:name="ACZ81_RS00985" fbc:label="G_ACZ81_RS00985"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS00020" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS00020" fbc:name="ACZ81_RS00020" fbc:label="G_ACZ81_RS00020"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS09665" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS09665" fbc:name="ACZ81_RS09665" fbc:label="G_ACZ81_RS09665"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS01760" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS01760" fbc:name="ACZ81_RS01760" fbc:label="G_ACZ81_RS01760"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS01750" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS01750" fbc:name="ACZ81_RS01750" fbc:label="G_ACZ81_RS01750"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS02745" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS02745" fbc:name="ACZ81_RS02745" fbc:label="G_ACZ81_RS02745"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS04575" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS04575" fbc:name="ACZ81_RS04575" fbc:label="G_ACZ81_RS04575"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS04170" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS04170" fbc:name="ACZ81_RS04170" fbc:label="G_ACZ81_RS04170"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS07305" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS07305" fbc:name="ACZ81_RS07305" fbc:label="G_ACZ81_RS07305"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS07300" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS07300" fbc:name="ACZ81_RS07300" fbc:label="G_ACZ81_RS07300"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS09660" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS09660" fbc:name="ACZ81_RS09660" fbc:label="G_ACZ81_RS09660"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS18345" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS18345" fbc:name="ACZ81_RS18345" fbc:label="G_ACZ81_RS18345"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS01720" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS01720" fbc:name="ACZ81_RS01720" fbc:label="G_ACZ81_RS01720"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS00660" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS00660" fbc:name="ACZ81_RS00660" fbc:label="G_ACZ81_RS00660"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS02305" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS02305" fbc:name="ACZ81_RS02305" fbc:label="G_ACZ81_RS02305"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS02400" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS02400" fbc:name="ACZ81_RS02400" fbc:label="G_ACZ81_RS02400"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS00380" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS00380" fbc:name="ACZ81_RS00380" fbc:label="G_ACZ81_RS00380"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS10215" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS10215" fbc:name="ACZ81_RS10215" fbc:label="G_ACZ81_RS10215"/>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS15345" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS15345" fbc:name="ACZ81_RS15345" fbc:label="G_ACZ81_RS15345">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS15345">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014977264.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS04105" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS04105" fbc:name="ACZ81_RS04105" fbc:label="G_ACZ81_RS04105">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS04105">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014975770.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS08205" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS08205" fbc:name="ACZ81_RS08205" fbc:label="G_ACZ81_RS08205">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS08205">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_061485631.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS15340" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS15340" fbc:name="ACZ81_RS15340" fbc:label="G_ACZ81_RS15340">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS15340">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014950543.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS15720" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS15720" fbc:name="ACZ81_RS15720" fbc:label="G_ACZ81_RS15720">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS15720">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_061486500.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS09325" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS09325" fbc:name="ACZ81_RS09325" fbc:label="G_ACZ81_RS09325">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS09325">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_232376010.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS08270" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS08270" fbc:name="ACZ81_RS08270" fbc:label="G_ACZ81_RS08270">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS08270">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_049586522.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS13040" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS13040" fbc:name="ACZ81_RS13040" fbc:label="G_ACZ81_RS13040">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS13040">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_061486145.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS17515" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS17515" fbc:name="ACZ81_RS17515" fbc:label="G_ACZ81_RS17515">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS17515">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_061486661.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS12435" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS12435" fbc:name="ACZ81_RS12435" fbc:label="G_ACZ81_RS12435">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS12435">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_039236405.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS16850" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS16850" fbc:name="ACZ81_RS16850" fbc:label="G_ACZ81_RS16850">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS16850">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014977484.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS01845" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS01845" fbc:name="ACZ81_RS01845" fbc:label="G_ACZ81_RS01845">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS01845">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014975466.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS03310" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS03310" fbc:name="ACZ81_RS03310" fbc:label="G_ACZ81_RS03310">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS03310">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014948274.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS12900" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS12900" fbc:name="ACZ81_RS12900" fbc:label="G_ACZ81_RS12900">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS12900">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_061486133.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS10630" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS10630" fbc:name="ACZ81_RS10630" fbc:label="G_ACZ81_RS10630">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS10630">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_061485935.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS11750" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS11750" fbc:name="ACZ81_RS11750" fbc:label="G_ACZ81_RS11750">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS11750">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_061486039.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS09940" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS09940" fbc:name="ACZ81_RS09940" fbc:label="G_ACZ81_RS09940">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS09940">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_061485872.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS14855" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS14855" fbc:name="ACZ81_RS14855" fbc:label="G_ACZ81_RS14855">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS14855">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014950446.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS11035" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS11035" fbc:name="ACZ81_RS11035" fbc:label="G_ACZ81_RS11035">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS11035">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014949715.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS14735" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS14735" fbc:name="ACZ81_RS14735" fbc:label="G_ACZ81_RS14735">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS14735">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014980041.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS15040" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS15040" fbc:name="ACZ81_RS15040" fbc:label="G_ACZ81_RS15040">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS15040">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_061486430.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS16960" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS16960" fbc:name="ACZ81_RS16960" fbc:label="G_ACZ81_RS16960">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS16960">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_061486596.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS12115" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS12115" fbc:name="ACZ81_RS12115" fbc:label="G_ACZ81_RS12115">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS12115">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014979644.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS01995" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS01995" fbc:name="ACZ81_RS01995" fbc:label="G_ACZ81_RS01995">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS01995">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014978126.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS03560" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS03560" fbc:name="ACZ81_RS03560" fbc:label="G_ACZ81_RS03560">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS03560">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_049586138.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS10130" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS10130" fbc:name="ACZ81_RS10130" fbc:label="G_ACZ81_RS10130">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS10130">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014949528.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS15485" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS15485" fbc:name="ACZ81_RS15485" fbc:label="G_ACZ81_RS15485">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS15485">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014977274.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS09705" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS09705" fbc:name="ACZ81_RS09705" fbc:label="G_ACZ81_RS09705">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS09705">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_061485850.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS02230" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS02230" fbc:name="ACZ81_RS02230" fbc:label="G_ACZ81_RS02230">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS02230">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014975513.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS18265" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS18265" fbc:name="ACZ81_RS18265" fbc:label="G_ACZ81_RS18265">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS18265">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014951084.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS02225" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS02225" fbc:name="ACZ81_RS02225" fbc:label="G_ACZ81_RS02225">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS02225">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_039225051.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS15055" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS15055" fbc:name="ACZ81_RS15055" fbc:label="G_ACZ81_RS15055">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS15055">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_061486433.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS06905" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS06905" fbc:name="ACZ81_RS06905" fbc:label="G_ACZ81_RS06905">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS06905">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014948943.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS14140" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS14140" fbc:name="ACZ81_RS14140" fbc:label="G_ACZ81_RS14140">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS14140">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_061486321.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS01835" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS01835" fbc:name="ACZ81_RS01835" fbc:label="G_ACZ81_RS01835">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS01835">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014975465.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS18820" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS18820" fbc:name="ACZ81_RS18820" fbc:label="G_ACZ81_RS18820">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS18820">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_061486773.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS08370" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS08370" fbc:name="ACZ81_RS08370" fbc:label="G_ACZ81_RS08370">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS08370">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_061485666.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS11875" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS11875" fbc:name="ACZ81_RS11875" fbc:label="G_ACZ81_RS11875">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS11875">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_061486045.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS16970" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS16970" fbc:name="ACZ81_RS16970" fbc:label="G_ACZ81_RS16970">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS16970">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_061486598.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS00130" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS00130" fbc:name="ACZ81_RS00130" fbc:label="G_ACZ81_RS00130">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS00130">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_049586350.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS18540" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS18540" fbc:name="ACZ81_RS18540" fbc:label="G_ACZ81_RS18540">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS18540">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_039229202.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS08255" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS08255" fbc:name="ACZ81_RS08255" fbc:label="G_ACZ81_RS08255">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS08255">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014976271.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS08265" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS08265" fbc:name="ACZ81_RS08265" fbc:label="G_ACZ81_RS08265">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS08265">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_061485641.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS06930" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS06930" fbc:name="ACZ81_RS06930" fbc:label="G_ACZ81_RS06930">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS06930">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_061485338.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS04900" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS04900" fbc:name="ACZ81_RS04900" fbc:label="G_ACZ81_RS04900">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS04900">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_081106067.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS00010" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS00010" fbc:name="ACZ81_RS00010" fbc:label="G_ACZ81_RS00010">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS00010">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_012516526.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS16795" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS16795" fbc:name="ACZ81_RS16795" fbc:label="G_ACZ81_RS16795">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS16795">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014980376.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS03265" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS03265" fbc:name="ACZ81_RS03265" fbc:label="G_ACZ81_RS03265">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS03265">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_049587032.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS15620" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS15620" fbc:name="ACZ81_RS15620" fbc:label="G_ACZ81_RS15620">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS15620">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_061486488.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS16190" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS16190" fbc:name="ACZ81_RS16190" fbc:label="G_ACZ81_RS16190">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS16190">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_232376026.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS06935" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS06935" fbc:name="ACZ81_RS06935" fbc:label="G_ACZ81_RS06935">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS06935">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_061485340.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS12815" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS12815" fbc:name="ACZ81_RS12815" fbc:label="G_ACZ81_RS12815">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS12815">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_061486125.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS19150" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS19150" fbc:name="ACZ81_RS19150" fbc:label="G_ACZ81_RS19150">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS19150">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_061486804.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS00005" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS00005" fbc:name="ACZ81_RS00005" fbc:label="G_ACZ81_RS00005">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS00005">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_232375975.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS17680" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS17680" fbc:name="ACZ81_RS17680" fbc:label="G_ACZ81_RS17680">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS17680">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_061486680.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS09330" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS09330" fbc:name="ACZ81_RS09330" fbc:label="G_ACZ81_RS09330">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS09330">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_061485803.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS08595" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS08595" fbc:name="ACZ81_RS08595" fbc:label="G_ACZ81_RS08595">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS08595">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014979119.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS08440" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS08440" fbc:name="ACZ81_RS08440" fbc:label="G_ACZ81_RS08440">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS08440">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_039229698.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS10690" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS10690" fbc:name="ACZ81_RS10690" fbc:label="G_ACZ81_RS10690">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS10690">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_061485937.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS08380" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS08380" fbc:name="ACZ81_RS08380" fbc:label="G_ACZ81_RS08380">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS08380">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014976297.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS00985" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS00985" fbc:name="ACZ81_RS00985" fbc:label="G_ACZ81_RS00985">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS00985">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014947881.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS00020" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS00020" fbc:name="ACZ81_RS00020" fbc:label="G_ACZ81_RS00020">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS00020">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014977848.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS09665" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS09665" fbc:name="ACZ81_RS09665" fbc:label="G_ACZ81_RS09665">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS09665">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_061485845.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS01760" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS01760" fbc:name="ACZ81_RS01760" fbc:label="G_ACZ81_RS01760">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS01760">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014975454.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS01750" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS01750" fbc:name="ACZ81_RS01750" fbc:label="G_ACZ81_RS01750">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS01750">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014975452.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS02745" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS02745" fbc:name="ACZ81_RS02745" fbc:label="G_ACZ81_RS02745">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS02745">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_061439395.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS04575" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS04575" fbc:name="ACZ81_RS04575" fbc:label="G_ACZ81_RS04575">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS04575">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014975823.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS04170" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS04170" fbc:name="ACZ81_RS04170" fbc:label="G_ACZ81_RS04170">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS04170">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_061484821.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS07305" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS07305" fbc:name="ACZ81_RS07305" fbc:label="G_ACZ81_RS07305">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS07305">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014949014.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS07300" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS07300" fbc:name="ACZ81_RS07300" fbc:label="G_ACZ81_RS07300">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS07300">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_061485392.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS09660" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS09660" fbc:name="ACZ81_RS09660" fbc:label="G_ACZ81_RS09660">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS09660">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014979262.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS18345" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS18345" fbc:name="ACZ81_RS18345" fbc:label="G_ACZ81_RS18345">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS18345">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_080760052.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS01720" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS01720" fbc:name="ACZ81_RS01720" fbc:label="G_ACZ81_RS01720">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS01720">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_061439208.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS00660" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS00660" fbc:name="ACZ81_RS00660" fbc:label="G_ACZ81_RS00660">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS00660">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_232375977.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS02305" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS02305" fbc:name="ACZ81_RS02305" fbc:label="G_ACZ81_RS02305">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS02305">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014948097.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS02400" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS02400" fbc:name="ACZ81_RS02400" fbc:label="G_ACZ81_RS02400">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS02400">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014975536.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS00380" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS00380" fbc:name="ACZ81_RS00380" fbc:label="G_ACZ81_RS00380">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS00380">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_061438916.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS10215" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS10215" fbc:name="ACZ81_RS10215" fbc:label="G_ACZ81_RS10215">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS10215">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014979337.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
       <fbc:geneProduct metaid="meta_G_ACZ81_RS18560" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS18560" fbc:name="ACZ81_RS18560" fbc:label="G_ACZ81_RS18560"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS12555" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS12555" fbc:name="ACZ81_RS12555" fbc:label="G_ACZ81_RS12555"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS15420" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS15420" fbc:name="ACZ81_RS15420" fbc:label="G_ACZ81_RS15420"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS14460" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS14460" fbc:name="ACZ81_RS14460" fbc:label="G_ACZ81_RS14460"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS10350" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS10350" fbc:name="ACZ81_RS10350" fbc:label="G_ACZ81_RS10350"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS00385" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS00385" fbc:name="ACZ81_RS00385" fbc:label="G_ACZ81_RS00385"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS15530" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS15530" fbc:name="ACZ81_RS15530" fbc:label="G_ACZ81_RS15530"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS03795" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS03795" fbc:name="ACZ81_RS03795" fbc:label="G_ACZ81_RS03795"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS07070" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS07070" fbc:name="ACZ81_RS07070" fbc:label="G_ACZ81_RS07070"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS19780" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS19780" fbc:name="ACZ81_RS19780" fbc:label="G_ACZ81_RS19780"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS18575" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS18575" fbc:name="ACZ81_RS18575" fbc:label="G_ACZ81_RS18575"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS10820" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS10820" fbc:name="ACZ81_RS10820" fbc:label="G_ACZ81_RS10820"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS07005" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS07005" fbc:name="ACZ81_RS07005" fbc:label="G_ACZ81_RS07005"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS02285" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS02285" fbc:name="ACZ81_RS02285" fbc:label="G_ACZ81_RS02285"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS10785" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS10785" fbc:name="ACZ81_RS10785" fbc:label="G_ACZ81_RS10785"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS06245" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS06245" fbc:name="ACZ81_RS06245" fbc:label="G_ACZ81_RS06245"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS08590" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS08590" fbc:name="ACZ81_RS08590" fbc:label="G_ACZ81_RS08590"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS08470" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS08470" fbc:name="ACZ81_RS08470" fbc:label="G_ACZ81_RS08470"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS08905" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS08905" fbc:name="ACZ81_RS08905" fbc:label="G_ACZ81_RS08905"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS14785" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS14785" fbc:name="ACZ81_RS14785" fbc:label="G_ACZ81_RS14785"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS02145" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS02145" fbc:name="ACZ81_RS02145" fbc:label="G_ACZ81_RS02145"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS09645" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS09645" fbc:name="ACZ81_RS09645" fbc:label="G_ACZ81_RS09645"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS08580" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS08580" fbc:name="ACZ81_RS08580" fbc:label="G_ACZ81_RS08580"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS13925" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS13925" fbc:name="ACZ81_RS13925" fbc:label="G_ACZ81_RS13925"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS01915" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS01915" fbc:name="ACZ81_RS01915" fbc:label="G_ACZ81_RS01915"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS10125" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS10125" fbc:name="ACZ81_RS10125" fbc:label="G_ACZ81_RS10125"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS10880" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS10880" fbc:name="ACZ81_RS10880" fbc:label="G_ACZ81_RS10880"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS08530" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS08530" fbc:name="ACZ81_RS08530" fbc:label="G_ACZ81_RS08530"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS10360" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS10360" fbc:name="ACZ81_RS10360" fbc:label="G_ACZ81_RS10360"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS10355" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS10355" fbc:name="ACZ81_RS10355" fbc:label="G_ACZ81_RS10355"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS10365" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS10365" fbc:name="ACZ81_RS10365" fbc:label="G_ACZ81_RS10365"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS19110" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS19110" fbc:name="ACZ81_RS19110" fbc:label="G_ACZ81_RS19110"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS17550" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS17550" fbc:name="ACZ81_RS17550" fbc:label="G_ACZ81_RS17550"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS01015" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS01015" fbc:name="ACZ81_RS01015" fbc:label="G_ACZ81_RS01015"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS17430" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS17430" fbc:name="ACZ81_RS17430" fbc:label="G_ACZ81_RS17430"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS16255" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS16255" fbc:name="ACZ81_RS16255" fbc:label="G_ACZ81_RS16255"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS18900" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS18900" fbc:name="ACZ81_RS18900" fbc:label="G_ACZ81_RS18900"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS18905" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS18905" fbc:name="ACZ81_RS18905" fbc:label="G_ACZ81_RS18905"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS18910" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS18910" fbc:name="ACZ81_RS18910" fbc:label="G_ACZ81_RS18910"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS07435" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS07435" fbc:name="ACZ81_RS07435" fbc:label="G_ACZ81_RS07435"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS09625" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS09625" fbc:name="ACZ81_RS09625" fbc:label="G_ACZ81_RS09625"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS11700" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS11700" fbc:name="ACZ81_RS11700" fbc:label="G_ACZ81_RS11700"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS11885" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS11885" fbc:name="ACZ81_RS11885" fbc:label="G_ACZ81_RS11885"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS08725" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS08725" fbc:name="ACZ81_RS08725" fbc:label="G_ACZ81_RS08725"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS13430" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS13430" fbc:name="ACZ81_RS13430" fbc:label="G_ACZ81_RS13430"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS11690" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS11690" fbc:name="ACZ81_RS11690" fbc:label="G_ACZ81_RS11690"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS04755" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS04755" fbc:name="ACZ81_RS04755" fbc:label="G_ACZ81_RS04755"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS07420" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS07420" fbc:name="ACZ81_RS07420" fbc:label="G_ACZ81_RS07420"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS02185" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS02185" fbc:name="ACZ81_RS02185" fbc:label="G_ACZ81_RS02185"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS06705" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS06705" fbc:name="ACZ81_RS06705" fbc:label="G_ACZ81_RS06705"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS06285" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS06285" fbc:name="ACZ81_RS06285" fbc:label="G_ACZ81_RS06285"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS03935" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS03935" fbc:name="ACZ81_RS03935" fbc:label="G_ACZ81_RS03935"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS05315" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS05315" fbc:name="ACZ81_RS05315" fbc:label="G_ACZ81_RS05315"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS05310" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS05310" fbc:name="ACZ81_RS05310" fbc:label="G_ACZ81_RS05310"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS13000" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS13000" fbc:name="ACZ81_RS13000" fbc:label="G_ACZ81_RS13000"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS15450" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS15450" fbc:name="ACZ81_RS15450" fbc:label="G_ACZ81_RS15450"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS19665" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS19665" fbc:name="ACZ81_RS19665" fbc:label="G_ACZ81_RS19665"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS14595" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS14595" fbc:name="ACZ81_RS14595" fbc:label="G_ACZ81_RS14595"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS00970" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS00970" fbc:name="ACZ81_RS00970" fbc:label="G_ACZ81_RS00970"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS04940" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS04940" fbc:name="ACZ81_RS04940" fbc:label="G_ACZ81_RS04940"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS19355" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS19355" fbc:name="ACZ81_RS19355" fbc:label="G_ACZ81_RS19355"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS14465" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS14465" fbc:name="ACZ81_RS14465" fbc:label="G_ACZ81_RS14465"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS14470" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS14470" fbc:name="ACZ81_RS14470" fbc:label="G_ACZ81_RS14470"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS01715" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS01715" fbc:name="ACZ81_RS01715" fbc:label="G_ACZ81_RS01715"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS11740" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS11740" fbc:name="ACZ81_RS11740" fbc:label="G_ACZ81_RS11740"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS15045" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS15045" fbc:name="ACZ81_RS15045" fbc:label="G_ACZ81_RS15045"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS17835" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS17835" fbc:name="ACZ81_RS17835" fbc:label="G_ACZ81_RS17835"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS11975" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS11975" fbc:name="ACZ81_RS11975" fbc:label="G_ACZ81_RS11975"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS00640" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS00640" fbc:name="ACZ81_RS00640" fbc:label="G_ACZ81_RS00640"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS03705" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS03705" fbc:name="ACZ81_RS03705" fbc:label="G_ACZ81_RS03705"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS00790" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS00790" fbc:name="ACZ81_RS00790" fbc:label="G_ACZ81_RS00790"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS06505" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS06505" fbc:name="ACZ81_RS06505" fbc:label="G_ACZ81_RS06505"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS05815" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS05815" fbc:name="ACZ81_RS05815" fbc:label="G_ACZ81_RS05815"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS03105" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS03105" fbc:name="ACZ81_RS03105" fbc:label="G_ACZ81_RS03105"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS03455" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS03455" fbc:name="ACZ81_RS03455" fbc:label="G_ACZ81_RS03455"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS03425" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS03425" fbc:name="ACZ81_RS03425" fbc:label="G_ACZ81_RS03425"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS01640" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS01640" fbc:name="ACZ81_RS01640" fbc:label="G_ACZ81_RS01640"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS18860" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS18860" fbc:name="ACZ81_RS18860" fbc:label="G_ACZ81_RS18860"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS00315" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS00315" fbc:name="ACZ81_RS00315" fbc:label="G_ACZ81_RS00315"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS06680" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS06680" fbc:name="ACZ81_RS06680" fbc:label="G_ACZ81_RS06680"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS08695" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS08695" fbc:name="ACZ81_RS08695" fbc:label="G_ACZ81_RS08695"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS14755" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS14755" fbc:name="ACZ81_RS14755" fbc:label="G_ACZ81_RS14755"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS16020" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS16020" fbc:name="ACZ81_RS16020" fbc:label="G_ACZ81_RS16020"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS15875" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS15875" fbc:name="ACZ81_RS15875" fbc:label="G_ACZ81_RS15875"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS16350" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS16350" fbc:name="ACZ81_RS16350" fbc:label="G_ACZ81_RS16350"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS14645" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS14645" fbc:name="ACZ81_RS14645" fbc:label="G_ACZ81_RS14645"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS13015" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS13015" fbc:name="ACZ81_RS13015" fbc:label="G_ACZ81_RS13015"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS01520" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS01520" fbc:name="ACZ81_RS01520" fbc:label="G_ACZ81_RS01520"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS16640" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS16640" fbc:name="ACZ81_RS16640" fbc:label="G_ACZ81_RS16640"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS12205" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS12205" fbc:name="ACZ81_RS12205" fbc:label="G_ACZ81_RS12205"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS02045" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS02045" fbc:name="ACZ81_RS02045" fbc:label="G_ACZ81_RS02045"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS17825" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS17825" fbc:name="ACZ81_RS17825" fbc:label="G_ACZ81_RS17825"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS18150" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS18150" fbc:name="ACZ81_RS18150" fbc:label="G_ACZ81_RS18150"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS07930" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS07930" fbc:name="ACZ81_RS07930" fbc:label="G_ACZ81_RS07930"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS02710" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS02710" fbc:name="ACZ81_RS02710" fbc:label="G_ACZ81_RS02710"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS08435" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS08435" fbc:name="ACZ81_RS08435" fbc:label="G_ACZ81_RS08435"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS14540" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS14540" fbc:name="ACZ81_RS14540" fbc:label="G_ACZ81_RS14540"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS15455" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS15455" fbc:name="ACZ81_RS15455" fbc:label="G_ACZ81_RS15455"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS05495" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS05495" fbc:name="ACZ81_RS05495" fbc:label="G_ACZ81_RS05495"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS09465" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS09465" fbc:name="ACZ81_RS09465" fbc:label="G_ACZ81_RS09465"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS16105" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS16105" fbc:name="ACZ81_RS16105" fbc:label="G_ACZ81_RS16105"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS04840" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS04840" fbc:name="ACZ81_RS04840" fbc:label="G_ACZ81_RS04840"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS07785" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS07785" fbc:name="ACZ81_RS07785" fbc:label="G_ACZ81_RS07785"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS12995" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS12995" fbc:name="ACZ81_RS12995" fbc:label="G_ACZ81_RS12995"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS06695" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS06695" fbc:name="ACZ81_RS06695" fbc:label="G_ACZ81_RS06695"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS15375" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS15375" fbc:name="ACZ81_RS15375" fbc:label="G_ACZ81_RS15375"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS05305" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS05305" fbc:name="ACZ81_RS05305" fbc:label="G_ACZ81_RS05305"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS14775" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS14775" fbc:name="ACZ81_RS14775" fbc:label="G_ACZ81_RS14775"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS07780" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS07780" fbc:name="ACZ81_RS07780" fbc:label="G_ACZ81_RS07780"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS00965" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS00965" fbc:name="ACZ81_RS00965" fbc:label="G_ACZ81_RS00965"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS01785" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS01785" fbc:name="ACZ81_RS01785" fbc:label="G_ACZ81_RS01785"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS01990" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS01990" fbc:name="ACZ81_RS01990" fbc:label="G_ACZ81_RS01990"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS00155" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS00155" fbc:name="ACZ81_RS00155" fbc:label="G_ACZ81_RS00155"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS13105" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS13105" fbc:name="ACZ81_RS13105" fbc:label="G_ACZ81_RS13105"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS08760" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS08760" fbc:name="ACZ81_RS08760" fbc:label="G_ACZ81_RS08760"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS12350" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS12350" fbc:name="ACZ81_RS12350" fbc:label="G_ACZ81_RS12350"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS17275" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS17275" fbc:name="ACZ81_RS17275" fbc:label="G_ACZ81_RS17275"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS19935" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS19935" fbc:name="ACZ81_RS19935" fbc:label="G_ACZ81_RS19935"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS03260" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS03260" fbc:name="ACZ81_RS03260" fbc:label="G_ACZ81_RS03260"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS18015" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS18015" fbc:name="ACZ81_RS18015" fbc:label="G_ACZ81_RS18015"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS18020" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS18020" fbc:name="ACZ81_RS18020" fbc:label="G_ACZ81_RS18020"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS03305" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS03305" fbc:name="ACZ81_RS03305" fbc:label="G_ACZ81_RS03305"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS00975" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS00975" fbc:name="ACZ81_RS00975" fbc:label="G_ACZ81_RS00975"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS02315" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS02315" fbc:name="ACZ81_RS02315" fbc:label="G_ACZ81_RS02315"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS11415" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS11415" fbc:name="ACZ81_RS11415" fbc:label="G_ACZ81_RS11415"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS09275" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS09275" fbc:name="ACZ81_RS09275" fbc:label="G_ACZ81_RS09275"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS09770" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS09770" fbc:name="ACZ81_RS09770" fbc:label="G_ACZ81_RS09770"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS13180" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS13180" fbc:name="ACZ81_RS13180" fbc:label="G_ACZ81_RS13180"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS04885" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS04885" fbc:name="ACZ81_RS04885" fbc:label="G_ACZ81_RS04885"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS14300" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS14300" fbc:name="ACZ81_RS14300" fbc:label="G_ACZ81_RS14300"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS15165" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS15165" fbc:name="ACZ81_RS15165" fbc:label="G_ACZ81_RS15165"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS07870" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS07870" fbc:name="ACZ81_RS07870" fbc:label="G_ACZ81_RS07870"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS07830" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS07830" fbc:name="ACZ81_RS07830" fbc:label="G_ACZ81_RS07830"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS14060" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS14060" fbc:name="ACZ81_RS14060" fbc:label="G_ACZ81_RS14060"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS12500" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS12500" fbc:name="ACZ81_RS12500" fbc:label="G_ACZ81_RS12500"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS06670" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS06670" fbc:name="ACZ81_RS06670" fbc:label="G_ACZ81_RS06670"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS18260" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS18260" fbc:name="ACZ81_RS18260" fbc:label="G_ACZ81_RS18260"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS09390" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS09390" fbc:name="ACZ81_RS09390" fbc:label="G_ACZ81_RS09390"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS07920" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS07920" fbc:name="ACZ81_RS07920" fbc:label="G_ACZ81_RS07920"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS18125" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS18125" fbc:name="ACZ81_RS18125" fbc:label="G_ACZ81_RS18125"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS16120" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS16120" fbc:name="ACZ81_RS16120" fbc:label="G_ACZ81_RS16120"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS00615" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS00615" fbc:name="ACZ81_RS00615" fbc:label="G_ACZ81_RS00615"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS12130" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS12130" fbc:name="ACZ81_RS12130" fbc:label="G_ACZ81_RS12130"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS08715" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS08715" fbc:name="ACZ81_RS08715" fbc:label="G_ACZ81_RS08715"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS04815" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS04815" fbc:name="ACZ81_RS04815" fbc:label="G_ACZ81_RS04815"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS10770" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS10770" fbc:name="ACZ81_RS10770" fbc:label="G_ACZ81_RS10770"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS02060" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS02060" fbc:name="ACZ81_RS02060" fbc:label="G_ACZ81_RS02060"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS13300" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS13300" fbc:name="ACZ81_RS13300" fbc:label="G_ACZ81_RS13300"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS12180" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS12180" fbc:name="ACZ81_RS12180" fbc:label="G_ACZ81_RS12180"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS17830" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS17830" fbc:name="ACZ81_RS17830" fbc:label="G_ACZ81_RS17830"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS16285" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS16285" fbc:name="ACZ81_RS16285" fbc:label="G_ACZ81_RS16285"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS16290" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS16290" fbc:name="ACZ81_RS16290" fbc:label="G_ACZ81_RS16290"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS19100" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS19100" fbc:name="ACZ81_RS19100" fbc:label="G_ACZ81_RS19100"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS17260" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS17260" fbc:name="ACZ81_RS17260" fbc:label="G_ACZ81_RS17260"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS09755" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS09755" fbc:name="ACZ81_RS09755" fbc:label="G_ACZ81_RS09755"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS15535" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS15535" fbc:name="ACZ81_RS15535" fbc:label="G_ACZ81_RS15535"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS11195" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS11195" fbc:name="ACZ81_RS11195" fbc:label="G_ACZ81_RS11195"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS11190" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS11190" fbc:name="ACZ81_RS11190" fbc:label="G_ACZ81_RS11190"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS18155" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS18155" fbc:name="ACZ81_RS18155" fbc:label="G_ACZ81_RS18155"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS00500" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS00500" fbc:name="ACZ81_RS00500" fbc:label="G_ACZ81_RS00500"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS05520" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS05520" fbc:name="ACZ81_RS05520" fbc:label="G_ACZ81_RS05520"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS18275" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS18275" fbc:name="ACZ81_RS18275" fbc:label="G_ACZ81_RS18275"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS12140" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS12140" fbc:name="ACZ81_RS12140" fbc:label="G_ACZ81_RS12140"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS01215" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS01215" fbc:name="ACZ81_RS01215" fbc:label="G_ACZ81_RS01215"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS18750" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS18750" fbc:name="ACZ81_RS18750" fbc:label="G_ACZ81_RS18750"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS11755" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS11755" fbc:name="ACZ81_RS11755" fbc:label="G_ACZ81_RS11755"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS00310" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS00310" fbc:name="ACZ81_RS00310" fbc:label="G_ACZ81_RS00310"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS07080" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS07080" fbc:name="ACZ81_RS07080" fbc:label="G_ACZ81_RS07080"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS02050" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS02050" fbc:name="ACZ81_RS02050" fbc:label="G_ACZ81_RS02050"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS11490" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS11490" fbc:name="ACZ81_RS11490" fbc:label="G_ACZ81_RS11490"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS10685" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS10685" fbc:name="ACZ81_RS10685" fbc:label="G_ACZ81_RS10685"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS09235" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS09235" fbc:name="ACZ81_RS09235" fbc:label="G_ACZ81_RS09235"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS10900" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS10900" fbc:name="ACZ81_RS10900" fbc:label="G_ACZ81_RS10900"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS07465" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS07465" fbc:name="ACZ81_RS07465" fbc:label="G_ACZ81_RS07465"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS13310" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS13310" fbc:name="ACZ81_RS13310" fbc:label="G_ACZ81_RS13310"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS02825" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS02825" fbc:name="ACZ81_RS02825" fbc:label="G_ACZ81_RS02825"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS13695" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS13695" fbc:name="ACZ81_RS13695" fbc:label="G_ACZ81_RS13695"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS12375" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS12375" fbc:name="ACZ81_RS12375" fbc:label="G_ACZ81_RS12375"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS05945" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS05945" fbc:name="ACZ81_RS05945" fbc:label="G_ACZ81_RS05945"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS14165" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS14165" fbc:name="ACZ81_RS14165" fbc:label="G_ACZ81_RS14165"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS19470" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS19470" fbc:name="ACZ81_RS19470" fbc:label="G_ACZ81_RS19470"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS12805" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS12805" fbc:name="ACZ81_RS12805" fbc:label="G_ACZ81_RS12805"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS11355" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS11355" fbc:name="ACZ81_RS11355" fbc:label="G_ACZ81_RS11355"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS00480" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS00480" fbc:name="ACZ81_RS00480" fbc:label="G_ACZ81_RS00480"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS10895" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS10895" fbc:name="ACZ81_RS10895" fbc:label="G_ACZ81_RS10895"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS00490" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS00490" fbc:name="ACZ81_RS00490" fbc:label="G_ACZ81_RS00490"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS19535" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS19535" fbc:name="ACZ81_RS19535" fbc:label="G_ACZ81_RS19535"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS03120" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS03120" fbc:name="ACZ81_RS03120" fbc:label="G_ACZ81_RS03120"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS19010" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS19010" fbc:name="ACZ81_RS19010" fbc:label="G_ACZ81_RS19010"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS19000" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS19000" fbc:name="ACZ81_RS19000" fbc:label="G_ACZ81_RS19000"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS19005" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS19005" fbc:name="ACZ81_RS19005" fbc:label="G_ACZ81_RS19005"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS18995" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS18995" fbc:name="ACZ81_RS18995" fbc:label="G_ACZ81_RS18995"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS18605" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS18605" fbc:name="ACZ81_RS18605" fbc:label="G_ACZ81_RS18605"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS17475" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS17475" fbc:name="ACZ81_RS17475" fbc:label="G_ACZ81_RS17475"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS18610" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS18610" fbc:name="ACZ81_RS18610" fbc:label="G_ACZ81_RS18610"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS17480" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS17480" fbc:name="ACZ81_RS17480" fbc:label="G_ACZ81_RS17480"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS02890" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS02890" fbc:name="ACZ81_RS02890" fbc:label="G_ACZ81_RS02890"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS10380" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS10380" fbc:name="ACZ81_RS10380" fbc:label="G_ACZ81_RS10380"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS10375" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS10375" fbc:name="ACZ81_RS10375" fbc:label="G_ACZ81_RS10375"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS03190" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS03190" fbc:name="ACZ81_RS03190" fbc:label="G_ACZ81_RS03190"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS10385" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS10385" fbc:name="ACZ81_RS10385" fbc:label="G_ACZ81_RS10385"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS10390" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS10390" fbc:name="ACZ81_RS10390" fbc:label="G_ACZ81_RS10390"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS10405" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS10405" fbc:name="ACZ81_RS10405" fbc:label="G_ACZ81_RS10405"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS16025" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS16025" fbc:name="ACZ81_RS16025" fbc:label="G_ACZ81_RS16025"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS19835" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS19835" fbc:name="ACZ81_RS19835" fbc:label="G_ACZ81_RS19835"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS19845" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS19845" fbc:name="ACZ81_RS19845" fbc:label="G_ACZ81_RS19845"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS19860" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS19860" fbc:name="ACZ81_RS19860" fbc:label="G_ACZ81_RS19860"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS19855" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS19855" fbc:name="ACZ81_RS19855" fbc:label="G_ACZ81_RS19855"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS19875" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS19875" fbc:name="ACZ81_RS19875" fbc:label="G_ACZ81_RS19875"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS19865" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS19865" fbc:name="ACZ81_RS19865" fbc:label="G_ACZ81_RS19865"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS19870" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS19870" fbc:name="ACZ81_RS19870" fbc:label="G_ACZ81_RS19870"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS19850" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS19850" fbc:name="ACZ81_RS19850" fbc:label="G_ACZ81_RS19850"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS19840" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS19840" fbc:name="ACZ81_RS19840" fbc:label="G_ACZ81_RS19840"/>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS12555" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS12555" fbc:name="ACZ81_RS12555" fbc:label="G_ACZ81_RS12555">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS12555">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014949997.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS15420" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS15420" fbc:name="ACZ81_RS15420" fbc:label="G_ACZ81_RS15420">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS15420">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_061486471.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS14460" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS14460" fbc:name="ACZ81_RS14460" fbc:label="G_ACZ81_RS14460">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS14460">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_061486366.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS10350" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS10350" fbc:name="ACZ81_RS10350" fbc:label="G_ACZ81_RS10350">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS10350">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_039227671.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS00385" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS00385" fbc:name="ACZ81_RS00385" fbc:label="G_ACZ81_RS00385">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS00385">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_061438918.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS15530" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS15530" fbc:name="ACZ81_RS15530" fbc:label="G_ACZ81_RS15530">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS15530">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_061486482.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS03795" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS03795" fbc:name="ACZ81_RS03795" fbc:label="G_ACZ81_RS03795">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS03795">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_061439598.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS07070" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS07070" fbc:name="ACZ81_RS07070" fbc:label="G_ACZ81_RS07070">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS07070">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_061485376.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS19780" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS19780" fbc:name="ACZ81_RS19780" fbc:label="G_ACZ81_RS19780">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS19780">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_061486866.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS18575" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS18575" fbc:name="ACZ81_RS18575" fbc:label="G_ACZ81_RS18575">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS18575">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014951144.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS10820" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS10820" fbc:name="ACZ81_RS10820" fbc:label="G_ACZ81_RS10820">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS10820">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014979423.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS07005" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS07005" fbc:name="ACZ81_RS07005" fbc:label="G_ACZ81_RS07005">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS07005">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_061094674.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS02285" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS02285" fbc:name="ACZ81_RS02285" fbc:label="G_ACZ81_RS02285">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS02285">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_012517074.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS10785" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS10785" fbc:name="ACZ81_RS10785" fbc:label="G_ACZ81_RS10785">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS10785">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_061485947.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS06245" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS06245" fbc:name="ACZ81_RS06245" fbc:label="G_ACZ81_RS06245">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS06245">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_061485214.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS08590" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS08590" fbc:name="ACZ81_RS08590" fbc:label="G_ACZ81_RS08590">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS08590">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014949218.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS08470" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS08470" fbc:name="ACZ81_RS08470" fbc:label="G_ACZ81_RS08470">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS08470">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_061485678.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS08905" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS08905" fbc:name="ACZ81_RS08905" fbc:label="G_ACZ81_RS08905">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS08905">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_061485755.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS14785" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS14785" fbc:name="ACZ81_RS14785" fbc:label="G_ACZ81_RS14785">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS14785">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_061486405.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS02145" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS02145" fbc:name="ACZ81_RS02145" fbc:label="G_ACZ81_RS02145">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS02145">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014948069.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS09645" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS09645" fbc:name="ACZ81_RS09645" fbc:label="G_ACZ81_RS09645">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS09645">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_232376014.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS08580" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS08580" fbc:name="ACZ81_RS08580" fbc:label="G_ACZ81_RS08580">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS08580">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014949216.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS13925" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS13925" fbc:name="ACZ81_RS13925" fbc:label="G_ACZ81_RS13925">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS13925">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014950254.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS01915" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS01915" fbc:name="ACZ81_RS01915" fbc:label="G_ACZ81_RS01915">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS01915">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_061439224.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS10125" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS10125" fbc:name="ACZ81_RS10125" fbc:label="G_ACZ81_RS10125">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS10125">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_061485895.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS10880" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS10880" fbc:name="ACZ81_RS10880" fbc:label="G_ACZ81_RS10880">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS10880">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_170826507.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS08530" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS08530" fbc:name="ACZ81_RS08530" fbc:label="G_ACZ81_RS08530">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS08530">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014979113.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS10360" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS10360" fbc:name="ACZ81_RS10360" fbc:label="G_ACZ81_RS10360">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS10360">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014949586.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS10355" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS10355" fbc:name="ACZ81_RS10355" fbc:label="G_ACZ81_RS10355">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS10355">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_061485915.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS10365" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS10365" fbc:name="ACZ81_RS10365" fbc:label="G_ACZ81_RS10365">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS10365">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014949587.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS19110" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS19110" fbc:name="ACZ81_RS19110" fbc:label="G_ACZ81_RS19110">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS19110">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014999994.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS17550" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS17550" fbc:name="ACZ81_RS17550" fbc:label="G_ACZ81_RS17550">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS17550">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_061486667.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS01015" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS01015" fbc:name="ACZ81_RS01015" fbc:label="G_ACZ81_RS01015">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS01015">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_061439046.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS17430" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS17430" fbc:name="ACZ81_RS17430" fbc:label="G_ACZ81_RS17430">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS17430">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014950926.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS16255" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS16255" fbc:name="ACZ81_RS16255" fbc:label="G_ACZ81_RS16255">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS16255">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014950712.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS18900" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS18900" fbc:name="ACZ81_RS18900" fbc:label="G_ACZ81_RS18900">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS18900">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014951244.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS18905" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS18905" fbc:name="ACZ81_RS18905" fbc:label="G_ACZ81_RS18905">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS18905">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014951245.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS18910" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS18910" fbc:name="ACZ81_RS18910" fbc:label="G_ACZ81_RS18910">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS18910">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_061486783.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS07435" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS07435" fbc:name="ACZ81_RS07435" fbc:label="G_ACZ81_RS07435">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS07435">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_061485428.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS09625" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS09625" fbc:name="ACZ81_RS09625" fbc:label="G_ACZ81_RS09625">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS09625">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_232376013.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS11700" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS11700" fbc:name="ACZ81_RS11700" fbc:label="G_ACZ81_RS11700">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS11700">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014949842.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS11885" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS11885" fbc:name="ACZ81_RS11885" fbc:label="G_ACZ81_RS11885">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS11885">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_061486046.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS08725" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS08725" fbc:name="ACZ81_RS08725" fbc:label="G_ACZ81_RS08725">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS08725">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_049586648.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS13430" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS13430" fbc:name="ACZ81_RS13430" fbc:label="G_ACZ81_RS13430">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS13430">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014950158.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS11690" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS11690" fbc:name="ACZ81_RS11690" fbc:label="G_ACZ81_RS11690">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS11690">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014949840.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS04755" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS04755" fbc:name="ACZ81_RS04755" fbc:label="G_ACZ81_RS04755">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS04755">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_061484976.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS07420" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS07420" fbc:name="ACZ81_RS07420" fbc:label="G_ACZ81_RS07420">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS07420">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_061485424.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS02185" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS02185" fbc:name="ACZ81_RS02185" fbc:label="G_ACZ81_RS02185">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS02185">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_061439269.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS06705" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS06705" fbc:name="ACZ81_RS06705" fbc:label="G_ACZ81_RS06705">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS06705">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014976067.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS06285" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS06285" fbc:name="ACZ81_RS06285" fbc:label="G_ACZ81_RS06285">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS06285">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_061485222.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS03935" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS03935" fbc:name="ACZ81_RS03935" fbc:label="G_ACZ81_RS03935">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS03935">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_061484788.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS05315" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS05315" fbc:name="ACZ81_RS05315" fbc:label="G_ACZ81_RS05315">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS05315">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_061485046.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS05310" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS05310" fbc:name="ACZ81_RS05310" fbc:label="G_ACZ81_RS05310">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS05310">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_061485044.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS13000" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS13000" fbc:name="ACZ81_RS13000" fbc:label="G_ACZ81_RS13000">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS13000">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_061486144.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS15450" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS15450" fbc:name="ACZ81_RS15450" fbc:label="G_ACZ81_RS15450">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS15450">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_061486475.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS19665" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS19665" fbc:name="ACZ81_RS19665" fbc:label="G_ACZ81_RS19665">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS19665">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_061486855.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS14595" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS14595" fbc:name="ACZ81_RS14595" fbc:label="G_ACZ81_RS14595">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS14595">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014980012.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS00970" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS00970" fbc:name="ACZ81_RS00970" fbc:label="G_ACZ81_RS00970">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS00970">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014947878.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS04940" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS04940" fbc:name="ACZ81_RS04940" fbc:label="G_ACZ81_RS04940">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS04940">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014978557.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS19355" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS19355" fbc:name="ACZ81_RS19355" fbc:label="G_ACZ81_RS19355">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS19355">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014951320.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS14465" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS14465" fbc:name="ACZ81_RS14465" fbc:label="G_ACZ81_RS14465">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS14465">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014950360.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS14470" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS14470" fbc:name="ACZ81_RS14470" fbc:label="G_ACZ81_RS14470">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS14470">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_061486367.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS01715" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS01715" fbc:name="ACZ81_RS01715" fbc:label="G_ACZ81_RS01715">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS01715">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014975446.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS11740" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS11740" fbc:name="ACZ81_RS11740" fbc:label="G_ACZ81_RS11740">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS11740">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014949850.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS15045" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS15045" fbc:name="ACZ81_RS15045" fbc:label="G_ACZ81_RS15045">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS15045">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_061486431.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS17835" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS17835" fbc:name="ACZ81_RS17835" fbc:label="G_ACZ81_RS17835">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS17835">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_061486691.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS11975" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS11975" fbc:name="ACZ81_RS11975" fbc:label="G_ACZ81_RS11975">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS11975">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014976852.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS00640" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS00640" fbc:name="ACZ81_RS00640" fbc:label="G_ACZ81_RS00640">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS00640">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_061438980.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS03705" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS03705" fbc:name="ACZ81_RS03705" fbc:label="G_ACZ81_RS03705">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS03705">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014948338.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS00790" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS00790" fbc:name="ACZ81_RS00790" fbc:label="G_ACZ81_RS00790">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS00790">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014977961.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS06505" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS06505" fbc:name="ACZ81_RS06505" fbc:label="G_ACZ81_RS06505">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS06505">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_061485264.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS05815" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS05815" fbc:name="ACZ81_RS05815" fbc:label="G_ACZ81_RS05815">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS05815">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_061485138.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS03105" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS03105" fbc:name="ACZ81_RS03105" fbc:label="G_ACZ81_RS03105">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS03105">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014978293.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS03455" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS03455" fbc:name="ACZ81_RS03455" fbc:label="G_ACZ81_RS03455">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS03455">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_061439571.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS03425" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS03425" fbc:name="ACZ81_RS03425" fbc:label="G_ACZ81_RS03425">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS03425">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014948296.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS01640" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS01640" fbc:name="ACZ81_RS01640" fbc:label="G_ACZ81_RS01640">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS01640">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_061439205.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS18860" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS18860" fbc:name="ACZ81_RS18860" fbc:label="G_ACZ81_RS18860">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS18860">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_061486778.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS00315" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS00315" fbc:name="ACZ81_RS00315" fbc:label="G_ACZ81_RS00315">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS00315">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014947766.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS06680" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS06680" fbc:name="ACZ81_RS06680" fbc:label="G_ACZ81_RS06680">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS06680">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_061485299.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS08695" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS08695" fbc:name="ACZ81_RS08695" fbc:label="G_ACZ81_RS08695">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS08695">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_061485710.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS14755" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS14755" fbc:name="ACZ81_RS14755" fbc:label="G_ACZ81_RS14755">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS14755">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014950427.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS16020" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS16020" fbc:name="ACZ81_RS16020" fbc:label="G_ACZ81_RS16020">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS16020">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_061486531.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS15875" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS15875" fbc:name="ACZ81_RS15875" fbc:label="G_ACZ81_RS15875">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS15875">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_061486512.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS16350" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS16350" fbc:name="ACZ81_RS16350" fbc:label="G_ACZ81_RS16350">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS16350">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014980323.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS14645" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS14645" fbc:name="ACZ81_RS14645" fbc:label="G_ACZ81_RS14645">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS14645">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014950394.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS13015" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS13015" fbc:name="ACZ81_RS13015" fbc:label="G_ACZ81_RS13015">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS13015">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014950086.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS01520" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS01520" fbc:name="ACZ81_RS01520" fbc:label="G_ACZ81_RS01520">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS01520">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_061439188.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS16640" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS16640" fbc:name="ACZ81_RS16640" fbc:label="G_ACZ81_RS16640">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS16640">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014977459.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS12205" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS12205" fbc:name="ACZ81_RS12205" fbc:label="G_ACZ81_RS12205">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS12205">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_061486077.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS02045" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS02045" fbc:name="ACZ81_RS02045" fbc:label="G_ACZ81_RS02045">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS02045">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_061439245.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS17825" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS17825" fbc:name="ACZ81_RS17825" fbc:label="G_ACZ81_RS17825">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS17825">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014977593.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS18150" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS18150" fbc:name="ACZ81_RS18150" fbc:label="G_ACZ81_RS18150">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS18150">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_061486718.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS07930" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS07930" fbc:name="ACZ81_RS07930" fbc:label="G_ACZ81_RS07930">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS07930">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014976218.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS02710" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS02710" fbc:name="ACZ81_RS02710" fbc:label="G_ACZ81_RS02710">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS02710">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_039231980.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS08435" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS08435" fbc:name="ACZ81_RS08435" fbc:label="G_ACZ81_RS08435">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS08435">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014979096.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS14540" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS14540" fbc:name="ACZ81_RS14540" fbc:label="G_ACZ81_RS14540">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS14540">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_061486379.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS15455" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS15455" fbc:name="ACZ81_RS15455" fbc:label="G_ACZ81_RS15455">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS15455">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_061486476.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS05495" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS05495" fbc:name="ACZ81_RS05495" fbc:label="G_ACZ81_RS05495">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS05495">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_061485079.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS09465" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS09465" fbc:name="ACZ81_RS09465" fbc:label="G_ACZ81_RS09465">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS09465">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_061485817.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS16105" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS16105" fbc:name="ACZ81_RS16105" fbc:label="G_ACZ81_RS16105">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS16105">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_061486536.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS04840" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS04840" fbc:name="ACZ81_RS04840" fbc:label="G_ACZ81_RS04840">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS04840">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014948554.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS07785" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS07785" fbc:name="ACZ81_RS07785" fbc:label="G_ACZ81_RS07785">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS07785">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014976192.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS12995" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS12995" fbc:name="ACZ81_RS12995" fbc:label="G_ACZ81_RS12995">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS12995">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_061486143.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS06695" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS06695" fbc:name="ACZ81_RS06695" fbc:label="G_ACZ81_RS06695">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS06695">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_061485303.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS15375" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS15375" fbc:name="ACZ81_RS15375" fbc:label="G_ACZ81_RS15375">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS15375">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_170826515.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS05305" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS05305" fbc:name="ACZ81_RS05305" fbc:label="G_ACZ81_RS05305">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS05305">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_039224879.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS14775" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS14775" fbc:name="ACZ81_RS14775" fbc:label="G_ACZ81_RS14775">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS14775">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_061486404.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS07780" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS07780" fbc:name="ACZ81_RS07780" fbc:label="G_ACZ81_RS07780">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS07780">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_061485519.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS00965" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS00965" fbc:name="ACZ81_RS00965" fbc:label="G_ACZ81_RS00965">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS00965">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014975371.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS01785" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS01785" fbc:name="ACZ81_RS01785" fbc:label="G_ACZ81_RS01785">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS01785">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014975459.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS01990" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS01990" fbc:name="ACZ81_RS01990" fbc:label="G_ACZ81_RS01990">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS01990">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_061439230.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS00155" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS00155" fbc:name="ACZ81_RS00155" fbc:label="G_ACZ81_RS00155">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS00155">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014977872.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS13105" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS13105" fbc:name="ACZ81_RS13105" fbc:label="G_ACZ81_RS13105">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS13105">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014950103.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS08760" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS08760" fbc:name="ACZ81_RS08760" fbc:label="G_ACZ81_RS08760">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS08760">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014949255.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS12350" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS12350" fbc:name="ACZ81_RS12350" fbc:label="G_ACZ81_RS12350">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS12350">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_061486093.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS17275" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS17275" fbc:name="ACZ81_RS17275" fbc:label="G_ACZ81_RS17275">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS17275">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_039226687.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS19935" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS19935" fbc:name="ACZ81_RS19935" fbc:label="G_ACZ81_RS19935">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS19935">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_015000154.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS03260" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS03260" fbc:name="ACZ81_RS03260" fbc:label="G_ACZ81_RS03260">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS03260">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014948265.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS18015" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS18015" fbc:name="ACZ81_RS18015" fbc:label="G_ACZ81_RS18015">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS18015">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_039229319.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS18020" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS18020" fbc:name="ACZ81_RS18020" fbc:label="G_ACZ81_RS18020">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS18020">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014977618.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS03305" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS03305" fbc:name="ACZ81_RS03305" fbc:label="G_ACZ81_RS03305">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS03305">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014948273.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS00975" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS00975" fbc:name="ACZ81_RS00975" fbc:label="G_ACZ81_RS00975">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS00975">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_061439037.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS02315" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS02315" fbc:name="ACZ81_RS02315" fbc:label="G_ACZ81_RS02315">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS02315">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_061439282.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS11415" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS11415" fbc:name="ACZ81_RS11415" fbc:label="G_ACZ81_RS11415">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS11415">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_061486019.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS09275" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS09275" fbc:name="ACZ81_RS09275" fbc:label="G_ACZ81_RS09275">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS09275">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_061485799.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS09770" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS09770" fbc:name="ACZ81_RS09770" fbc:label="G_ACZ81_RS09770">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS09770">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014949444.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS13180" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS13180" fbc:name="ACZ81_RS13180" fbc:label="G_ACZ81_RS13180">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS13180">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_061486990.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS04885" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS04885" fbc:name="ACZ81_RS04885" fbc:label="G_ACZ81_RS04885">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS04885">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014948563.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS14300" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS14300" fbc:name="ACZ81_RS14300" fbc:label="G_ACZ81_RS14300">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS14300">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_061486346.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS15165" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS15165" fbc:name="ACZ81_RS15165" fbc:label="G_ACZ81_RS15165">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS15165">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_061486444.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS07870" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS07870" fbc:name="ACZ81_RS07870" fbc:label="G_ACZ81_RS07870">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS07870">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_061485542.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS07830" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS07830" fbc:name="ACZ81_RS07830" fbc:label="G_ACZ81_RS07830">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS07830">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014976199.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS14060" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS14060" fbc:name="ACZ81_RS14060" fbc:label="G_ACZ81_RS14060">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS14060">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_061486310.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS12500" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS12500" fbc:name="ACZ81_RS12500" fbc:label="G_ACZ81_RS12500">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS12500">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014976912.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS06670" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS06670" fbc:name="ACZ81_RS06670" fbc:label="G_ACZ81_RS06670">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS06670">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_061485295.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS18260" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS18260" fbc:name="ACZ81_RS18260" fbc:label="G_ACZ81_RS18260">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS18260">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_061486730.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS09390" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS09390" fbc:name="ACZ81_RS09390" fbc:label="G_ACZ81_RS09390">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS09390">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_061485810.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS07920" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS07920" fbc:name="ACZ81_RS07920" fbc:label="G_ACZ81_RS07920">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS07920">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_061485557.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS18125" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS18125" fbc:name="ACZ81_RS18125" fbc:label="G_ACZ81_RS18125">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS18125">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014977631.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS16120" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS16120" fbc:name="ACZ81_RS16120" fbc:label="G_ACZ81_RS16120">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS16120">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014949480.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS00615" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS00615" fbc:name="ACZ81_RS00615" fbc:label="G_ACZ81_RS00615">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS00615">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_061438970.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS12130" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS12130" fbc:name="ACZ81_RS12130" fbc:label="G_ACZ81_RS12130">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS12130">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_061486070.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS08715" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS08715" fbc:name="ACZ81_RS08715" fbc:label="G_ACZ81_RS08715">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS08715">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_061485715.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS04815" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS04815" fbc:name="ACZ81_RS04815" fbc:label="G_ACZ81_RS04815">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS04815">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014948549.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS10770" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS10770" fbc:name="ACZ81_RS10770" fbc:label="G_ACZ81_RS10770">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS10770">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014949662.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS02060" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS02060" fbc:name="ACZ81_RS02060" fbc:label="G_ACZ81_RS02060">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS02060">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_061486910.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS13300" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS13300" fbc:name="ACZ81_RS13300" fbc:label="G_ACZ81_RS13300">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS13300">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_061486166.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS12180" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS12180" fbc:name="ACZ81_RS12180" fbc:label="G_ACZ81_RS12180">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS12180">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014949923.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS17830" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS17830" fbc:name="ACZ81_RS17830" fbc:label="G_ACZ81_RS17830">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS17830">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_061486690.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS16285" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS16285" fbc:name="ACZ81_RS16285" fbc:label="G_ACZ81_RS16285">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS16285">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_039227383.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS16290" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS16290" fbc:name="ACZ81_RS16290" fbc:label="G_ACZ81_RS16290">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS16290">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014950719.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS19100" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS19100" fbc:name="ACZ81_RS19100" fbc:label="G_ACZ81_RS19100">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS19100">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_061487015.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS17260" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS17260" fbc:name="ACZ81_RS17260" fbc:label="G_ACZ81_RS17260">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS17260">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014950904.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS09755" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS09755" fbc:name="ACZ81_RS09755" fbc:label="G_ACZ81_RS09755">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS09755">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_061485856.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS15535" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS15535" fbc:name="ACZ81_RS15535" fbc:label="G_ACZ81_RS15535">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS15535">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014950585.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS11195" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS11195" fbc:name="ACZ81_RS11195" fbc:label="G_ACZ81_RS11195">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS11195">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_061485997.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS11190" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS11190" fbc:name="ACZ81_RS11190" fbc:label="G_ACZ81_RS11190">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS11190">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_061485996.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS18155" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS18155" fbc:name="ACZ81_RS18155" fbc:label="G_ACZ81_RS18155">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS18155">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_061486719.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS00500" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS00500" fbc:name="ACZ81_RS00500" fbc:label="G_ACZ81_RS00500">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS00500">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_061438948.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS05520" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS05520" fbc:name="ACZ81_RS05520" fbc:label="G_ACZ81_RS05520">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS05520">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_061485082.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS18275" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS18275" fbc:name="ACZ81_RS18275" fbc:label="G_ACZ81_RS18275">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS18275">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014951087.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS12140" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS12140" fbc:name="ACZ81_RS12140" fbc:label="G_ACZ81_RS12140">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS12140">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014949916.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS01215" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS01215" fbc:name="ACZ81_RS01215" fbc:label="G_ACZ81_RS01215">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS01215">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_061439110.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS18750" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS18750" fbc:name="ACZ81_RS18750" fbc:label="G_ACZ81_RS18750">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS18750">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_061486768.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS11755" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS11755" fbc:name="ACZ81_RS11755" fbc:label="G_ACZ81_RS11755">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS11755">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014949853.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS00310" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS00310" fbc:name="ACZ81_RS00310" fbc:label="G_ACZ81_RS00310">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS00310">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014977894.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS07080" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS07080" fbc:name="ACZ81_RS07080" fbc:label="G_ACZ81_RS07080">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS07080">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014976121.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS02050" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS02050" fbc:name="ACZ81_RS02050" fbc:label="G_ACZ81_RS02050">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS02050">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_061439246.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS11490" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS11490" fbc:name="ACZ81_RS11490" fbc:label="G_ACZ81_RS11490">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS11490">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_061486024.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS10685" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS10685" fbc:name="ACZ81_RS10685" fbc:label="G_ACZ81_RS10685">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS10685">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014949645.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS09235" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS09235" fbc:name="ACZ81_RS09235" fbc:label="G_ACZ81_RS09235">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS09235">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014949336.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS10900" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS10900" fbc:name="ACZ81_RS10900" fbc:label="G_ACZ81_RS10900">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS10900">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_061485960.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS07465" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS07465" fbc:name="ACZ81_RS07465" fbc:label="G_ACZ81_RS07465">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS07465">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014976172.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS13310" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS13310" fbc:name="ACZ81_RS13310" fbc:label="G_ACZ81_RS13310">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS13310">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_061486167.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS02825" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS02825" fbc:name="ACZ81_RS02825" fbc:label="G_ACZ81_RS02825">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS02825">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014948183.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS13695" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS13695" fbc:name="ACZ81_RS13695" fbc:label="G_ACZ81_RS13695">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS13695">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_061486201.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS12375" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS12375" fbc:name="ACZ81_RS12375" fbc:label="G_ACZ81_RS12375">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS12375">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014949961.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS05945" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS05945" fbc:name="ACZ81_RS05945" fbc:label="G_ACZ81_RS05945">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS05945">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014948774.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS14165" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS14165" fbc:name="ACZ81_RS14165" fbc:label="G_ACZ81_RS14165">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS14165">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014950300.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS19470" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS19470" fbc:name="ACZ81_RS19470" fbc:label="G_ACZ81_RS19470">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS19470">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014980724.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS12805" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS12805" fbc:name="ACZ81_RS12805" fbc:label="G_ACZ81_RS12805">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS12805">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_061486124.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS11355" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS11355" fbc:name="ACZ81_RS11355" fbc:label="G_ACZ81_RS11355">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS11355">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014949774.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS00480" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS00480" fbc:name="ACZ81_RS00480" fbc:label="G_ACZ81_RS00480">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS00480">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_061438943.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS10895" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS10895" fbc:name="ACZ81_RS10895" fbc:label="G_ACZ81_RS10895">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS10895">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_061485959.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS00490" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS00490" fbc:name="ACZ81_RS00490" fbc:label="G_ACZ81_RS00490">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS00490">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_061438944.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS19535" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS19535" fbc:name="ACZ81_RS19535" fbc:label="G_ACZ81_RS19535">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS19535">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_061487021.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS03120" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS03120" fbc:name="ACZ81_RS03120" fbc:label="G_ACZ81_RS03120">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS03120">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_061439513.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS19010" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS19010" fbc:name="ACZ81_RS19010" fbc:label="G_ACZ81_RS19010">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS19010">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014951264.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS19000" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS19000" fbc:name="ACZ81_RS19000" fbc:label="G_ACZ81_RS19000">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS19000">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_061486797.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS19005" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS19005" fbc:name="ACZ81_RS19005" fbc:label="G_ACZ81_RS19005">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS19005">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014980664.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS18995" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS18995" fbc:name="ACZ81_RS18995" fbc:label="G_ACZ81_RS18995">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS18995">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_012520077.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS18605" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS18605" fbc:name="ACZ81_RS18605" fbc:label="G_ACZ81_RS18605">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS18605">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_061486755.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS17475" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS17475" fbc:name="ACZ81_RS17475" fbc:label="G_ACZ81_RS17475">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS17475">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014980453.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS18610" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS18610" fbc:name="ACZ81_RS18610" fbc:label="G_ACZ81_RS18610">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS18610">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_061486756.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS17480" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS17480" fbc:name="ACZ81_RS17480" fbc:label="G_ACZ81_RS17480">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS17480">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014950934.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS02890" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS02890" fbc:name="ACZ81_RS02890" fbc:label="G_ACZ81_RS02890">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS02890">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_061439425.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS10380" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS10380" fbc:name="ACZ81_RS10380" fbc:label="G_ACZ81_RS10380">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS10380">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014949590.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS10375" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS10375" fbc:name="ACZ81_RS10375" fbc:label="G_ACZ81_RS10375">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS10375">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014949589.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS03190" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS03190" fbc:name="ACZ81_RS03190" fbc:label="G_ACZ81_RS03190">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS03190">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014975671.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS10385" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS10385" fbc:name="ACZ81_RS10385" fbc:label="G_ACZ81_RS10385">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS10385">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014949591.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS10390" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS10390" fbc:name="ACZ81_RS10390" fbc:label="G_ACZ81_RS10390">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS10390">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014949592.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS10405" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS10405" fbc:name="ACZ81_RS10405" fbc:label="G_ACZ81_RS10405">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS10405">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014949594.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS16025" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS16025" fbc:name="ACZ81_RS16025" fbc:label="G_ACZ81_RS16025">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS16025">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_061487006.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS19835" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS19835" fbc:name="ACZ81_RS19835" fbc:label="G_ACZ81_RS19835">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS19835">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014951448.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS19845" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS19845" fbc:name="ACZ81_RS19845" fbc:label="G_ACZ81_RS19845">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS19845">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_012520217.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS19860" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS19860" fbc:name="ACZ81_RS19860" fbc:label="G_ACZ81_RS19860">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS19860">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014951452.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS19855" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS19855" fbc:name="ACZ81_RS19855" fbc:label="G_ACZ81_RS19855">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS19855">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014951451.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS19875" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS19875" fbc:name="ACZ81_RS19875" fbc:label="G_ACZ81_RS19875">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS19875">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014977839.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS19865" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS19865" fbc:name="ACZ81_RS19865" fbc:label="G_ACZ81_RS19865">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS19865">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_012520222.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS19870" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS19870" fbc:name="ACZ81_RS19870" fbc:label="G_ACZ81_RS19870">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS19870">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_012520223.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS19850" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS19850" fbc:name="ACZ81_RS19850" fbc:label="G_ACZ81_RS19850">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS19850">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014951450.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS19840" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS19840" fbc:name="ACZ81_RS19840" fbc:label="G_ACZ81_RS19840">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS19840">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_039221268.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
       <fbc:geneProduct metaid="meta_G_ACZ81_RS20260" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS20260" fbc:name="ACZ81_RS20260" fbc:label="G_ACZ81_RS20260"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS03665" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS03665" fbc:name="ACZ81_RS03665" fbc:label="G_ACZ81_RS03665"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS03670" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS03670" fbc:name="ACZ81_RS03670" fbc:label="G_ACZ81_RS03670"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS19555" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS19555" fbc:name="ACZ81_RS19555" fbc:label="G_ACZ81_RS19555"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS19565" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS19565" fbc:name="ACZ81_RS19565" fbc:label="G_ACZ81_RS19565"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS19570" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS19570" fbc:name="ACZ81_RS19570" fbc:label="G_ACZ81_RS19570"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS11345" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS11345" fbc:name="ACZ81_RS11345" fbc:label="G_ACZ81_RS11345"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS11365" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS11365" fbc:name="ACZ81_RS11365" fbc:label="G_ACZ81_RS11365"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS10885" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS10885" fbc:name="ACZ81_RS10885" fbc:label="G_ACZ81_RS10885"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS08460" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS08460" fbc:name="ACZ81_RS08460" fbc:label="G_ACZ81_RS08460"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS00290" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS00290" fbc:name="ACZ81_RS00290" fbc:label="G_ACZ81_RS00290"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS15200" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS15200" fbc:name="ACZ81_RS15200" fbc:label="G_ACZ81_RS15200"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS06675" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS06675" fbc:name="ACZ81_RS06675" fbc:label="G_ACZ81_RS06675"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS00880" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS00880" fbc:name="ACZ81_RS00880" fbc:label="G_ACZ81_RS00880"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS00475" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS00475" fbc:name="ACZ81_RS00475" fbc:label="G_ACZ81_RS00475"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS07790" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS07790" fbc:name="ACZ81_RS07790" fbc:label="G_ACZ81_RS07790"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS04765" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS04765" fbc:name="ACZ81_RS04765" fbc:label="G_ACZ81_RS04765"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS16605" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS16605" fbc:name="ACZ81_RS16605" fbc:label="G_ACZ81_RS16605"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS16610" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS16610" fbc:name="ACZ81_RS16610" fbc:label="G_ACZ81_RS16610"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS16595" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS16595" fbc:name="ACZ81_RS16595" fbc:label="G_ACZ81_RS16595"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS14545" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS14545" fbc:name="ACZ81_RS14545" fbc:label="G_ACZ81_RS14545"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS13475" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS13475" fbc:name="ACZ81_RS13475" fbc:label="G_ACZ81_RS13475"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS11680" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS11680" fbc:name="ACZ81_RS11680" fbc:label="G_ACZ81_RS11680"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS15510" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS15510" fbc:name="ACZ81_RS15510" fbc:label="G_ACZ81_RS15510"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS03450" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS03450" fbc:name="ACZ81_RS03450" fbc:label="G_ACZ81_RS03450"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS09285" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS09285" fbc:name="ACZ81_RS09285" fbc:label="G_ACZ81_RS09285"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS13840" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS13840" fbc:name="ACZ81_RS13840" fbc:label="G_ACZ81_RS13840"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS13825" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS13825" fbc:name="ACZ81_RS13825" fbc:label="G_ACZ81_RS13825"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS06030" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS06030" fbc:name="ACZ81_RS06030" fbc:label="G_ACZ81_RS06030"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS06035" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS06035" fbc:name="ACZ81_RS06035" fbc:label="G_ACZ81_RS06035"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS09985" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS09985" fbc:name="ACZ81_RS09985" fbc:label="G_ACZ81_RS09985"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS11460" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS11460" fbc:name="ACZ81_RS11460" fbc:label="G_ACZ81_RS11460"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS16805" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS16805" fbc:name="ACZ81_RS16805" fbc:label="G_ACZ81_RS16805"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS00905" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS00905" fbc:name="ACZ81_RS00905" fbc:label="G_ACZ81_RS00905"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS15195" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS15195" fbc:name="ACZ81_RS15195" fbc:label="G_ACZ81_RS15195"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS06665" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS06665" fbc:name="ACZ81_RS06665" fbc:label="G_ACZ81_RS06665"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS16590" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS16590" fbc:name="ACZ81_RS16590" fbc:label="G_ACZ81_RS16590"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS19530" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS19530" fbc:name="ACZ81_RS19530" fbc:label="G_ACZ81_RS19530"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS18990" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS18990" fbc:name="ACZ81_RS18990" fbc:label="G_ACZ81_RS18990"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS16600" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS16600" fbc:name="ACZ81_RS16600" fbc:label="G_ACZ81_RS16600"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS05790" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS05790" fbc:name="ACZ81_RS05790" fbc:label="G_ACZ81_RS05790"/>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS03665" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS03665" fbc:name="ACZ81_RS03665" fbc:label="G_ACZ81_RS03665">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS03665">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_049586157.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS03670" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS03670" fbc:name="ACZ81_RS03670" fbc:label="G_ACZ81_RS03670">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS03670">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014948332.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS19555" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS19555" fbc:name="ACZ81_RS19555" fbc:label="G_ACZ81_RS19555">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS19555">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014951383.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS19565" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS19565" fbc:name="ACZ81_RS19565" fbc:label="G_ACZ81_RS19565">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS19565">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_039228778.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS19570" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS19570" fbc:name="ACZ81_RS19570" fbc:label="G_ACZ81_RS19570">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS19570">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_081106125.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS11345" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS11345" fbc:name="ACZ81_RS11345" fbc:label="G_ACZ81_RS11345">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS11345">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014949772.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS11365" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS11365" fbc:name="ACZ81_RS11365" fbc:label="G_ACZ81_RS11365">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS11365">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_061486013.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS10885" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS10885" fbc:name="ACZ81_RS10885" fbc:label="G_ACZ81_RS10885">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS10885">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_061485957.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS08460" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS08460" fbc:name="ACZ81_RS08460" fbc:label="G_ACZ81_RS08460">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS08460">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_061485677.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS00290" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS00290" fbc:name="ACZ81_RS00290" fbc:label="G_ACZ81_RS00290">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS00290">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_061438902.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS15200" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS15200" fbc:name="ACZ81_RS15200" fbc:label="G_ACZ81_RS15200">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS15200">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_061487000.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS06675" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS06675" fbc:name="ACZ81_RS06675" fbc:label="G_ACZ81_RS06675">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS06675">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_061485297.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS00880" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS00880" fbc:name="ACZ81_RS00880" fbc:label="G_ACZ81_RS00880">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS00880">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014975357.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS00475" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS00475" fbc:name="ACZ81_RS00475" fbc:label="G_ACZ81_RS00475">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS00475">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_061438940.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS07790" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS07790" fbc:name="ACZ81_RS07790" fbc:label="G_ACZ81_RS07790">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS07790">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_061485521.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS04765" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS04765" fbc:name="ACZ81_RS04765" fbc:label="G_ACZ81_RS04765">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS04765">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_061484980.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS16605" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS16605" fbc:name="ACZ81_RS16605" fbc:label="G_ACZ81_RS16605">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS16605">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_039228642.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS16610" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS16610" fbc:name="ACZ81_RS16610" fbc:label="G_ACZ81_RS16610">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS16610">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014950780.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS16595" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS16595" fbc:name="ACZ81_RS16595" fbc:label="G_ACZ81_RS16595">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS16595">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_081106114.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS14545" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS14545" fbc:name="ACZ81_RS14545" fbc:label="G_ACZ81_RS14545">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS14545">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_061486380.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS13475" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS13475" fbc:name="ACZ81_RS13475" fbc:label="G_ACZ81_RS13475">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS13475">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014950167.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS11680" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS11680" fbc:name="ACZ81_RS11680" fbc:label="G_ACZ81_RS11680">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS11680">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014949838.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS15510" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS15510" fbc:name="ACZ81_RS15510" fbc:label="G_ACZ81_RS15510">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS15510">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_039235311.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS03450" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS03450" fbc:name="ACZ81_RS03450" fbc:label="G_ACZ81_RS03450">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS03450">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_061439570.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS09285" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS09285" fbc:name="ACZ81_RS09285" fbc:label="G_ACZ81_RS09285">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS09285">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014976409.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS13840" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS13840" fbc:name="ACZ81_RS13840" fbc:label="G_ACZ81_RS13840">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS13840">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_061486250.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS13825" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS13825" fbc:name="ACZ81_RS13825" fbc:label="G_ACZ81_RS13825">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS13825">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_081106102.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS06030" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS06030" fbc:name="ACZ81_RS06030" fbc:label="G_ACZ81_RS06030">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS06030">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014975995.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS06035" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS06035" fbc:name="ACZ81_RS06035" fbc:label="G_ACZ81_RS06035">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS06035">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_061485161.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS09985" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS09985" fbc:name="ACZ81_RS09985" fbc:label="G_ACZ81_RS09985">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS09985">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014949501.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS11460" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS11460" fbc:name="ACZ81_RS11460" fbc:label="G_ACZ81_RS11460">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS11460">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014949793.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS16805" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS16805" fbc:name="ACZ81_RS16805" fbc:label="G_ACZ81_RS16805">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS16805">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014980378.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS00905" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS00905" fbc:name="ACZ81_RS00905" fbc:label="G_ACZ81_RS00905">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS00905">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_061439033.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS15195" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS15195" fbc:name="ACZ81_RS15195" fbc:label="G_ACZ81_RS15195">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS15195">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014950514.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS06665" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS06665" fbc:name="ACZ81_RS06665" fbc:label="G_ACZ81_RS06665">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS06665">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_061485293.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS16590" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS16590" fbc:name="ACZ81_RS16590" fbc:label="G_ACZ81_RS16590">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS16590">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014977452.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS19530" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS19530" fbc:name="ACZ81_RS19530" fbc:label="G_ACZ81_RS19530">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS19530">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014980735.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS18990" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS18990" fbc:name="ACZ81_RS18990" fbc:label="G_ACZ81_RS18990">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS18990">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_061486796.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS16600" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS16600" fbc:name="ACZ81_RS16600" fbc:label="G_ACZ81_RS16600">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS16600">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_061486583.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS05790" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS05790" fbc:name="ACZ81_RS05790" fbc:label="G_ACZ81_RS05790">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS05790">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_232375997.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
       <fbc:geneProduct metaid="meta_G_ACZ81_RS20290" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS20290" fbc:name="ACZ81_RS20290" fbc:label="G_ACZ81_RS20290"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS02665" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS02665" fbc:name="ACZ81_RS02665" fbc:label="G_ACZ81_RS02665"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS13515" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS13515" fbc:name="ACZ81_RS13515" fbc:label="G_ACZ81_RS13515"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS13535" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS13535" fbc:name="ACZ81_RS13535" fbc:label="G_ACZ81_RS13535"/>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS02665" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS02665" fbc:name="ACZ81_RS02665" fbc:label="G_ACZ81_RS02665">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS02665">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_061439380.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS13515" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS13515" fbc:name="ACZ81_RS13515" fbc:label="G_ACZ81_RS13515">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS13515">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_039231541.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS13535" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS13535" fbc:name="ACZ81_RS13535" fbc:label="G_ACZ81_RS13535">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS13535">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_061486181.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
     </fbc:listOfGeneProducts>
   </model>
 </sbml>

--- a/model.xml
+++ b/model.xml
@@ -65308,7 +65308,19 @@
           </rdf:RDF>
         </annotation>
       </fbc:geneProduct>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS20365" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS20365" fbc:name="ACZ81_RS20365" fbc:label="G_ACZ81_RS20365"/>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS20365" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS20365" fbc:name="ACZ81_RS20365" fbc:label="G_ACZ81_RS20365">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS20365">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014996986.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
       <fbc:geneProduct metaid="meta_G_ACZ81_RS14835" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS14835" fbc:name="ACZ81_RS14835" fbc:label="G_ACZ81_RS14835">
         <annotation>
           <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
@@ -70409,7 +70421,19 @@
           </rdf:RDF>
         </annotation>
       </fbc:geneProduct>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS20180" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS20180" fbc:name="ACZ81_RS20180" fbc:label="G_ACZ81_RS20180"/>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS20180" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS20180" fbc:name="ACZ81_RS20180" fbc:label="G_ACZ81_RS20180">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS20180">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_012516877.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
       <fbc:geneProduct metaid="meta_G_ACZ81_RS15345" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS15345" fbc:name="ACZ81_RS15345" fbc:label="G_ACZ81_RS15345">
         <annotation>
           <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
@@ -74181,7 +74205,19 @@
           </rdf:RDF>
         </annotation>
       </fbc:geneProduct>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS20260" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS20260" fbc:name="ACZ81_RS20260" fbc:label="G_ACZ81_RS20260"/>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS20260" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS20260" fbc:name="ACZ81_RS20260" fbc:label="G_ACZ81_RS20260">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS20260">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_061487034.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
       <fbc:geneProduct metaid="meta_G_ACZ81_RS03665" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS03665" fbc:name="ACZ81_RS03665" fbc:label="G_ACZ81_RS03665">
         <annotation>
           <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
@@ -74702,7 +74738,19 @@
           </rdf:RDF>
         </annotation>
       </fbc:geneProduct>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS20290" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS20290" fbc:name="ACZ81_RS20290" fbc:label="G_ACZ81_RS20290"/>
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS20290" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS20290" fbc:name="ACZ81_RS20290" fbc:label="G_ACZ81_RS20290">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_ACZ81_RS20290">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_061487036.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
       <fbc:geneProduct metaid="meta_G_ACZ81_RS02665" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS02665" fbc:name="ACZ81_RS02665" fbc:label="G_ACZ81_RS02665">
         <annotation>
           <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">

--- a/model.xml
+++ b/model.xml
@@ -36056,7 +36056,6 @@
             <fbc:geneProductRef fbc:geneProduct="G_ACZ81_RS10600"/>
             <fbc:geneProductRef fbc:geneProduct="G_ACZ81_RS07955"/>
             <fbc:geneProductRef fbc:geneProduct="G_ACZ81_RS02680"/>
-            <fbc:geneProductRef fbc:geneProduct="G_ACZ81_RS20695"/>
             <fbc:geneProductRef fbc:geneProduct="G_ACZ81_RS17310"/>
             <fbc:geneProductRef fbc:geneProduct="G_ACZ81_RS01685"/>
             <fbc:geneProductRef fbc:geneProduct="G_ACZ81_RS06385"/>
@@ -68299,7 +68298,6 @@
           </rdf:RDF>
         </annotation>
       </fbc:geneProduct>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS20695" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS20695" fbc:name="ACZ81_RS20695" fbc:label="G_ACZ81_RS20695"/>
       <fbc:geneProduct metaid="meta_G_ACZ81_RS17310" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS17310" fbc:name="ACZ81_RS17310" fbc:label="G_ACZ81_RS17310">
         <annotation>
           <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">

--- a/model.xml
+++ b/model.xml
@@ -27395,11 +27395,7 @@
           <speciesReference species="M_cpd00067_c0" stoichiometry="1" constant="true"/>
         </listOfProducts>
         <fbc:geneProductAssociation>
-          <fbc:and>
-            <fbc:geneProductRef fbc:geneProduct="G_ACZ81_RS20710"/>
-            <fbc:geneProductRef fbc:geneProduct="G_ACZ81_RS20210"/>
-            <fbc:geneProductRef fbc:geneProduct="G_ACZ81_RS10400"/>
-          </fbc:and>
+          <fbc:geneProductRef fbc:geneProduct="G_ACZ81_RS10400"/>
         </fbc:geneProductAssociation>
       </reaction>
       <reaction metaid="meta_R_rxn03535_c0" sboTerm="SBO:0000176" id="R_rxn03535_c0" name="ATP:cob(I)yrinic acid-a,c-diamide Cobeta-adenosyltransferase [c0]" reversible="false" fast="false" fbc:lowerFluxBound="cobra_0_bound" fbc:upperFluxBound="cobra_default_ub">
@@ -32158,10 +32154,7 @@
           <speciesReference species="M_cpd00292_c0" stoichiometry="1" constant="true"/>
         </listOfProducts>
         <fbc:geneProductAssociation>
-          <fbc:and>
-            <fbc:geneProductRef fbc:geneProduct="G_ACZ81_RS03575"/>
-            <fbc:geneProductRef fbc:geneProduct="G_ACZ81_RS17610"/>
-          </fbc:and>
+          <fbc:geneProductRef fbc:geneProduct="G_ACZ81_RS03575"/>
         </fbc:geneProductAssociation>
       </reaction>
       <reaction metaid="meta_R_rxn00555_c0" sboTerm="SBO:0000176" id="R_rxn00555_c0" name="L-glutamine:D-fructose-6-phosphate isomerase (deaminating) [c0]" reversible="true" fast="false" fbc:lowerFluxBound="cobra_default_lb" fbc:upperFluxBound="cobra_default_ub">
@@ -44101,11 +44094,7 @@
           <speciesReference species="M_cpd00067_c0" stoichiometry="1" constant="true"/>
         </listOfProducts>
         <fbc:geneProductAssociation>
-          <fbc:and>
-            <fbc:geneProductRef fbc:geneProduct="G_ACZ81_RS20710"/>
-            <fbc:geneProductRef fbc:geneProduct="G_ACZ81_RS20210"/>
-            <fbc:geneProductRef fbc:geneProduct="G_ACZ81_RS10400"/>
-          </fbc:and>
+          <fbc:geneProductRef fbc:geneProduct="G_ACZ81_RS10400"/>
         </fbc:geneProductAssociation>
       </reaction>
       <reaction metaid="meta_R_rxn00791_c0" sboTerm="SBO:0000176" id="R_rxn00791_c0" name="N-(5-Phospho-D-ribosyl)anthranilate:pyrophosphate phosphoribosyl-transferase [c0]" reversible="true" fast="false" fbc:lowerFluxBound="cobra_default_lb" fbc:upperFluxBound="cobra_0_bound">
@@ -45574,7 +45563,6 @@
             <fbc:and>
               <fbc:geneProductRef fbc:geneProduct="G_ACZ81_RS00380"/>
               <fbc:geneProductRef fbc:geneProduct="G_ACZ81_RS10215"/>
-              <fbc:geneProductRef fbc:geneProduct="G_ACZ81_RS18560"/>
             </fbc:and>
             <fbc:geneProductRef fbc:geneProduct="G_ACZ81_RS12555"/>
             <fbc:geneProductRef fbc:geneProduct="G_ACZ81_RS15420"/>
@@ -65698,8 +65686,6 @@
           </rdf:RDF>
         </annotation>
       </fbc:geneProduct>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS20710" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS20710" fbc:name="ACZ81_RS20710" fbc:label="G_ACZ81_RS20710"/>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS20210" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS20210" fbc:name="ACZ81_RS20210" fbc:label="G_ACZ81_RS20210"/>
       <fbc:geneProduct metaid="meta_G_ACZ81_RS10400" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS10400" fbc:name="ACZ81_RS10400" fbc:label="G_ACZ81_RS10400">
         <annotation>
           <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
@@ -67312,7 +67298,6 @@
           </rdf:RDF>
         </annotation>
       </fbc:geneProduct>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS17610" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS17610" fbc:name="ACZ81_RS17610" fbc:label="G_ACZ81_RS17610"/>
       <fbc:geneProduct metaid="meta_G_ACZ81_RS18845" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS18845" fbc:name="ACZ81_RS18845" fbc:label="G_ACZ81_RS18845">
         <annotation>
           <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
@@ -71448,7 +71433,6 @@
           </rdf:RDF>
         </annotation>
       </fbc:geneProduct>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS18560" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS18560" fbc:name="ACZ81_RS18560" fbc:label="G_ACZ81_RS18560"/>
       <fbc:geneProduct metaid="meta_G_ACZ81_RS12555" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS12555" fbc:name="ACZ81_RS12555" fbc:label="G_ACZ81_RS12555">
         <annotation>
           <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">


### PR DESCRIPTION
This pull request:
- Adds RefSeq non-redundant protein accessions as annotations to all of the genes that are currently in the model (except for those mentioned below)
- Removes `ACZ81_RS20710` and `ACZ81_RS20210` from the GPRs of `rxn05528_c0` and `rxn10481_c0`
- Removes `ACZ81_RS17610` from the GPR of `rxn01501_c0`
- Removes `ACZ81_RS18560` from the GPR of `rxn05209_c0`
- Removes `ACZ81_RS20695` from the GPR of `rxn05296_c0`
- Removes `ACZ81_RS20710`, `ACZ81_RS20210`, `ACZ81_RS17610`, `ACZ81_RS18560`, and `ACZ81_RS20695` from the model

These changes will facilitate [mapping genes between models](https://github.com/C-CoMP-STC/GEM-mit1002/pull/223) for different strains of _Alteromonas macleodii_.

`ACZ81_RS20710`, `ACZ81_RS20210`, `ACZ81_RS17610`, and `ACZ81_RS18560` were all annotated as pseudogenes, and `rxn05528_c0`, `rxn10481_c0`, `rxn01501_c0`, and `rxn05209_c0` all had other genes in their GPRs, so removing these genes does not leave any reactions in the model associated with no genes. I couldn't find `ACZ81_RS20695` in any of the genome annotation files for HOT1A3 on RefSeq, so I don't even know if it's a real gene, and `rxn05296_c0` has plenty of other genes in its GPR, so I'm just removing it from the model. If someone figures out which gene it is and which protein it encodes later, it'll be easy to add it back.