### PR TITLE
Feat: remove reactions, metabolites, and genes that were removed from the MIT1002 model

### DIFF
--- a/model.xml
+++ b/model.xml
@@ -3531,25 +3531,6 @@
           </rdf:RDF>
         </annotation>
       </species>
-      <species metaid="meta_M_cpd02654_c0" sboTerm="SBO:0000247" id="M_cpd02654_c0" name="4-Methyl-5--2-phosphoethyl-thiazole [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-2" fbc:chemicalFormula="C6H8NO4PS">
-        <annotation>
-          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
-            <rdf:Description rdf:about="#meta_M_cpd02654_c0">
-              <bqbiol:is>
-                <rdf:Bag>
-                  <rdf:li rdf:resource="https://identifiers.org/seed.compound/cpd02654"/>
-                  <rdf:li rdf:resource="https://identifiers.org/inchi/InChI=1S/C6H10NO4PS/c1-5-6(13-4-7-5)2-3-11-12(8,9)10/h4H,2-3H2,1H3,(H2,8,9,10)/p-2"/>
-                  <rdf:li rdf:resource="https://identifiers.org/inchikey/OCYMERZCMYJQQO-UHFFFAOYSA-L"/>
-                  <rdf:li rdf:resource="https://identifiers.org/bigg.metabolite/4mpetz"/>
-                  <rdf:li rdf:resource="https://identifiers.org/kegg.compound/C04327"/>
-                  <rdf:li rdf:resource="https://identifiers.org/metanetx.chemical/MNXM960"/>
-                  <rdf:li rdf:resource="https://identifiers.org/biocyc/META:THZ-P"/>
-                </rdf:Bag>
-              </bqbiol:is>
-            </rdf:Description>
-          </rdf:RDF>
-        </annotation>
-      </species>
       <species metaid="meta_M_cpd02894_c0" sboTerm="SBO:0000247" id="M_cpd02894_c0" name="4-Amino-2-methyl-5-diphosphomethylpyrimidine [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-2" fbc:chemicalFormula="C6H9N3O7P2">
         <annotation>
           <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
@@ -7570,24 +7551,6 @@
           </rdf:RDF>
         </annotation>
       </species>
-      <species metaid="meta_M_cpd11836_c0" sboTerm="SBO:0000247" id="M_cpd11836_c0" name="(R)-3-Hydroxyacyl-[acyl-carrier protein] [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-1" fbc:chemicalFormula="C15H27N2O9PRS">
-        <annotation>
-          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
-            <rdf:Description rdf:about="#meta_M_cpd11836_c0">
-              <bqbiol:is>
-                <rdf:Bag>
-                  <rdf:li rdf:resource="https://identifiers.org/seed.compound/cpd11836"/>
-                  <rdf:li rdf:resource="https://identifiers.org/bigg.metabolite/3haACP"/>
-                  <rdf:li rdf:resource="https://identifiers.org/kegg.compound/C01271"/>
-                  <rdf:li rdf:resource="https://identifiers.org/metanetx.chemical/MNXM5861"/>
-                  <rdf:li rdf:resource="https://identifiers.org/biocyc/META:3R-hydroxy-meromycolyl-ACP"/>
-                  <rdf:li rdf:resource="https://identifiers.org/biocyc/META:OH-ACYL-ACP"/>
-                </rdf:Bag>
-              </bqbiol:is>
-            </rdf:Description>
-          </rdf:RDF>
-        </annotation>
-      </species>
       <species metaid="meta_M_cpd00770_c0" sboTerm="SBO:0000247" id="M_cpd00770_c0" name="N-Formyl-L-glutamate [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-2" fbc:chemicalFormula="C6H7NO5">
         <annotation>
           <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
@@ -8413,26 +8376,6 @@
           </rdf:RDF>
         </annotation>
       </species>
-      <species metaid="meta_M_cpd02120_c0" sboTerm="SBO:0000247" id="M_cpd02120_c0" name="Dihydrodipicolinate [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-2" fbc:chemicalFormula="C7H5NO4">
-        <annotation>
-          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
-            <rdf:Description rdf:about="#meta_M_cpd02120_c0">
-              <bqbiol:is>
-                <rdf:Bag>
-                  <rdf:li rdf:resource="https://identifiers.org/seed.compound/cpd02120"/>
-                  <rdf:li rdf:resource="https://identifiers.org/inchi/InChI=1S/C7H7NO4/c9-6(10)4-2-1-3-5(8-4)7(11)12/h1-2,5H,3H2,(H,9,10)(H,11,12)/p-2/t5-/m0/s1"/>
-                  <rdf:li rdf:resource="https://identifiers.org/inchikey/UWOCFOFVIBZJGH-YFKPBYRVSA-L"/>
-                  <rdf:li rdf:resource="https://identifiers.org/bigg.metabolite/23dhdp"/>
-                  <rdf:li rdf:resource="https://identifiers.org/kegg.compound/C03340"/>
-                  <rdf:li rdf:resource="https://identifiers.org/metanetx.chemical/MNXM807"/>
-                  <rdf:li rdf:resource="https://identifiers.org/metanetx.chemical/MNXM50760"/>
-                  <rdf:li rdf:resource="https://identifiers.org/biocyc/META:2-3-DIHYDRODIPICOLINATE"/>
-                </rdf:Bag>
-              </bqbiol:is>
-            </rdf:Description>
-          </rdf:RDF>
-        </annotation>
-      </species>
       <species metaid="meta_M_cpd15309_c0" sboTerm="SBO:0000247" id="M_cpd15309_c0" name="1,2-Diacyl-sn-glycerol dihexadecanoyl [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="0" fbc:chemicalFormula="C35H68O5">
         <annotation>
           <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
@@ -9125,25 +9068,6 @@
                   <rdf:li rdf:resource="https://identifiers.org/kegg.compound/C00447"/>
                   <rdf:li rdf:resource="https://identifiers.org/metanetx.chemical/MNXM1294"/>
                   <rdf:li rdf:resource="https://identifiers.org/biocyc/META:D-SEDOHEPTULOSE-1-7-P2"/>
-                </rdf:Bag>
-              </bqbiol:is>
-            </rdf:Description>
-          </rdf:RDF>
-        </annotation>
-      </species>
-      <species metaid="meta_M_cpd00190_c0" sboTerm="SBO:0000247" id="M_cpd00190_c0" name="beta-D-Glucose [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="0" fbc:chemicalFormula="C6H12O6">
-        <annotation>
-          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
-            <rdf:Description rdf:about="#meta_M_cpd00190_c0">
-              <bqbiol:is>
-                <rdf:Bag>
-                  <rdf:li rdf:resource="https://identifiers.org/seed.compound/cpd00190"/>
-                  <rdf:li rdf:resource="https://identifiers.org/inchi/InChI=1S/C6H12O6/c7-1-2-3(8)4(9)5(10)6(11)12-2/h2-11H,1H2/t2-,3-,4+,5-,6-/m1/s1"/>
-                  <rdf:li rdf:resource="https://identifiers.org/inchikey/WQZGKKKJIJFFOK-VFUOTHLCSA-N"/>
-                  <rdf:li rdf:resource="https://identifiers.org/kegg.compound/C00221"/>
-                  <rdf:li rdf:resource="https://identifiers.org/metanetx.chemical/MNXM105"/>
-                  <rdf:li rdf:resource="https://identifiers.org/biocyc/META:B-XGLC-HEX-1:5_6:A"/>
-                  <rdf:li rdf:resource="https://identifiers.org/biocyc/META:GLC"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -10127,20 +10051,6 @@
                   <rdf:li rdf:resource="https://identifiers.org/metanetx.chemical/MNXM78210"/>
                   <rdf:li rdf:resource="https://identifiers.org/metanetx.chemical/MNXM650"/>
                   <rdf:li rdf:resource="https://identifiers.org/biocyc/META:ACRYLYL-COA"/>
-                </rdf:Bag>
-              </bqbiol:is>
-            </rdf:Description>
-          </rdf:RDF>
-        </annotation>
-      </species>
-      <species metaid="meta_M_cpd15360_c0" sboTerm="SBO:0000247" id="M_cpd15360_c0" name="2-Octaprenyl-3-methyl-5-hydroxy-6-methoxy-1,4-benzoquinol [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="0" fbc:chemicalFormula="C48H74O4">
-        <annotation>
-          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
-            <rdf:Description rdf:about="#meta_M_cpd15360_c0">
-              <bqbiol:is>
-                <rdf:Bag>
-                  <rdf:li rdf:resource="https://identifiers.org/seed.compound/cpd15360"/>
-                  <rdf:li rdf:resource="https://identifiers.org/bigg.metabolite/2omhmbl"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -13196,26 +13106,6 @@
           </rdf:RDF>
         </annotation>
       </species>
-      <species metaid="meta_M_cpd01914_c0" sboTerm="SBO:0000247" id="M_cpd01914_c0" name="L-Methionine S-oxide [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="0" fbc:chemicalFormula="C5H11NO3S">
-        <annotation>
-          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
-            <rdf:Description rdf:about="#meta_M_cpd01914_c0">
-              <bqbiol:is>
-                <rdf:Bag>
-                  <rdf:li rdf:resource="https://identifiers.org/seed.compound/cpd01914"/>
-                  <rdf:li rdf:resource="https://identifiers.org/inchi/InChI=1S/C5H11NO3S/c1-10(9)3-2-4(6)5(7)8/h4H,2-3,6H2,1H3,(H,7,8)/t4-,10?/m0/s1"/>
-                  <rdf:li rdf:resource="https://identifiers.org/inchikey/QEFRNWWLZKMPFJ-YGVKFDHGSA-N"/>
-                  <rdf:li rdf:resource="https://identifiers.org/bigg.metabolite/metsox_S__L"/>
-                  <rdf:li rdf:resource="https://identifiers.org/kegg.compound/C02989"/>
-                  <rdf:li rdf:resource="https://identifiers.org/metanetx.chemical/MNXM2246"/>
-                  <rdf:li rdf:resource="https://identifiers.org/biocyc/META:CPD0-1959"/>
-                  <rdf:li rdf:resource="https://identifiers.org/biocyc/META:L-Methionine-sulfoxides"/>
-                </rdf:Bag>
-              </bqbiol:is>
-            </rdf:Description>
-          </rdf:RDF>
-        </annotation>
-      </species>
       <species metaid="meta_M_cpd00109_c0" sboTerm="SBO:0000247" id="M_cpd00109_c0" name="Cytochrome c3+ [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="5" fbc:chemicalFormula="C42H52FeN8O6S2">
         <annotation>
           <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
@@ -14350,34 +14240,6 @@
           </rdf:RDF>
         </annotation>
       </species>
-      <species metaid="meta_M_cpd15371_c0" sboTerm="SBO:0000247" id="M_cpd15371_c0" name="R-3-Hydroxyoctadecanoyl-acyl-carrierprotein- [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-1" fbc:chemicalFormula="C29H55N2O9PRS">
-        <annotation>
-          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
-            <rdf:Description rdf:about="#meta_M_cpd15371_c0">
-              <bqbiol:is>
-                <rdf:Bag>
-                  <rdf:li rdf:resource="https://identifiers.org/seed.compound/cpd15371"/>
-                  <rdf:li rdf:resource="https://identifiers.org/bigg.metabolite/3hoctaACP"/>
-                </rdf:Bag>
-              </bqbiol:is>
-            </rdf:Description>
-          </rdf:RDF>
-        </annotation>
-      </species>
-      <species metaid="meta_M_cpd15572_c0" sboTerm="SBO:0000247" id="M_cpd15572_c0" name="trans-octadec-2-enoyl-[acyl-carrier protein] [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-1" fbc:chemicalFormula="C29H53N2O8PRS">
-        <annotation>
-          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
-            <rdf:Description rdf:about="#meta_M_cpd15572_c0">
-              <bqbiol:is>
-                <rdf:Bag>
-                  <rdf:li rdf:resource="https://identifiers.org/seed.compound/cpd15572"/>
-                  <rdf:li rdf:resource="https://identifiers.org/bigg.metabolite/toctd2eACP"/>
-                </rdf:Bag>
-              </bqbiol:is>
-            </rdf:Description>
-          </rdf:RDF>
-        </annotation>
-      </species>
       <species metaid="meta_M_cpd00142_c0" sboTerm="SBO:0000247" id="M_cpd00142_c0" name="Acetoacetate [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-1" fbc:chemicalFormula="C4H5O3">
         <annotation>
           <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
@@ -14777,44 +14639,6 @@
           </rdf:RDF>
         </annotation>
       </species>
-      <species metaid="meta_M_cpd15359_c0" sboTerm="SBO:0000247" id="M_cpd15359_c0" name="2-Octaprenyl-6-methoxy-1,4-benzoquinol [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="0" fbc:chemicalFormula="C47H72O3">
-        <annotation>
-          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
-            <rdf:Description rdf:about="#meta_M_cpd15359_c0">
-              <bqbiol:is>
-                <rdf:Bag>
-                  <rdf:li rdf:resource="https://identifiers.org/seed.compound/cpd15359"/>
-                  <rdf:li rdf:resource="https://identifiers.org/inchi/InChI=1S/C47H72O3/c1-36(2)18-11-19-37(3)20-12-21-38(4)22-13-23-39(5)24-14-25-40(6)26-15-27-41(7)28-16-29-42(8)30-17-31-43(9)32-33-44-34-45(48)35-46(50-10)47(44)49/h18,20,22,24,26,28,30,32,34-35,48-49H,11-17,19,21,23,25,27,29,31,33H2,1-10H3/b37-20+,38-22+,39-24+,40-26+,41-28+,42-30+,43-32+"/>
-                  <rdf:li rdf:resource="https://identifiers.org/inchikey/CZFRMASEEPTBAQ-MYCGWMCTSA-N"/>
-                  <rdf:li rdf:resource="https://identifiers.org/bigg.metabolite/2ombzl"/>
-                  <rdf:li rdf:resource="https://identifiers.org/bigg.metabolite/2ombz"/>
-                  <rdf:li rdf:resource="https://identifiers.org/metanetx.chemical/MNXM90444"/>
-                  <rdf:li rdf:resource="https://identifiers.org/biocyc/META:OCTAPRENYL-METHOXY-BENZOQUINONE"/>
-                </rdf:Bag>
-              </bqbiol:is>
-            </rdf:Description>
-          </rdf:RDF>
-        </annotation>
-      </species>
-      <species metaid="meta_M_cpd15361_c0" sboTerm="SBO:0000247" id="M_cpd15361_c0" name="2-Octaprenyl3-methyl-6-methoxy- 1,4-benzoquinol [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="0" fbc:chemicalFormula="C48H74O3">
-        <annotation>
-          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
-            <rdf:Description rdf:about="#meta_M_cpd15361_c0">
-              <bqbiol:is>
-                <rdf:Bag>
-                  <rdf:li rdf:resource="https://identifiers.org/seed.compound/cpd15361"/>
-                  <rdf:li rdf:resource="https://identifiers.org/inchi/InChI=1S/C48H74O3/c1-36(2)19-12-20-37(3)21-13-22-38(4)23-14-24-39(5)25-15-26-40(6)27-16-28-41(7)29-17-30-42(8)31-18-32-43(9)33-34-45-44(10)46(49)35-47(51-11)48(45)50/h19,21,23,25,27,29,31,33,35,49-50H,12-18,20,22,24,26,28,30,32,34H2,1-11H3/b37-21+,38-23+,39-25+,40-27+,41-29+,42-31+,43-33+"/>
-                  <rdf:li rdf:resource="https://identifiers.org/inchikey/HDSGDGSLNMIMKU-KFSSTAEESA-N"/>
-                  <rdf:li rdf:resource="https://identifiers.org/bigg.metabolite/2ommb"/>
-                  <rdf:li rdf:resource="https://identifiers.org/bigg.metabolite/2ommbl"/>
-                  <rdf:li rdf:resource="https://identifiers.org/metanetx.chemical/MNXM1899"/>
-                  <rdf:li rdf:resource="https://identifiers.org/biocyc/META:OCTAPRENYL-METHYL-METHOXY-BENZQ"/>
-                </rdf:Bag>
-              </bqbiol:is>
-            </rdf:Description>
-          </rdf:RDF>
-        </annotation>
-      </species>
       <species metaid="meta_M_cpd00142_e0" sboTerm="SBO:0000247" id="M_cpd00142_e0" name="Acetoacetate [e0]" compartment="e0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-1" fbc:chemicalFormula="C4H5O3">
         <annotation>
           <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
@@ -15150,24 +14974,6 @@
           </rdf:RDF>
         </annotation>
       </species>
-      <species metaid="meta_M_cpd14720_c0" sboTerm="SBO:0000247" id="M_cpd14720_c0" name="L-Methionine (R)-S-oxide [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="0" fbc:chemicalFormula="C5H11NO3S">
-        <annotation>
-          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
-            <rdf:Description rdf:about="#meta_M_cpd14720_c0">
-              <bqbiol:is>
-                <rdf:Bag>
-                  <rdf:li rdf:resource="https://identifiers.org/seed.compound/cpd14720"/>
-                  <rdf:li rdf:resource="https://identifiers.org/inchi/InChI=1S/C5H11NO3S/c1-10(9)3-2-4(6)5(7)8/h4H,2-3,6H2,1H3,(H,7,8)/t4-,10+/m0/s1"/>
-                  <rdf:li rdf:resource="https://identifiers.org/inchikey/QEFRNWWLZKMPFJ-ZXPFJRLXSA-N"/>
-                  <rdf:li rdf:resource="https://identifiers.org/kegg.compound/C15998"/>
-                  <rdf:li rdf:resource="https://identifiers.org/metanetx.chemical/MNXM2245"/>
-                  <rdf:li rdf:resource="https://identifiers.org/biocyc/META:CPD-8990"/>
-                </rdf:Bag>
-              </bqbiol:is>
-            </rdf:Description>
-          </rdf:RDF>
-        </annotation>
-      </species>
       <species metaid="meta_M_cpd00162_c0" sboTerm="SBO:0000247" id="M_cpd00162_c0" name="Aminoethanol [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="1" fbc:chemicalFormula="C2H8NO">
         <annotation>
           <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
@@ -15258,27 +15064,6 @@
                   <rdf:li rdf:resource="https://identifiers.org/kegg.compound/C00817"/>
                   <rdf:li rdf:resource="https://identifiers.org/metanetx.chemical/MNXM2011"/>
                   <rdf:li rdf:resource="https://identifiers.org/biocyc/META:D-ALTRONATE"/>
-                </rdf:Bag>
-              </bqbiol:is>
-            </rdf:Description>
-          </rdf:RDF>
-        </annotation>
-      </species>
-      <species metaid="meta_M_cpd03422_c0" sboTerm="SBO:0000247" id="M_cpd03422_c0" name="Cobinamide [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="3" fbc:chemicalFormula="C48H75CoN11O8">
-        <annotation>
-          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
-            <rdf:Description rdf:about="#meta_M_cpd03422_c0">
-              <bqbiol:is>
-                <rdf:Bag>
-                  <rdf:li rdf:resource="https://identifiers.org/seed.compound/cpd03422"/>
-                  <rdf:li rdf:resource="https://identifiers.org/inchi/InChI=1S/C48H73N11O8.Co/c1-23(60)22-55-38(67)16-17-45(6)29(18-35(52)64)43-48(9)47(8,21-37(54)66)28(12-15-34(51)63)40(59-48)25(3)42-46(7,20-36(53)65)26(10-13-32(49)61)30(56-42)19-31-44(4,5)27(11-14-33(50)62)39(57-31)24(2)41(45)58-43;/h19,23,26-29,43,60H,10-18,20-22H2,1-9H3,(H14,49,50,51,52,53,54,55,56,57,58,59,61,62,63,64,65,66,67);/q;+1/p-1/t23-,26-,27-,28-,29+,43-,45-,46+,47+,48+;/m1./s1"/>
-                  <rdf:li rdf:resource="https://identifiers.org/inchikey/XQRJFEVDQXEIAX-JFYQDRLCSA-M"/>
-                  <rdf:li rdf:resource="https://identifiers.org/bigg.metabolite/cbi"/>
-                  <rdf:li rdf:resource="https://identifiers.org/kegg.compound/C05774"/>
-                  <rdf:li rdf:resource="https://identifiers.org/metanetx.chemical/MNXM1549"/>
-                  <rdf:li rdf:resource="https://identifiers.org/metanetx.chemical/MNXM90619"/>
-                  <rdf:li rdf:resource="https://identifiers.org/metanetx.chemical/MNXM47455"/>
-                  <rdf:li rdf:resource="https://identifiers.org/biocyc/META:COBINAMIDE"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -16654,36 +16439,6 @@
                 <rdf:Bag>
                   <rdf:li rdf:resource="https://identifiers.org/seed.compound/cpd15672"/>
                   <rdf:li rdf:resource="https://identifiers.org/metanetx.chemical/MNXM9603"/>
-                </rdf:Bag>
-              </bqbiol:is>
-            </rdf:Description>
-          </rdf:RDF>
-        </annotation>
-      </species>
-      <species metaid="meta_M_cpd12237_c0" sboTerm="SBO:0000247" id="M_cpd12237_c0" name="Peptide-L-methionine [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="0" fbc:chemicalFormula="C6H10N2O2R2S">
-        <annotation>
-          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
-            <rdf:Description rdf:about="#meta_M_cpd12237_c0">
-              <bqbiol:is>
-                <rdf:Bag>
-                  <rdf:li rdf:resource="https://identifiers.org/seed.compound/cpd12237"/>
-                  <rdf:li rdf:resource="https://identifiers.org/kegg.compound/C03023"/>
-                  <rdf:li rdf:resource="https://identifiers.org/metanetx.chemical/MNXM163551"/>
-                </rdf:Bag>
-              </bqbiol:is>
-            </rdf:Description>
-          </rdf:RDF>
-        </annotation>
-      </species>
-      <species metaid="meta_M_cpd14507_c0" sboTerm="SBO:0000247" id="M_cpd14507_c0" name="Peptide-L-methionine (R)-S-oxide [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="0" fbc:chemicalFormula="C6H10N2O3R2S">
-        <annotation>
-          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
-            <rdf:Description rdf:about="#meta_M_cpd14507_c0">
-              <bqbiol:is>
-                <rdf:Bag>
-                  <rdf:li rdf:resource="https://identifiers.org/seed.compound/cpd14507"/>
-                  <rdf:li rdf:resource="https://identifiers.org/kegg.compound/C15653"/>
-                  <rdf:li rdf:resource="https://identifiers.org/metanetx.chemical/MNXM21320"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -19533,50 +19288,6 @@
           </rdf:RDF>
         </annotation>
       </species>
-      <species metaid="meta_M_cpd28070_c0" sboTerm="SBO:0000247" id="M_cpd28070_c0" name="Reduced-Flavoproteins [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="0" fbc:chemicalFormula="C12H11N4O2R">
-        <annotation>
-          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
-            <rdf:Description rdf:about="#meta_M_cpd28070_c0">
-              <bqbiol:is>
-                <rdf:Bag>
-                  <rdf:li rdf:resource="https://identifiers.org/seed.compound/cpd28070"/>
-                  <rdf:li rdf:resource="https://identifiers.org/biocyc/META:Reduced-Flavoproteins"/>
-                </rdf:Bag>
-              </bqbiol:is>
-            </rdf:Description>
-          </rdf:RDF>
-        </annotation>
-      </species>
-      <species metaid="meta_M_cpd33817_c0" sboTerm="SBO:0000247" id="M_cpd33817_c0" name="Cbi(II) [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="2" fbc:chemicalFormula="C48H73CoN11O8">
-        <annotation>
-          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
-            <rdf:Description rdf:about="#meta_M_cpd33817_c0">
-              <bqbiol:is>
-                <rdf:Bag>
-                  <rdf:li rdf:resource="https://identifiers.org/seed.compound/cpd33817"/>
-                  <rdf:li rdf:resource="https://identifiers.org/inchi/InChI=1S/C48H73N11O8.Co/c1-23(60)22-55-38(67)16-17-45(6)29(18-35(52)64)43-48(9)47(8,21-37(54)66)28(12-15-34(51)63)40(59-48)25(3)42-46(7,20-36(53)65)26(10-13-32(49)61)30(56-42)19-31-44(4,5)27(11-14-33(50)62)39(57-31)24(2)41(45)58-43;/h19,23,26-29,43,60H,10-18,20-22H2,1-9H3,(H14,49,50,51,52,53,54,55,56,57,58,59,61,62,63,64,65,66,67);/q;+2/p-1/t23-,26-,27-,28-,29+,43-,45-,46+,47+,48+;/m1./s1"/>
-                  <rdf:li rdf:resource="https://identifiers.org/inchikey/GFVWZOGCSKVPRA-JFYQDRLCSA-M"/>
-                  <rdf:li rdf:resource="https://identifiers.org/biocyc/META:CPD-20903"/>
-                </rdf:Bag>
-              </bqbiol:is>
-            </rdf:Description>
-          </rdf:RDF>
-        </annotation>
-      </species>
-      <species metaid="meta_M_cpd27744_c0" sboTerm="SBO:0000247" id="M_cpd27744_c0" name="Oxidized-Flavoproteins [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="0" fbc:chemicalFormula="C12H9N4O2R">
-        <annotation>
-          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
-            <rdf:Description rdf:about="#meta_M_cpd27744_c0">
-              <bqbiol:is>
-                <rdf:Bag>
-                  <rdf:li rdf:resource="https://identifiers.org/seed.compound/cpd27744"/>
-                  <rdf:li rdf:resource="https://identifiers.org/biocyc/META:Oxidized-Flavoproteins"/>
-                </rdf:Bag>
-              </bqbiol:is>
-            </rdf:Description>
-          </rdf:RDF>
-        </annotation>
-      </species>
       <species metaid="meta_M_cpd12489_c0" sboTerm="SBO:0000247" id="M_cpd12489_c0" name="cis-3-Decenoyl-[acyl-carrier protein] [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-2" fbc:chemicalFormula="C21H37N2O8PRS">
         <annotation>
           <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
@@ -19673,25 +19384,6 @@
           </rdf:RDF>
         </annotation>
       </species>
-      <species metaid="meta_M_cpd22312_c0" sboTerm="SBO:0000247" id="M_cpd22312_c0" name="Adenylated-ThiS-Proteins [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="0" fbc:chemicalFormula="C14H19N7O9PR">
-        <annotation>
-          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
-            <rdf:Description rdf:about="#meta_M_cpd22312_c0">
-              <bqbiol:is>
-                <rdf:Bag>
-                  <rdf:li rdf:resource="https://identifiers.org/seed.compound/cpd22312"/>
-                  <rdf:li rdf:resource="https://identifiers.org/metanetx.chemical/MNXM8251"/>
-                  <rdf:li rdf:resource="https://identifiers.org/metanetx.chemical/MNXM147968"/>
-                  <rdf:li rdf:resource="https://identifiers.org/biocyc/META:Carboxyadenylated-TtuB"/>
-                  <rdf:li rdf:resource="https://identifiers.org/biocyc/META:Carboxyadenylated-URM1"/>
-                  <rdf:li rdf:resource="https://identifiers.org/biocyc/META:Carboxyadenylated-CysO"/>
-                  <rdf:li rdf:resource="https://identifiers.org/biocyc/META:Adenylated-ThiS-Proteins"/>
-                </rdf:Bag>
-              </bqbiol:is>
-            </rdf:Description>
-          </rdf:RDF>
-        </annotation>
-      </species>
       <species metaid="meta_M_cpd21480_c0" sboTerm="SBO:0000247" id="M_cpd21480_c0" name="2-(2-Carboxy-4-methylthiazol-5-yl)ethyl phosphate [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-3" fbc:chemicalFormula="C7H7NO6PS">
         <annotation>
           <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
@@ -19723,26 +19415,6 @@
                   <rdf:li rdf:resource="https://identifiers.org/kegg.compound/C06010"/>
                   <rdf:li rdf:resource="https://identifiers.org/metanetx.chemical/MNXM114079"/>
                   <rdf:li rdf:resource="https://identifiers.org/biocyc/META:2-ACETO-LACTATE"/>
-                </rdf:Bag>
-              </bqbiol:is>
-            </rdf:Description>
-          </rdf:RDF>
-        </annotation>
-      </species>
-      <species metaid="meta_M_cpd00635_c0" sboTerm="SBO:0000247" id="M_cpd00635_c0" name="Cbl [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="2" fbc:chemicalFormula="C62H91CoN13O14P">
-        <annotation>
-          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
-            <rdf:Description rdf:about="#meta_M_cpd00635_c0">
-              <bqbiol:is>
-                <rdf:Bag>
-                  <rdf:li rdf:resource="https://identifiers.org/seed.compound/cpd00635"/>
-                  <rdf:li rdf:resource="https://identifiers.org/inchi/InChI=1S/C62H90N13O14P.Co/c1-29-20-39-40(21-30(29)2)75(28-70-39)57-52(84)53(41(27-76)87-57)89-90(85,86)88-31(3)26-69-49(83)18-19-59(8)37(22-46(66)80)56-62(11)61(10,25-48(68)82)36(14-17-45(65)79)51(74-62)33(5)55-60(9,24-47(67)81)34(12-15-43(63)77)38(71-55)23-42-58(6,7)35(13-16-44(64)78)50(72-42)32(4)54(59)73-56;/h20-21,23,28,31,34-37,41,52-53,56-57,76,84H,12-19,22,24-27H2,1-11H3,(H15,63,64,65,66,67,68,69,71,72,73,74,77,78,79,80,81,82,83,85,86);/q;+1/p-2/t31-,34-,35-,36-,37+,41-,52-,53-,56-,57+,59-,60+,61+,62+;/m1./s1"/>
-                  <rdf:li rdf:resource="https://identifiers.org/inchikey/OMAOKVYASDIYQG-DSRCUDDDSA-L"/>
-                  <rdf:li rdf:resource="https://identifiers.org/bigg.metabolite/cbl1"/>
-                  <rdf:li rdf:resource="https://identifiers.org/kegg.compound/C00853"/>
-                  <rdf:li rdf:resource="https://identifiers.org/metanetx.chemical/MNXM91519"/>
-                  <rdf:li rdf:resource="https://identifiers.org/metanetx.chemical/MNXM90163"/>
-                  <rdf:li rdf:resource="https://identifiers.org/biocyc/META:COB-I-ALAMIN"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -19800,42 +19472,6 @@
                   <rdf:li rdf:resource="https://identifiers.org/kegg.compound/C15532"/>
                   <rdf:li rdf:resource="https://identifiers.org/metanetx.chemical/MNXM3314"/>
                   <rdf:li rdf:resource="https://identifiers.org/biocyc/META:CPD-7224"/>
-                </rdf:Bag>
-              </bqbiol:is>
-            </rdf:Description>
-          </rdf:RDF>
-        </annotation>
-      </species>
-      <species metaid="meta_M_cpd19001_c0" sboTerm="SBO:0000247" id="M_cpd19001_c0" name="alpha-D-Glucose [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="0" fbc:chemicalFormula="C6H12O6">
-        <annotation>
-          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
-            <rdf:Description rdf:about="#meta_M_cpd19001_c0">
-              <bqbiol:is>
-                <rdf:Bag>
-                  <rdf:li rdf:resource="https://identifiers.org/seed.compound/cpd19001"/>
-                  <rdf:li rdf:resource="https://identifiers.org/inchi/InChI=1S/C6H12O6/c7-1-2-3(8)4(9)5(10)6(11)12-2/h2-11H,1H2/t2-,3-,4+,5-,6+/m1/s1"/>
-                  <rdf:li rdf:resource="https://identifiers.org/inchikey/WQZGKKKJIJFFOK-DVKNGEFBSA-N"/>
-                  <rdf:li rdf:resource="https://identifiers.org/kegg.compound/C00267"/>
-                  <rdf:li rdf:resource="https://identifiers.org/metanetx.chemical/MNXM99"/>
-                  <rdf:li rdf:resource="https://identifiers.org/biocyc/META:ALPHA-GLUCOSE"/>
-                </rdf:Bag>
-              </bqbiol:is>
-            </rdf:Description>
-          </rdf:RDF>
-        </annotation>
-      </species>
-      <species metaid="meta_M_cpd19006_c0" sboTerm="SBO:0000247" id="M_cpd19006_c0" name="alpha-D-Glucose 6-phosphate [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-2" fbc:chemicalFormula="C6H11O9P">
-        <annotation>
-          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
-            <rdf:Description rdf:about="#meta_M_cpd19006_c0">
-              <bqbiol:is>
-                <rdf:Bag>
-                  <rdf:li rdf:resource="https://identifiers.org/seed.compound/cpd19006"/>
-                  <rdf:li rdf:resource="https://identifiers.org/inchi/InChI=1S/C6H13O9P/c7-3-2(1-14-16(11,12)13)15-6(10)5(9)4(3)8/h2-10H,1H2,(H2,11,12,13)/p-2/t2-,3-,4+,5-,6+/m1/s1"/>
-                  <rdf:li rdf:resource="https://identifiers.org/inchikey/NBSCHQHZLSJFNQ-DVKNGEFBSA-L"/>
-                  <rdf:li rdf:resource="https://identifiers.org/kegg.compound/C00668"/>
-                  <rdf:li rdf:resource="https://identifiers.org/metanetx.chemical/MNXM215"/>
-                  <rdf:li rdf:resource="https://identifiers.org/biocyc/META:ALPHA-GLC-6-P"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -20060,26 +19696,6 @@
           </rdf:RDF>
         </annotation>
       </species>
-      <species metaid="meta_M_cpd00635_e0" sboTerm="SBO:0000247" id="M_cpd00635_e0" name="Cbl [e0]" compartment="e0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="2" fbc:chemicalFormula="C62H91CoN13O14P">
-        <annotation>
-          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
-            <rdf:Description rdf:about="#meta_M_cpd00635_e0">
-              <bqbiol:is>
-                <rdf:Bag>
-                  <rdf:li rdf:resource="https://identifiers.org/seed.compound/cpd00635"/>
-                  <rdf:li rdf:resource="https://identifiers.org/inchi/InChI=1S/C62H90N13O14P.Co/c1-29-20-39-40(21-30(29)2)75(28-70-39)57-52(84)53(41(27-76)87-57)89-90(85,86)88-31(3)26-69-49(83)18-19-59(8)37(22-46(66)80)56-62(11)61(10,25-48(68)82)36(14-17-45(65)79)51(74-62)33(5)55-60(9,24-47(67)81)34(12-15-43(63)77)38(71-55)23-42-58(6,7)35(13-16-44(64)78)50(72-42)32(4)54(59)73-56;/h20-21,23,28,31,34-37,41,52-53,56-57,76,84H,12-19,22,24-27H2,1-11H3,(H15,63,64,65,66,67,68,69,71,72,73,74,77,78,79,80,81,82,83,85,86);/q;+1/p-2/t31-,34-,35-,36-,37+,41-,52-,53-,56-,57+,59-,60+,61+,62+;/m1./s1"/>
-                  <rdf:li rdf:resource="https://identifiers.org/inchikey/OMAOKVYASDIYQG-DSRCUDDDSA-L"/>
-                  <rdf:li rdf:resource="https://identifiers.org/bigg.metabolite/cbl1"/>
-                  <rdf:li rdf:resource="https://identifiers.org/kegg.compound/C00853"/>
-                  <rdf:li rdf:resource="https://identifiers.org/metanetx.chemical/MNXM91519"/>
-                  <rdf:li rdf:resource="https://identifiers.org/metanetx.chemical/MNXM90163"/>
-                  <rdf:li rdf:resource="https://identifiers.org/biocyc/META:COB-I-ALAMIN"/>
-                </rdf:Bag>
-              </bqbiol:is>
-            </rdf:Description>
-          </rdf:RDF>
-        </annotation>
-      </species>
       <species metaid="meta_M_cpd11640_c0" sboTerm="SBO:0000247" id="M_cpd11640_c0" name="H2 [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="0" fbc:chemicalFormula="H2">
         <annotation>
           <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
@@ -20297,26 +19913,6 @@
                   <rdf:li rdf:resource="https://identifiers.org/kegg.compound/C00315"/>
                   <rdf:li rdf:resource="https://identifiers.org/metanetx.chemical/MNXM124"/>
                   <rdf:li rdf:resource="https://identifiers.org/biocyc/META:SPERMIDINE"/>
-                </rdf:Bag>
-              </bqbiol:is>
-            </rdf:Description>
-          </rdf:RDF>
-        </annotation>
-      </species>
-      <species metaid="meta_M_cpd15807_c0" sboTerm="SBO:0000247" id="M_cpd15807_c0" name="2,5-diamino-6-ribitylamino-4(3H)-pyrimidinone 5&apos;-phosphate [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-2" fbc:chemicalFormula="C9H16N5O8P">
-        <annotation>
-          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
-            <rdf:Description rdf:about="#meta_M_cpd15807_c0">
-              <bqbiol:is>
-                <rdf:Bag>
-                  <rdf:li rdf:resource="https://identifiers.org/seed.compound/cpd15807"/>
-                  <rdf:li rdf:resource="https://identifiers.org/inchi/InChI=1S/C9H18N5O8P/c10-5-7(13-9(11)14-8(5)18)12-1-3(15)6(17)4(16)2-22-23(19,20)21/h3-4,6,15-17H,1-2,10H2,(H2,19,20,21)(H4,11,12,13,14,18)/p-2/t3-,4+,6-/m0/s1"/>
-                  <rdf:li rdf:resource="https://identifiers.org/inchikey/ACIVVGBVOVHFPQ-RPDRRWSUSA-L"/>
-                  <rdf:li rdf:resource="https://identifiers.org/bigg.metabolite/25dthpp"/>
-                  <rdf:li rdf:resource="https://identifiers.org/kegg.compound/C18910"/>
-                  <rdf:li rdf:resource="https://identifiers.org/metanetx.chemical/MNXM1099"/>
-                  <rdf:li rdf:resource="https://identifiers.org/metanetx.chemical/MNXM722877"/>
-                  <rdf:li rdf:resource="https://identifiers.org/biocyc/META:CPD-10809"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -20841,21 +20437,6 @@
           </rdf:RDF>
         </annotation>
       </species>
-      <species metaid="meta_M_cpd27713_c0" sboTerm="SBO:0000247" id="M_cpd27713_c0" name="Octanoylated-Gcv-H [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="1" fbc:chemicalFormula="C14H27N2O2R2">
-        <annotation>
-          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
-            <rdf:Description rdf:about="#meta_M_cpd27713_c0">
-              <bqbiol:is>
-                <rdf:Bag>
-                  <rdf:li rdf:resource="https://identifiers.org/seed.compound/cpd27713"/>
-                  <rdf:li rdf:resource="https://identifiers.org/metanetx.chemical/MNXM97429"/>
-                  <rdf:li rdf:resource="https://identifiers.org/biocyc/META:Octanoylated-Gcv-H"/>
-                </rdf:Bag>
-              </bqbiol:is>
-            </rdf:Description>
-          </rdf:RDF>
-        </annotation>
-      </species>
       <species metaid="meta_M_cpd35272_c0" sboTerm="SBO:0000247" id="M_cpd35272_c0" name="2-O-sulfo-alpha,alpha-trehalose [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-1" fbc:chemicalFormula="C12H21O14S">
         <annotation>
           <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
@@ -21012,55 +20593,6 @@
                   <rdf:li rdf:resource="https://identifiers.org/kegg.compound/C01013"/>
                   <rdf:li rdf:resource="https://identifiers.org/metanetx.chemical/MNXM872"/>
                   <rdf:li rdf:resource="https://identifiers.org/biocyc/META:3-HYDROXY-PROPIONATE"/>
-                </rdf:Bag>
-              </bqbiol:is>
-            </rdf:Description>
-          </rdf:RDF>
-        </annotation>
-      </species>
-      <species metaid="meta_M_cpd28205_c0" sboTerm="SBO:0000247" id="M_cpd28205_c0" name="Sulfur-Carrier-Proteins-ThiI [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="0" fbc:chemicalFormula="C3H5NOR2S">
-        <annotation>
-          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
-            <rdf:Description rdf:about="#meta_M_cpd28205_c0">
-              <bqbiol:is>
-                <rdf:Bag>
-                  <rdf:li rdf:resource="https://identifiers.org/seed.compound/cpd28205"/>
-                  <rdf:li rdf:resource="https://identifiers.org/metanetx.chemical/MNXM12970"/>
-                  <rdf:li rdf:resource="https://identifiers.org/biocyc/META:Sulfur-Carrier-Proteins-ThiI"/>
-                </rdf:Bag>
-              </bqbiol:is>
-            </rdf:Description>
-          </rdf:RDF>
-        </annotation>
-      </species>
-      <species metaid="meta_M_cpd14548_c0" sboTerm="SBO:0000247" id="M_cpd14548_c0" name="C15812 [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="0" fbc:chemicalFormula="C4H6N2O2S2R2">
-        <annotation>
-          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
-            <rdf:Description rdf:about="#meta_M_cpd14548_c0">
-              <bqbiol:is>
-                <rdf:Bag>
-                  <rdf:li rdf:resource="https://identifiers.org/seed.compound/cpd14548"/>
-                  <rdf:li rdf:resource="https://identifiers.org/kegg.compound/C15812"/>
-                  <rdf:li rdf:resource="https://identifiers.org/metanetx.chemical/MNXM147960"/>
-                  <rdf:li rdf:resource="https://identifiers.org/metanetx.chemical/MNXM147414"/>
-                  <rdf:li rdf:resource="https://identifiers.org/metanetx.chemical/MNXM147437"/>
-                  <rdf:li rdf:resource="https://identifiers.org/metanetx.chemical/MNXM163766"/>
-                  <rdf:li rdf:resource="https://identifiers.org/metanetx.chemical/MNXM146527"/>
-                  <rdf:li rdf:resource="https://identifiers.org/metanetx.chemical/MNXM147964"/>
-                  <rdf:li rdf:resource="https://identifiers.org/metanetx.chemical/MNXM3891"/>
-                  <rdf:li rdf:resource="https://identifiers.org/metanetx.chemical/MNXM147933"/>
-                  <rdf:li rdf:resource="https://identifiers.org/metanetx.chemical/MNXM163257"/>
-                  <rdf:li rdf:resource="https://identifiers.org/biocyc/META:L-Cysteine-Desulfurase-persulfide"/>
-                  <rdf:li rdf:resource="https://identifiers.org/biocyc/META:ENZYME-S-SULFANYLCYSTEINE"/>
-                  <rdf:li rdf:resource="https://identifiers.org/biocyc/META:TusD-Persulfides"/>
-                  <rdf:li rdf:resource="https://identifiers.org/biocyc/META:TtuD-S-sulfanyl-L-cysteine"/>
-                  <rdf:li rdf:resource="https://identifiers.org/biocyc/META:MOCS3-S-sulfanylcysteine"/>
-                  <rdf:li rdf:resource="https://identifiers.org/biocyc/META:TUM1-S-sulfanylcysteine"/>
-                  <rdf:li rdf:resource="https://identifiers.org/biocyc/META:TusA-Persulfides"/>
-                  <rdf:li rdf:resource="https://identifiers.org/biocyc/META:DsrE-Persulfides"/>
-                  <rdf:li rdf:resource="https://identifiers.org/biocyc/META:SoxY-S-Thiocysteine"/>
-                  <rdf:li rdf:resource="https://identifiers.org/biocyc/META:RhD-Persulfides"/>
-                  <rdf:li rdf:resource="https://identifiers.org/biocyc/META:Sulfurylated-ThiI"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -24960,38 +24492,6 @@
         </listOfProducts>
         <fbc:geneProductAssociation>
           <fbc:geneProductRef fbc:geneProduct="G_ACZ81_RS10640"/>
-        </fbc:geneProductAssociation>
-      </reaction>
-      <reaction metaid="meta_R_rxn02305_c0" sboTerm="SBO:0000176" id="R_rxn02305_c0" name="2-methyl-4-amino-5-hydroxymethylpyrimidine-diphosphate:4-methyl-5-(2-phosphoethyl)-thiazole 2-methyl-4-aminopyridine-5-methenyltransferase [c0]" reversible="false" fast="false" fbc:lowerFluxBound="cobra_0_bound" fbc:upperFluxBound="cobra_default_ub">
-        <annotation>
-          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
-            <rdf:Description rdf:about="#meta_R_rxn02305_c0">
-              <bqbiol:is>
-                <rdf:Bag>
-                  <rdf:li rdf:resource="https://identifiers.org/seed.reaction/rxn02305"/>
-                  <rdf:li rdf:resource="https://identifiers.org/bigg.reaction/TMPPP"/>
-                  <rdf:li rdf:resource="https://identifiers.org/bigg.reaction/THI6_2"/>
-                  <rdf:li rdf:resource="https://identifiers.org/kegg.reaction/R03223"/>
-                  <rdf:li rdf:resource="https://identifiers.org/rhea/22331"/>
-                  <rdf:li rdf:resource="https://identifiers.org/rhea/22329"/>
-                  <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR104908"/>
-                  <rdf:li rdf:resource="https://identifiers.org/biocyc/META:THI-P-SYN-RXN"/>
-                  <rdf:li rdf:resource="https://identifiers.org/ec-code/2.5.1.3"/>
-                </rdf:Bag>
-              </bqbiol:is>
-            </rdf:Description>
-          </rdf:RDF>
-        </annotation>
-        <listOfReactants>
-          <speciesReference species="M_cpd02654_c0" stoichiometry="1" constant="true"/>
-          <speciesReference species="M_cpd02894_c0" stoichiometry="1" constant="true"/>
-        </listOfReactants>
-        <listOfProducts>
-          <speciesReference species="M_cpd00012_c0" stoichiometry="1" constant="true"/>
-          <speciesReference species="M_cpd00793_c0" stoichiometry="1" constant="true"/>
-        </listOfProducts>
-        <fbc:geneProductAssociation>
-          <fbc:geneProductRef fbc:geneProduct="G_ACZ81_RS00495"/>
         </fbc:geneProductAssociation>
       </reaction>
       <reaction metaid="meta_R_rxn08817_c0" sboTerm="SBO:0000176" id="R_rxn08817_c0" name="Lysophospholipase L2 (2-acylglycerophosphotidate, n-C12:0) [c0]" reversible="true" fast="false" fbc:lowerFluxBound="cobra_default_lb" fbc:upperFluxBound="cobra_default_ub">
@@ -29916,32 +29416,6 @@
           </fbc:or>
         </fbc:geneProductAssociation>
       </reaction>
-      <reaction metaid="meta_R_rxn07981_c0" sboTerm="SBO:0000176" id="R_rxn07981_c0" name="3-hydroxyacyl-[acyl-carrier-protein] dehydratase (n-C4:0) [c0]" reversible="true" fast="false" fbc:lowerFluxBound="cobra_default_lb" fbc:upperFluxBound="cobra_default_ub">
-        <annotation>
-          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
-            <rdf:Description rdf:about="#meta_R_rxn07981_c0">
-              <bqbiol:is>
-                <rdf:Bag>
-                  <rdf:li rdf:resource="https://identifiers.org/seed.reaction/rxn07981"/>
-                  <rdf:li rdf:resource="https://identifiers.org/bigg.reaction/3HAD40"/>
-                  <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR94885"/>
-                  <rdf:li rdf:resource="https://identifiers.org/ec-code/4.2.1.58"/>
-                </rdf:Bag>
-              </bqbiol:is>
-            </rdf:Description>
-          </rdf:RDF>
-        </annotation>
-        <listOfReactants>
-          <speciesReference species="M_cpd11836_c0" stoichiometry="1" constant="true"/>
-        </listOfReactants>
-        <listOfProducts>
-          <speciesReference species="M_cpd00001_c0" stoichiometry="1" constant="true"/>
-          <speciesReference species="M_cpd11465_c0" stoichiometry="1" constant="true"/>
-        </listOfProducts>
-        <fbc:geneProductAssociation>
-          <fbc:geneProductRef fbc:geneProduct="G_ACZ81_RS10285"/>
-        </fbc:geneProductAssociation>
-      </reaction>
       <reaction metaid="meta_R_rxn00375_c0" sboTerm="SBO:0000176" id="R_rxn00375_c0" name="N-Formyl-L-glutamate amidohydrolase [c0]" reversible="true" fast="false" fbc:lowerFluxBound="cobra_default_lb" fbc:upperFluxBound="cobra_default_ub">
         <annotation>
           <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
@@ -30961,37 +30435,6 @@
         </listOfProducts>
         <fbc:geneProductAssociation>
           <fbc:geneProductRef fbc:geneProduct="G_ACZ81_RS03750"/>
-        </fbc:geneProductAssociation>
-      </reaction>
-      <reaction metaid="meta_R_rxn01644_c0" sboTerm="SBO:0000176" id="R_rxn01644_c0" name="L-Aspartate-4-semialdehyde hydro-lyase (adding pyruvate and cyclizing) [c0]" reversible="false" fast="false" fbc:lowerFluxBound="cobra_0_bound" fbc:upperFluxBound="cobra_default_ub">
-        <annotation>
-          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
-            <rdf:Description rdf:about="#meta_R_rxn01644_c0">
-              <bqbiol:is>
-                <rdf:Bag>
-                  <rdf:li rdf:resource="https://identifiers.org/seed.reaction/rxn01644"/>
-                  <rdf:li rdf:resource="https://identifiers.org/bigg.reaction/DHDPS"/>
-                  <rdf:li rdf:resource="https://identifiers.org/kegg.reaction/R02292"/>
-                  <rdf:li rdf:resource="https://identifiers.org/rhea/34174"/>
-                  <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR141927"/>
-                  <rdf:li rdf:resource="https://identifiers.org/biocyc/META:DIHYDRODIPICSYN-RXN"/>
-                  <rdf:li rdf:resource="https://identifiers.org/ec-code/4.2.1.52"/>
-                </rdf:Bag>
-              </bqbiol:is>
-            </rdf:Description>
-          </rdf:RDF>
-        </annotation>
-        <listOfReactants>
-          <speciesReference species="M_cpd00020_c0" stoichiometry="1" constant="true"/>
-          <speciesReference species="M_cpd00346_c0" stoichiometry="1" constant="true"/>
-        </listOfReactants>
-        <listOfProducts>
-          <speciesReference species="M_cpd00001_c0" stoichiometry="2" constant="true"/>
-          <speciesReference species="M_cpd00067_c0" stoichiometry="1" constant="true"/>
-          <speciesReference species="M_cpd02120_c0" stoichiometry="1" constant="true"/>
-        </listOfProducts>
-        <fbc:geneProductAssociation>
-          <fbc:geneProductRef fbc:geneProduct="G_ACZ81_RS10760"/>
         </fbc:geneProductAssociation>
       </reaction>
       <reaction metaid="meta_R_rxn08297_c0" sboTerm="SBO:0000176" id="R_rxn08297_c0" name="diacylglycerol kinase (n-C16:0) [c0]" reversible="false" fast="false" fbc:lowerFluxBound="cobra_0_bound" fbc:upperFluxBound="cobra_default_ub">
@@ -32274,38 +31717,6 @@
         </listOfProducts>
         <fbc:geneProductAssociation>
           <fbc:geneProductRef fbc:geneProduct="G_ACZ81_RS03955"/>
-        </fbc:geneProductAssociation>
-      </reaction>
-      <reaction metaid="meta_R_rxn01108_c0" sboTerm="SBO:0000176" id="R_rxn01108_c0" name="beta-D-Glucose:NAD+ 1-oxoreductase [c0]" reversible="true" fast="false" fbc:lowerFluxBound="cobra_default_lb" fbc:upperFluxBound="cobra_default_ub">
-        <annotation>
-          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
-            <rdf:Description rdf:about="#meta_R_rxn01108_c0">
-              <bqbiol:is>
-                <rdf:Bag>
-                  <rdf:li rdf:resource="https://identifiers.org/seed.reaction/rxn01108"/>
-                  <rdf:li rdf:resource="https://identifiers.org/kegg.reaction/R01520"/>
-                  <rdf:li rdf:resource="https://identifiers.org/rhea/13652"/>
-                  <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR107038"/>
-                  <rdf:li rdf:resource="https://identifiers.org/biocyc/META:GLUCOSE-1-DEHYDROGENASE-NAD+-RXN"/>
-                  <rdf:li rdf:resource="https://identifiers.org/biocyc/META:GLUCOSE-1-DEHYDROGENASE-RXN"/>
-                  <rdf:li rdf:resource="https://identifiers.org/ec-code/1.1.1.47"/>
-                  <rdf:li rdf:resource="https://identifiers.org/ec-code/1.1.1.118"/>
-                </rdf:Bag>
-              </bqbiol:is>
-            </rdf:Description>
-          </rdf:RDF>
-        </annotation>
-        <listOfReactants>
-          <speciesReference species="M_cpd00003_c0" stoichiometry="1" constant="true"/>
-          <speciesReference species="M_cpd00190_c0" stoichiometry="1" constant="true"/>
-        </listOfReactants>
-        <listOfProducts>
-          <speciesReference species="M_cpd00004_c0" stoichiometry="1" constant="true"/>
-          <speciesReference species="M_cpd00067_c0" stoichiometry="1" constant="true"/>
-          <speciesReference species="M_cpd00170_c0" stoichiometry="1" constant="true"/>
-        </listOfProducts>
-        <fbc:geneProductAssociation>
-          <fbc:geneProductRef fbc:geneProduct="G_ACZ81_RS08640"/>
         </fbc:geneProductAssociation>
       </reaction>
       <reaction metaid="meta_R_rxn03406_c0" sboTerm="SBO:0000176" id="R_rxn03406_c0" name="Undecaprenyl-diphospho-N-acetylmuramoyl-(N-acetylglucosamine)- [c0]" reversible="false" fast="false" fbc:lowerFluxBound="cobra_0_bound" fbc:upperFluxBound="cobra_default_ub">
@@ -33866,38 +33277,6 @@
         </listOfProducts>
         <fbc:geneProductAssociation>
           <fbc:geneProductRef fbc:geneProduct="G_ACZ81_RS12215"/>
-        </fbc:geneProductAssociation>
-      </reaction>
-      <reaction metaid="meta_R_rxn08353_c0" sboTerm="SBO:0000176" id="R_rxn08353_c0" name="5-demethylubiquinone-8 methyltransferase [c0]" reversible="true" fast="false" fbc:lowerFluxBound="cobra_default_lb" fbc:upperFluxBound="cobra_default_ub">
-        <annotation>
-          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
-            <rdf:Description rdf:about="#meta_R_rxn08353_c0">
-              <bqbiol:is>
-                <rdf:Bag>
-                  <rdf:li rdf:resource="https://identifiers.org/seed.reaction/rxn08353"/>
-                  <rdf:li rdf:resource="https://identifiers.org/bigg.reaction/DMQMT"/>
-                  <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR97527"/>
-                  <rdf:li rdf:resource="https://identifiers.org/biocyc/META:DHHB-METHYLTRANSFER-RXN"/>
-                  <rdf:li rdf:resource="https://identifiers.org/ec-code/2.1.1.64"/>
-                </rdf:Bag>
-              </bqbiol:is>
-            </rdf:Description>
-          </rdf:RDF>
-        </annotation>
-        <listOfReactants>
-          <speciesReference species="M_cpd00017_c0" stoichiometry="1" constant="true"/>
-          <speciesReference species="M_cpd15360_c0" stoichiometry="1" constant="true"/>
-        </listOfReactants>
-        <listOfProducts>
-          <speciesReference species="M_cpd00019_c0" stoichiometry="1" constant="true"/>
-          <speciesReference species="M_cpd00067_c0" stoichiometry="1" constant="true"/>
-          <speciesReference species="M_cpd15561_c0" stoichiometry="1" constant="true"/>
-        </listOfProducts>
-        <fbc:geneProductAssociation>
-          <fbc:and>
-            <fbc:geneProductRef fbc:geneProduct="G_ACZ81_RS18250"/>
-            <fbc:geneProductRef fbc:geneProduct="G_ACZ81_RS10695"/>
-          </fbc:and>
         </fbc:geneProductAssociation>
       </reaction>
       <reaction metaid="meta_R_rxn02314_c0" sboTerm="SBO:0000176" id="R_rxn02314_c0" name="ATP:D-tagatose-6-phosphate 1-phosphotransferase [c0]" reversible="true" fast="false" fbc:lowerFluxBound="cobra_default_lb" fbc:upperFluxBound="cobra_default_ub">
@@ -37791,38 +37170,6 @@
           <fbc:geneProductRef fbc:geneProduct="G_ACZ81_RS02180"/>
         </fbc:geneProductAssociation>
       </reaction>
-      <reaction metaid="meta_R_rxn08527_c0" sboTerm="SBO:0000176" id="R_rxn08527_c0" name="fumarate reductase [c0]" reversible="true" fast="false" fbc:lowerFluxBound="cobra_default_lb" fbc:upperFluxBound="cobra_default_ub">
-        <annotation>
-          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
-            <rdf:Description rdf:about="#meta_R_rxn08527_c0">
-              <bqbiol:is>
-                <rdf:Bag>
-                  <rdf:li rdf:resource="https://identifiers.org/seed.reaction/rxn08527"/>
-                  <rdf:li rdf:resource="https://identifiers.org/bigg.reaction/FRD2"/>
-                  <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR99637"/>
-                  <rdf:li rdf:resource="https://identifiers.org/ec-code/1.3.99.1"/>
-                </rdf:Bag>
-              </bqbiol:is>
-            </rdf:Description>
-          </rdf:RDF>
-        </annotation>
-        <listOfReactants>
-          <speciesReference species="M_cpd00106_c0" stoichiometry="1" constant="true"/>
-          <speciesReference species="M_cpd15499_c0" stoichiometry="1" constant="true"/>
-        </listOfReactants>
-        <listOfProducts>
-          <speciesReference species="M_cpd00036_c0" stoichiometry="1" constant="true"/>
-          <speciesReference species="M_cpd15500_c0" stoichiometry="1" constant="true"/>
-        </listOfProducts>
-        <fbc:geneProductAssociation>
-          <fbc:and>
-            <fbc:geneProductRef fbc:geneProduct="G_ACZ81_RS09785"/>
-            <fbc:geneProductRef fbc:geneProduct="G_ACZ81_RS09775"/>
-            <fbc:geneProductRef fbc:geneProduct="G_ACZ81_RS09780"/>
-            <fbc:geneProductRef fbc:geneProduct="G_ACZ81_RS09790"/>
-          </fbc:and>
-        </fbc:geneProductAssociation>
-      </reaction>
       <reaction metaid="meta_R_rxn03253_c0" sboTerm="SBO:0000176" id="R_rxn03253_c0" name="Decanoyl-CoA:(acceptor) 2,3-oxidoreductase [c0]" reversible="true" fast="false" fbc:lowerFluxBound="cobra_default_lb" fbc:upperFluxBound="cobra_default_ub">
         <annotation>
           <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
@@ -37978,38 +37325,6 @@
         </listOfProducts>
         <fbc:geneProductAssociation>
           <fbc:geneProductRef fbc:geneProduct="G_ACZ81_RS07135"/>
-        </fbc:geneProductAssociation>
-      </reaction>
-      <reaction metaid="meta_R_rxn08528_c0" sboTerm="SBO:0000176" id="R_rxn08528_c0" name="fumarate reductase [c0]" reversible="true" fast="false" fbc:lowerFluxBound="cobra_default_lb" fbc:upperFluxBound="cobra_default_ub">
-        <annotation>
-          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
-            <rdf:Description rdf:about="#meta_R_rxn08528_c0">
-              <bqbiol:is>
-                <rdf:Bag>
-                  <rdf:li rdf:resource="https://identifiers.org/seed.reaction/rxn08528"/>
-                  <rdf:li rdf:resource="https://identifiers.org/bigg.reaction/FRD3"/>
-                  <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR99639"/>
-                  <rdf:li rdf:resource="https://identifiers.org/ec-code/1.3.99.1"/>
-                </rdf:Bag>
-              </bqbiol:is>
-            </rdf:Description>
-          </rdf:RDF>
-        </annotation>
-        <listOfReactants>
-          <speciesReference species="M_cpd00106_c0" stoichiometry="1" constant="true"/>
-          <speciesReference species="M_cpd15353_c0" stoichiometry="1" constant="true"/>
-        </listOfReactants>
-        <listOfProducts>
-          <speciesReference species="M_cpd00036_c0" stoichiometry="1" constant="true"/>
-          <speciesReference species="M_cpd15352_c0" stoichiometry="1" constant="true"/>
-        </listOfProducts>
-        <fbc:geneProductAssociation>
-          <fbc:and>
-            <fbc:geneProductRef fbc:geneProduct="G_ACZ81_RS09785"/>
-            <fbc:geneProductRef fbc:geneProduct="G_ACZ81_RS09775"/>
-            <fbc:geneProductRef fbc:geneProduct="G_ACZ81_RS09780"/>
-            <fbc:geneProductRef fbc:geneProduct="G_ACZ81_RS09790"/>
-          </fbc:and>
         </fbc:geneProductAssociation>
       </reaction>
       <reaction metaid="meta_R_rxn01145_c0" sboTerm="SBO:0000176" id="R_rxn01145_c0" name="Thymidylate 5&apos;-phosphohydrolase [c0]" reversible="false" fast="false" fbc:lowerFluxBound="cobra_0_bound" fbc:upperFluxBound="cobra_default_ub">
@@ -40171,42 +39486,6 @@
             </fbc:and>
             <fbc:geneProductRef fbc:geneProduct="G_ACZ81_RS12335"/>
             <fbc:geneProductRef fbc:geneProduct="G_ACZ81_RS08575"/>
-          </fbc:or>
-        </fbc:geneProductAssociation>
-      </reaction>
-      <reaction metaid="meta_R_rxn06077_c0" sboTerm="SBO:0000176" id="R_rxn06077_c0" name="L-methionine:oxidized-thioredoxin S-oxidoreductase [c0]" reversible="true" fast="false" fbc:lowerFluxBound="cobra_default_lb" fbc:upperFluxBound="cobra_default_ub">
-        <annotation>
-          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
-            <rdf:Description rdf:about="#meta_R_rxn06077_c0">
-              <bqbiol:is>
-                <rdf:Bag>
-                  <rdf:li rdf:resource="https://identifiers.org/seed.reaction/rxn06077"/>
-                  <rdf:li rdf:resource="https://identifiers.org/bigg.reaction/METSR-S1"/>
-                  <rdf:li rdf:resource="https://identifiers.org/kegg.reaction/R02025"/>
-                  <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR101484"/>
-                  <rdf:li rdf:resource="https://identifiers.org/ec-code/1.8.4.14"/>
-                  <rdf:li rdf:resource="https://identifiers.org/ec-code/1.8.4.13"/>
-                </rdf:Bag>
-              </bqbiol:is>
-            </rdf:Description>
-          </rdf:RDF>
-        </annotation>
-        <listOfReactants>
-          <speciesReference species="M_cpd00001_c0" stoichiometry="1" constant="true"/>
-          <speciesReference species="M_cpd00060_c0" stoichiometry="1" constant="true"/>
-          <speciesReference species="M_cpd11420_c0" stoichiometry="1" constant="true"/>
-        </listOfReactants>
-        <listOfProducts>
-          <speciesReference species="M_cpd01914_c0" stoichiometry="1" constant="true"/>
-          <speciesReference species="M_cpd11421_c0" stoichiometry="1" constant="true"/>
-        </listOfProducts>
-        <fbc:geneProductAssociation>
-          <fbc:or>
-            <fbc:and>
-              <fbc:geneProductRef fbc:geneProduct="G_ACZ81_RS14995"/>
-              <fbc:geneProductRef fbc:geneProduct="G_ACZ81_RS16400"/>
-            </fbc:and>
-            <fbc:geneProductRef fbc:geneProduct="G_ACZ81_RS10190"/>
           </fbc:or>
         </fbc:geneProductAssociation>
       </reaction>
@@ -43043,31 +42322,6 @@
           <fbc:geneProductRef fbc:geneProduct="G_ACZ81_RS04850"/>
         </fbc:geneProductAssociation>
       </reaction>
-      <reaction metaid="meta_R_rxn07979_c0" sboTerm="SBO:0000176" id="R_rxn07979_c0" name="3-hydroxyacyl-[acyl-carrier-protein] dehydratase (n-C18:0) [c0]" reversible="true" fast="false" fbc:lowerFluxBound="cobra_default_lb" fbc:upperFluxBound="cobra_default_ub">
-        <annotation>
-          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
-            <rdf:Description rdf:about="#meta_R_rxn07979_c0">
-              <bqbiol:is>
-                <rdf:Bag>
-                  <rdf:li rdf:resource="https://identifiers.org/seed.reaction/rxn07979"/>
-                  <rdf:li rdf:resource="https://identifiers.org/bigg.reaction/3HAD180"/>
-                  <rdf:li rdf:resource="https://identifiers.org/ec-code/4.2.1.61"/>
-                </rdf:Bag>
-              </bqbiol:is>
-            </rdf:Description>
-          </rdf:RDF>
-        </annotation>
-        <listOfReactants>
-          <speciesReference species="M_cpd15371_c0" stoichiometry="1" constant="true"/>
-        </listOfReactants>
-        <listOfProducts>
-          <speciesReference species="M_cpd00001_c0" stoichiometry="1" constant="true"/>
-          <speciesReference species="M_cpd15572_c0" stoichiometry="1" constant="true"/>
-        </listOfProducts>
-        <fbc:geneProductAssociation>
-          <fbc:geneProductRef fbc:geneProduct="G_ACZ81_RS04880"/>
-        </fbc:geneProductAssociation>
-      </reaction>
       <reaction metaid="meta_R_rxn00993_c0" sboTerm="SBO:0000176" id="R_rxn00993_c0" name="4-fumarylacetoacetate fumarylhydrolase [c0]" reversible="true" fast="false" fbc:lowerFluxBound="cobra_default_lb" fbc:upperFluxBound="cobra_default_ub">
         <annotation>
           <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
@@ -44026,35 +43280,6 @@
             <fbc:geneProductRef fbc:geneProduct="G_ACZ81_RS12335"/>
             <fbc:geneProductRef fbc:geneProduct="G_ACZ81_RS08575"/>
           </fbc:or>
-        </fbc:geneProductAssociation>
-      </reaction>
-      <reaction metaid="meta_R_rxn09039_c0" sboTerm="SBO:0000176" id="R_rxn09039_c0" name="2-OCTAPRENYL-METHOXY-BENZOQ-METH-RXN.c [c0]" reversible="true" fast="false" fbc:lowerFluxBound="cobra_default_lb" fbc:upperFluxBound="cobra_default_ub">
-        <annotation>
-          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
-            <rdf:Description rdf:about="#meta_R_rxn09039_c0">
-              <bqbiol:is>
-                <rdf:Bag>
-                  <rdf:li rdf:resource="https://identifiers.org/seed.reaction/rxn09039"/>
-                  <rdf:li rdf:resource="https://identifiers.org/bigg.reaction/OMBZLM"/>
-                  <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR115030"/>
-                  <rdf:li rdf:resource="https://identifiers.org/biocyc/META:2-OCTAPRENYL-METHOXY-BENZOQ-METH-RXN"/>
-                  <rdf:li rdf:resource="https://identifiers.org/ec-code/2.1.1.201"/>
-                </rdf:Bag>
-              </bqbiol:is>
-            </rdf:Description>
-          </rdf:RDF>
-        </annotation>
-        <listOfReactants>
-          <speciesReference species="M_cpd00017_c0" stoichiometry="1" constant="true"/>
-          <speciesReference species="M_cpd15359_c0" stoichiometry="1" constant="true"/>
-        </listOfReactants>
-        <listOfProducts>
-          <speciesReference species="M_cpd00019_c0" stoichiometry="1" constant="true"/>
-          <speciesReference species="M_cpd00067_c0" stoichiometry="1" constant="true"/>
-          <speciesReference species="M_cpd15361_c0" stoichiometry="1" constant="true"/>
-        </listOfProducts>
-        <fbc:geneProductAssociation>
-          <fbc:geneProductRef fbc:geneProduct="G_ACZ81_RS17515"/>
         </fbc:geneProductAssociation>
       </reaction>
       <reaction metaid="meta_R_rxn05484_c0" sboTerm="SBO:0000655" id="R_rxn05484_c0" name="acetoacetate transport via proton symport [c0]" reversible="true" fast="false" fbc:lowerFluxBound="cobra_default_lb" fbc:upperFluxBound="cobra_default_ub">
@@ -45353,36 +44578,6 @@
           </fbc:or>
         </fbc:geneProductAssociation>
       </reaction>
-      <reaction metaid="meta_R_rxn07439_c0" sboTerm="SBO:0000176" id="R_rxn07439_c0" name="L-methionine:thioredoxin-disulfide S-oxidoreductase [L-methionine (R)-S-oxide-forming] [c0]" reversible="true" fast="false" fbc:lowerFluxBound="cobra_default_lb" fbc:upperFluxBound="cobra_default_ub">
-        <annotation>
-          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
-            <rdf:Description rdf:about="#meta_R_rxn07439_c0">
-              <bqbiol:is>
-                <rdf:Bag>
-                  <rdf:li rdf:resource="https://identifiers.org/seed.reaction/rxn07439"/>
-                  <rdf:li rdf:resource="https://identifiers.org/bigg.reaction/METSOXR2"/>
-                  <rdf:li rdf:resource="https://identifiers.org/kegg.reaction/R07608"/>
-                  <rdf:li rdf:resource="https://identifiers.org/rhea/21263"/>
-                  <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR138594"/>
-                  <rdf:li rdf:resource="https://identifiers.org/ec-code/1.8.4.14"/>
-                </rdf:Bag>
-              </bqbiol:is>
-            </rdf:Description>
-          </rdf:RDF>
-        </annotation>
-        <listOfReactants>
-          <speciesReference species="M_cpd00001_c0" stoichiometry="1" constant="true"/>
-          <speciesReference species="M_cpd00060_c0" stoichiometry="1" constant="true"/>
-          <speciesReference species="M_cpd11420_c0" stoichiometry="1" constant="true"/>
-        </listOfReactants>
-        <listOfProducts>
-          <speciesReference species="M_cpd11421_c0" stoichiometry="1" constant="true"/>
-          <speciesReference species="M_cpd14720_c0" stoichiometry="1" constant="true"/>
-        </listOfProducts>
-        <fbc:geneProductAssociation>
-          <fbc:geneProductRef fbc:geneProduct="G_ACZ81_RS10190"/>
-        </fbc:geneProductAssociation>
-      </reaction>
       <reaction metaid="meta_R_rxn01073_c0" sboTerm="SBO:0000176" id="R_rxn01073_c0" name="sn-Glycero-3-phosphoethanolamine glycerophosphohydrolase [c0]" reversible="false" fast="false" fbc:lowerFluxBound="cobra_0_bound" fbc:upperFluxBound="cobra_default_ub">
         <annotation>
           <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
@@ -45533,44 +44728,6 @@
             <fbc:geneProductRef fbc:geneProduct="G_ACZ81_RS10150"/>
             <fbc:geneProductRef fbc:geneProduct="G_ACZ81_RS10145"/>
           </fbc:and>
-        </fbc:geneProductAssociation>
-      </reaction>
-      <reaction metaid="meta_R_rxn02200_c0" sboTerm="SBO:0000176" id="R_rxn02200_c0" name="2-amino-4-hydroxy-6-hydroxymethyl-7,8-dihydropteridine:4-aminobenzoate 2-amino-4-hydroxydihydropteridine-6-methenyltransferase [c0]" reversible="true" fast="false" fbc:lowerFluxBound="cobra_default_lb" fbc:upperFluxBound="cobra_default_ub">
-        <annotation>
-          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
-            <rdf:Description rdf:about="#meta_R_rxn02200_c0">
-              <bqbiol:is>
-                <rdf:Bag>
-                  <rdf:li rdf:resource="https://identifiers.org/seed.reaction/rxn02200"/>
-                  <rdf:li rdf:resource="https://identifiers.org/bigg.reaction/DHPS"/>
-                  <rdf:li rdf:resource="https://identifiers.org/bigg.reaction/DHPSm"/>
-                  <rdf:li rdf:resource="https://identifiers.org/kegg.reaction/R03066"/>
-                  <rdf:li rdf:resource="https://identifiers.org/rhea/30890"/>
-                  <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR139168"/>
-                  <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR140386"/>
-                  <rdf:li rdf:resource="https://identifiers.org/biocyc/META:RXN-14226"/>
-                  <rdf:li rdf:resource="https://identifiers.org/ec-code/2.5.1.15"/>
-                </rdf:Bag>
-              </bqbiol:is>
-            </rdf:Description>
-          </rdf:RDF>
-        </annotation>
-        <listOfReactants>
-          <speciesReference species="M_cpd00443_c0" stoichiometry="1" constant="true"/>
-          <speciesReference species="M_cpd00954_c0" stoichiometry="1" constant="true"/>
-        </listOfReactants>
-        <listOfProducts>
-          <speciesReference species="M_cpd00001_c0" stoichiometry="1" constant="true"/>
-          <speciesReference species="M_cpd00683_c0" stoichiometry="1" constant="true"/>
-        </listOfProducts>
-        <fbc:geneProductAssociation>
-          <fbc:or>
-            <fbc:geneProductRef fbc:geneProduct="G_ACZ81_RS09385"/>
-            <fbc:and>
-              <fbc:geneProductRef fbc:geneProduct="G_ACZ81_RS03300"/>
-              <fbc:geneProductRef fbc:geneProduct="G_ACZ81_RS17820"/>
-            </fbc:and>
-          </fbc:or>
         </fbc:geneProductAssociation>
       </reaction>
       <reaction metaid="meta_R_rxn01069_c0" sboTerm="SBO:0000176" id="R_rxn01069_c0" name="O-phospho-L-homoserine phosphate-lyase (adding water;L-threonine-forming) [c0]" reversible="false" fast="false" fbc:lowerFluxBound="cobra_0_bound" fbc:upperFluxBound="cobra_default_ub">
@@ -46162,39 +45319,6 @@
           <fbc:geneProductRef fbc:geneProduct="G_ACZ81_RS11875"/>
         </fbc:geneProductAssociation>
       </reaction>
-      <reaction metaid="meta_R_rxn05029_c0" sboTerm="SBO:0000176" id="R_rxn05029_c0" name="ATP:cobinamide Cobeta-adenosyltransferase [c0]" reversible="false" fast="false" fbc:lowerFluxBound="cobra_0_bound" fbc:upperFluxBound="cobra_default_ub">
-        <annotation>
-          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
-            <rdf:Description rdf:about="#meta_R_rxn05029_c0">
-              <bqbiol:is>
-                <rdf:Bag>
-                  <rdf:li rdf:resource="https://identifiers.org/seed.reaction/rxn05029"/>
-                  <rdf:li rdf:resource="https://identifiers.org/bigg.reaction/CBIAT"/>
-                  <rdf:li rdf:resource="https://identifiers.org/bigg.reaction/CBIAT2"/>
-                  <rdf:li rdf:resource="https://identifiers.org/kegg.reaction/R07268"/>
-                  <rdf:li rdf:resource="https://identifiers.org/rhea/14728"/>
-                  <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR134792"/>
-                  <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR110951"/>
-                  <rdf:li rdf:resource="https://identifiers.org/biocyc/META:BTUR2-RXN"/>
-                  <rdf:li rdf:resource="https://identifiers.org/ec-code/2.5.1.17"/>
-                </rdf:Bag>
-              </bqbiol:is>
-            </rdf:Description>
-          </rdf:RDF>
-        </annotation>
-        <listOfReactants>
-          <speciesReference species="M_cpd00002_c0" stoichiometry="1" constant="true"/>
-          <speciesReference species="M_cpd00067_c0" stoichiometry="1" constant="true"/>
-          <speciesReference species="M_cpd03422_c0" stoichiometry="1" constant="true"/>
-        </listOfReactants>
-        <listOfProducts>
-          <speciesReference species="M_cpd00421_c0" stoichiometry="1" constant="true"/>
-          <speciesReference species="M_cpd03918_c0" stoichiometry="1" constant="true"/>
-        </listOfProducts>
-        <fbc:geneProductAssociation>
-          <fbc:geneProductRef fbc:geneProduct="G_ACZ81_RS08145"/>
-        </fbc:geneProductAssociation>
-      </reaction>
       <reaction metaid="meta_R_rxn00368_c0" sboTerm="SBO:0000176" id="R_rxn00368_c0" name="UTP:cytidine 5&apos;-phosphotransferase [c0]" reversible="false" fast="false" fbc:lowerFluxBound="cobra_0_bound" fbc:upperFluxBound="cobra_default_ub">
         <annotation>
           <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
@@ -46487,37 +45611,6 @@
             <fbc:geneProductRef fbc:geneProduct="G_ACZ81_RS17255"/>
             <fbc:geneProductRef fbc:geneProduct="G_ACZ81_RS07965"/>
           </fbc:and>
-        </fbc:geneProductAssociation>
-      </reaction>
-      <reaction metaid="meta_R_rxn01109_c0" sboTerm="SBO:0000176" id="R_rxn01109_c0" name="beta-D-Glucose:NADP+ 1-oxoreductase [c0]" reversible="true" fast="false" fbc:lowerFluxBound="cobra_default_lb" fbc:upperFluxBound="cobra_default_ub">
-        <annotation>
-          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
-            <rdf:Description rdf:about="#meta_R_rxn01109_c0">
-              <bqbiol:is>
-                <rdf:Bag>
-                  <rdf:li rdf:resource="https://identifiers.org/seed.reaction/rxn01109"/>
-                  <rdf:li rdf:resource="https://identifiers.org/kegg.reaction/R01521"/>
-                  <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR107039"/>
-                  <rdf:li rdf:resource="https://identifiers.org/biocyc/META:GLUCOSE-1-DEHYDROGENASE-RXN"/>
-                  <rdf:li rdf:resource="https://identifiers.org/biocyc/META:GLUCOSE-1-DEHYDROGENASE-NADP+-RXN"/>
-                  <rdf:li rdf:resource="https://identifiers.org/ec-code/1.1.1.47"/>
-                  <rdf:li rdf:resource="https://identifiers.org/ec-code/1.1.1.119"/>
-                </rdf:Bag>
-              </bqbiol:is>
-            </rdf:Description>
-          </rdf:RDF>
-        </annotation>
-        <listOfReactants>
-          <speciesReference species="M_cpd00006_c0" stoichiometry="1" constant="true"/>
-          <speciesReference species="M_cpd00190_c0" stoichiometry="1" constant="true"/>
-        </listOfReactants>
-        <listOfProducts>
-          <speciesReference species="M_cpd00005_c0" stoichiometry="1" constant="true"/>
-          <speciesReference species="M_cpd00067_c0" stoichiometry="1" constant="true"/>
-          <speciesReference species="M_cpd00170_c0" stoichiometry="1" constant="true"/>
-        </listOfProducts>
-        <fbc:geneProductAssociation>
-          <fbc:geneProductRef fbc:geneProduct="G_ACZ81_RS08640"/>
         </fbc:geneProductAssociation>
       </reaction>
       <reaction metaid="meta_R_rxn08848_c0" sboTerm="SBO:0000176" id="R_rxn08848_c0" name="Lysophospholipase L2 (2-acylglycerophosphoglycerol, n-C16:0) [c0]" reversible="true" fast="false" fbc:lowerFluxBound="cobra_default_lb" fbc:upperFluxBound="cobra_default_ub">
@@ -49466,41 +48559,6 @@
           </fbc:and>
         </fbc:geneProductAssociation>
       </reaction>
-      <reaction metaid="meta_R_rxn09272_c0" sboTerm="SBO:0000176" id="R_rxn09272_c0" name="fumarate reductase complex (i.e. FRD, involved in anaerobic respiration, repressed in aerobic respiration) [c0]" reversible="false" fast="false" fbc:lowerFluxBound="cobra_0_bound" fbc:upperFluxBound="cobra_default_ub">
-        <annotation>
-          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
-            <rdf:Description rdf:about="#meta_R_rxn09272_c0">
-              <bqbiol:is>
-                <rdf:Bag>
-                  <rdf:li rdf:resource="https://identifiers.org/seed.reaction/rxn09272"/>
-                  <rdf:li rdf:resource="https://identifiers.org/bigg.reaction/SUCDi"/>
-                  <rdf:li rdf:resource="https://identifiers.org/bigg.reaction/SUCD7"/>
-                  <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR99641"/>
-                  <rdf:li rdf:resource="https://identifiers.org/biocyc/META:SUCCINATE-DEHYDROGENASE-UBIQUINONE-RXN"/>
-                  <rdf:li rdf:resource="https://identifiers.org/ec-code/1.3.99.1"/>
-                  <rdf:li rdf:resource="https://identifiers.org/ec-code/1.3.5.1"/>
-                </rdf:Bag>
-              </bqbiol:is>
-            </rdf:Description>
-          </rdf:RDF>
-        </annotation>
-        <listOfReactants>
-          <speciesReference species="M_cpd00036_c0" stoichiometry="1" constant="true"/>
-          <speciesReference species="M_cpd15560_c0" stoichiometry="1" constant="true"/>
-        </listOfReactants>
-        <listOfProducts>
-          <speciesReference species="M_cpd00106_c0" stoichiometry="1" constant="true"/>
-          <speciesReference species="M_cpd15561_c0" stoichiometry="1" constant="true"/>
-        </listOfProducts>
-        <fbc:geneProductAssociation>
-          <fbc:and>
-            <fbc:geneProductRef fbc:geneProduct="G_ACZ81_RS09785"/>
-            <fbc:geneProductRef fbc:geneProduct="G_ACZ81_RS09775"/>
-            <fbc:geneProductRef fbc:geneProduct="G_ACZ81_RS09780"/>
-            <fbc:geneProductRef fbc:geneProduct="G_ACZ81_RS09790"/>
-          </fbc:and>
-        </fbc:geneProductAssociation>
-      </reaction>
       <reaction metaid="meta_R_rxn00943_c0" sboTerm="SBO:0000176" id="R_rxn00943_c0" name="Palmitoyl-CoA hydrolase [c0]" reversible="false" fast="false" fbc:lowerFluxBound="cobra_0_bound" fbc:upperFluxBound="cobra_default_ub">
         <annotation>
           <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
@@ -50269,34 +49327,6 @@
             <fbc:geneProductRef fbc:geneProduct="G_ACZ81_RS07435"/>
             <fbc:geneProductRef fbc:geneProduct="G_ACZ81_RS09625"/>
           </fbc:and>
-        </fbc:geneProductAssociation>
-      </reaction>
-      <reaction metaid="meta_R_rxn07438_c0" sboTerm="SBO:0000176" id="R_rxn07438_c0" name="peptide-methionine:thioredoxin-disulfide S-oxidoreductase [c0]" reversible="true" fast="false" fbc:lowerFluxBound="cobra_default_lb" fbc:upperFluxBound="cobra_default_ub">
-        <annotation>
-          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
-            <rdf:Description rdf:about="#meta_R_rxn07438_c0">
-              <bqbiol:is>
-                <rdf:Bag>
-                  <rdf:li rdf:resource="https://identifiers.org/seed.reaction/rxn07438"/>
-                  <rdf:li rdf:resource="https://identifiers.org/kegg.reaction/R07607"/>
-                  <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR111211"/>
-                  <rdf:li rdf:resource="https://identifiers.org/ec-code/1.8.4.12"/>
-                </rdf:Bag>
-              </bqbiol:is>
-            </rdf:Description>
-          </rdf:RDF>
-        </annotation>
-        <listOfReactants>
-          <speciesReference species="M_cpd00001_c0" stoichiometry="1" constant="true"/>
-          <speciesReference species="M_cpd11420_c0" stoichiometry="1" constant="true"/>
-          <speciesReference species="M_cpd12237_c0" stoichiometry="1" constant="true"/>
-        </listOfReactants>
-        <listOfProducts>
-          <speciesReference species="M_cpd11421_c0" stoichiometry="1" constant="true"/>
-          <speciesReference species="M_cpd14507_c0" stoichiometry="1" constant="true"/>
-        </listOfProducts>
-        <fbc:geneProductAssociation>
-          <fbc:geneProductRef fbc:geneProduct="G_ACZ81_RS11700"/>
         </fbc:geneProductAssociation>
       </reaction>
       <reaction metaid="meta_R_rxn00743_c0" sboTerm="SBO:0000176" id="R_rxn00743_c0" name="Glycerone phosphate phosphohydrolase [c0]" reversible="false" fast="false" fbc:lowerFluxBound="cobra_0_bound" fbc:upperFluxBound="cobra_default_ub">
@@ -55052,33 +54082,6 @@
           <fbc:geneProductRef fbc:geneProduct="G_ACZ81_RS16760"/>
         </fbc:geneProductAssociation>
       </reaction>
-      <reaction metaid="meta_R_rxn01171_c0" sboTerm="SBO:0000176" id="R_rxn01171_c0" name="D-glucose 1-epimerase [c0]" reversible="true" fast="false" fbc:lowerFluxBound="cobra_default_lb" fbc:upperFluxBound="cobra_default_ub">
-        <annotation>
-          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
-            <rdf:Description rdf:about="#meta_R_rxn01171_c0">
-              <bqbiol:is>
-                <rdf:Bag>
-                  <rdf:li rdf:resource="https://identifiers.org/seed.reaction/rxn01171"/>
-                  <rdf:li rdf:resource="https://identifiers.org/kegg.reaction/R01602"/>
-                  <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR107082"/>
-                  <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR134274"/>
-                  <rdf:li rdf:resource="https://identifiers.org/biocyc/META:ALDOSE-1-EPIMERASE-RXN"/>
-                  <rdf:li rdf:resource="https://identifiers.org/ec-code/5.1.3.3"/>
-                </rdf:Bag>
-              </bqbiol:is>
-            </rdf:Description>
-          </rdf:RDF>
-        </annotation>
-        <listOfReactants>
-          <speciesReference species="M_cpd00027_c0" stoichiometry="1" constant="true"/>
-        </listOfReactants>
-        <listOfProducts>
-          <speciesReference species="M_cpd00190_c0" stoichiometry="1" constant="true"/>
-        </listOfProducts>
-        <fbc:geneProductAssociation>
-          <fbc:geneProductRef fbc:geneProduct="G_ACZ81_RS00965"/>
-        </fbc:geneProductAssociation>
-      </reaction>
       <reaction metaid="meta_R_rxn02288_c0" sboTerm="SBO:0000176" id="R_rxn02288_c0" name="Uroporphyrinogen-III carboxy-lyase [c0]" reversible="false" fast="false" fbc:lowerFluxBound="cobra_0_bound" fbc:upperFluxBound="cobra_default_ub">
         <annotation>
           <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
@@ -57791,35 +56794,6 @@
           <fbc:geneProductRef fbc:geneProduct="G_ACZ81_RS18155"/>
         </fbc:geneProductAssociation>
       </reaction>
-      <reaction metaid="meta_R_rxn08131_c0" sboTerm="SBO:0000176" id="R_rxn08131_c0" name="4-amino-2-methyl-5-phosphomethylpyrimidine synthetase [c0]" reversible="true" fast="false" fbc:lowerFluxBound="cobra_default_lb" fbc:upperFluxBound="cobra_default_ub">
-        <annotation>
-          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
-            <rdf:Description rdf:about="#meta_R_rxn08131_c0">
-              <bqbiol:is>
-                <rdf:Bag>
-                  <rdf:li rdf:resource="https://identifiers.org/seed.reaction/rxn08131"/>
-                  <rdf:li rdf:resource="https://identifiers.org/bigg.reaction/AMPMS2"/>
-                  <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR135733"/>
-                </rdf:Bag>
-              </bqbiol:is>
-            </rdf:Description>
-          </rdf:RDF>
-        </annotation>
-        <listOfReactants>
-          <speciesReference species="M_cpd00001_c0" stoichiometry="1" constant="true"/>
-          <speciesReference species="M_cpd00003_c0" stoichiometry="1" constant="true"/>
-          <speciesReference species="M_cpd02140_c0" stoichiometry="1" constant="true"/>
-        </listOfReactants>
-        <listOfProducts>
-          <speciesReference species="M_cpd00004_c0" stoichiometry="1" constant="true"/>
-          <speciesReference species="M_cpd00047_c0" stoichiometry="2" constant="true"/>
-          <speciesReference species="M_cpd00067_c0" stoichiometry="4" constant="true"/>
-          <speciesReference species="M_cpd02775_c0" stoichiometry="1" constant="true"/>
-        </listOfProducts>
-        <fbc:geneProductAssociation>
-          <fbc:geneProductRef fbc:geneProduct="G_ACZ81_RS00500"/>
-        </fbc:geneProductAssociation>
-      </reaction>
       <reaction metaid="meta_R_rxn10220_c0" sboTerm="SBO:0000176" id="R_rxn10220_c0" name="isoheptadecanoyl-phosphatidate cytidylyltransferase [c0]" reversible="false" fast="false" fbc:lowerFluxBound="cobra_0_bound" fbc:upperFluxBound="cobra_default_ub">
         <annotation>
           <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
@@ -58875,38 +57849,6 @@
         </listOfProducts>
         <fbc:geneProductAssociation>
           <fbc:geneProductRef fbc:geneProduct="G_ACZ81_RS07070"/>
-        </fbc:geneProductAssociation>
-      </reaction>
-      <reaction metaid="meta_R_rxn02929_c0" sboTerm="SBO:0000176" id="R_rxn02929_c0" name="2,3,4,5-Tetrahydrodipicolinate:NADP+ oxidoreductase [c0]" reversible="true" fast="false" fbc:lowerFluxBound="cobra_default_lb" fbc:upperFluxBound="cobra_default_ub">
-        <annotation>
-          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
-            <rdf:Description rdf:about="#meta_R_rxn02929_c0">
-              <bqbiol:is>
-                <rdf:Bag>
-                  <rdf:li rdf:resource="https://identifiers.org/seed.reaction/rxn02929"/>
-                  <rdf:li rdf:resource="https://identifiers.org/bigg.reaction/DHDPRy"/>
-                  <rdf:li rdf:resource="https://identifiers.org/kegg.reaction/R04199"/>
-                  <rdf:li rdf:resource="https://identifiers.org/rhea/35334"/>
-                  <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR139260"/>
-                  <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR142020"/>
-                  <rdf:li rdf:resource="https://identifiers.org/biocyc/META:DIHYDROPICRED-RXN"/>
-                  <rdf:li rdf:resource="https://identifiers.org/ec-code/1.3.1.26"/>
-                </rdf:Bag>
-              </bqbiol:is>
-            </rdf:Description>
-          </rdf:RDF>
-        </annotation>
-        <listOfReactants>
-          <speciesReference species="M_cpd00006_c0" stoichiometry="1" constant="true"/>
-          <speciesReference species="M_cpd02465_c0" stoichiometry="1" constant="true"/>
-        </listOfReactants>
-        <listOfProducts>
-          <speciesReference species="M_cpd00005_c0" stoichiometry="1" constant="true"/>
-          <speciesReference species="M_cpd00067_c0" stoichiometry="1" constant="true"/>
-          <speciesReference species="M_cpd02120_c0" stoichiometry="1" constant="true"/>
-        </listOfProducts>
-        <fbc:geneProductAssociation>
-          <fbc:geneProductRef fbc:geneProduct="G_ACZ81_RS07080"/>
         </fbc:geneProductAssociation>
       </reaction>
       <reaction metaid="meta_R_rxn00104_c0" sboTerm="SBO:0000176" id="R_rxn00104_c0" name="polyphosphate kinase [c0]" reversible="true" fast="false" fbc:lowerFluxBound="cobra_default_lb" fbc:upperFluxBound="cobra_default_ub">
@@ -60542,37 +59484,6 @@
           </fbc:and>
         </fbc:geneProductAssociation>
       </reaction>
-      <reaction metaid="meta_R_rxn42230_c0" sboTerm="SBO:0000176" id="R_rxn42230_c0" name="[c0]" reversible="true" fast="false" fbc:lowerFluxBound="cobra_default_lb" fbc:upperFluxBound="cobra_default_ub">
-        <annotation>
-          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
-            <rdf:Description rdf:about="#meta_R_rxn42230_c0">
-              <bqbiol:is>
-                <rdf:Bag>
-                  <rdf:li rdf:resource="https://identifiers.org/seed.reaction/rxn42230"/>
-                  <rdf:li rdf:resource="https://identifiers.org/rhea/14726"/>
-                  <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR96465"/>
-                  <rdf:li rdf:resource="https://identifiers.org/biocyc/META:BTUR2-RXN"/>
-                  <rdf:li rdf:resource="https://identifiers.org/ec-code/2.5.1.17"/>
-                </rdf:Bag>
-              </bqbiol:is>
-            </rdf:Description>
-          </rdf:RDF>
-        </annotation>
-        <listOfReactants>
-          <speciesReference species="M_cpd00002_c0" stoichiometry="2" constant="true"/>
-          <speciesReference species="M_cpd28070_c0" stoichiometry="1" constant="true"/>
-          <speciesReference species="M_cpd33817_c0" stoichiometry="2" constant="true"/>
-        </listOfReactants>
-        <listOfProducts>
-          <speciesReference species="M_cpd00067_c0" stoichiometry="3" constant="true"/>
-          <speciesReference species="M_cpd00421_c0" stoichiometry="2" constant="true"/>
-          <speciesReference species="M_cpd03918_c0" stoichiometry="2" constant="true"/>
-          <speciesReference species="M_cpd27744_c0" stoichiometry="1" constant="true"/>
-        </listOfProducts>
-        <fbc:geneProductAssociation>
-          <fbc:geneProductRef fbc:geneProduct="G_ACZ81_RS08145"/>
-        </fbc:geneProductAssociation>
-      </reaction>
       <reaction metaid="meta_R_rxn07455_c0" sboTerm="SBO:0000176" id="R_rxn07455_c0" name="decenoyl-[acyl-carrier-protein] delta2-trans-delta3-cis-isomerase [c0]" reversible="true" fast="false" fbc:lowerFluxBound="cobra_default_lb" fbc:upperFluxBound="cobra_default_ub">
         <annotation>
           <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
@@ -60689,39 +59600,6 @@
           <fbc:geneProductRef fbc:geneProduct="G_ACZ81_RS08565"/>
         </fbc:geneProductAssociation>
       </reaction>
-      <reaction metaid="meta_R_rxn25839_c0" sboTerm="SBO:0000176" id="R_rxn25839_c0" name="ATP:[ThiS] adenylyltransferase [c0]" reversible="false" fast="false" fbc:lowerFluxBound="cobra_0_bound" fbc:upperFluxBound="cobra_default_ub">
-        <annotation>
-          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
-            <rdf:Description rdf:about="#meta_R_rxn25839_c0">
-              <bqbiol:is>
-                <rdf:Bag>
-                  <rdf:li rdf:resource="https://identifiers.org/seed.reaction/rxn25839"/>
-                  <rdf:li rdf:resource="https://identifiers.org/rhea/43345"/>
-                  <rdf:li rdf:resource="https://identifiers.org/rhea/55169"/>
-                  <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR118766"/>
-                  <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR122993"/>
-                  <rdf:li rdf:resource="https://identifiers.org/biocyc/META:RXN-14564"/>
-                  <rdf:li rdf:resource="https://identifiers.org/biocyc/META:RXN-9789"/>
-                  <rdf:li rdf:resource="https://identifiers.org/biocyc/META:RXN-18455"/>
-                  <rdf:li rdf:resource="https://identifiers.org/ec-code/2.7.7.M15"/>
-                  <rdf:li rdf:resource="https://identifiers.org/ec-code/2.7.7.73"/>
-                </rdf:Bag>
-              </bqbiol:is>
-            </rdf:Description>
-          </rdf:RDF>
-        </annotation>
-        <listOfReactants>
-          <speciesReference species="M_cpd00002_c0" stoichiometry="1" constant="true"/>
-          <speciesReference species="M_cpd28253_c0" stoichiometry="1" constant="true"/>
-        </listOfReactants>
-        <listOfProducts>
-          <speciesReference species="M_cpd00012_c0" stoichiometry="1" constant="true"/>
-          <speciesReference species="M_cpd22312_c0" stoichiometry="1" constant="true"/>
-        </listOfProducts>
-        <fbc:geneProductAssociation>
-          <fbc:geneProductRef fbc:geneProduct="G_ACZ81_RS00490"/>
-        </fbc:geneProductAssociation>
-      </reaction>
       <reaction metaid="meta_R_rxn23042_c0" sboTerm="SBO:0000176" id="R_rxn23042_c0" name="thiamine-phosphate diphosphorylase [c0]" reversible="false" fast="false" fbc:lowerFluxBound="cobra_0_bound" fbc:upperFluxBound="cobra_default_ub">
         <annotation>
           <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
@@ -60798,78 +59676,6 @@
           </fbc:and>
         </fbc:geneProductAssociation>
       </reaction>
-      <reaction metaid="meta_R_rxn00154_c0" sboTerm="SBO:0000176" id="R_rxn00154_c0" name="pyruvate:NAD+ 2-oxidoreductase (CoA-acetylating) [c0]" reversible="true" fast="false" fbc:lowerFluxBound="cobra_default_lb" fbc:upperFluxBound="cobra_default_ub">
-        <annotation>
-          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
-            <rdf:Description rdf:about="#meta_R_rxn00154_c0">
-              <bqbiol:is>
-                <rdf:Bag>
-                  <rdf:li rdf:resource="https://identifiers.org/seed.reaction/rxn00154"/>
-                  <rdf:li rdf:resource="https://identifiers.org/bigg.reaction/PDH"/>
-                  <rdf:li rdf:resource="https://identifiers.org/bigg.reaction/PDHm"/>
-                  <rdf:li rdf:resource="https://identifiers.org/kegg.reaction/R00209"/>
-                  <rdf:li rdf:resource="https://identifiers.org/rhea/28045"/>
-                  <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR102425"/>
-                  <rdf:li rdf:resource="https://identifiers.org/biocyc/META:PYRUVDEH-RXN"/>
-                  <rdf:li rdf:resource="https://identifiers.org/ec-code/2.3.1.12"/>
-                  <rdf:li rdf:resource="https://identifiers.org/ec-code/1.8.1.4"/>
-                  <rdf:li rdf:resource="https://identifiers.org/ec-code/1.2.1.-"/>
-                  <rdf:li rdf:resource="https://identifiers.org/ec-code/1.2.4.1"/>
-                  <rdf:li rdf:resource="https://identifiers.org/ec-code/1.2.1.M10"/>
-                </rdf:Bag>
-              </bqbiol:is>
-            </rdf:Description>
-          </rdf:RDF>
-        </annotation>
-        <listOfReactants>
-          <speciesReference species="M_cpd00003_c0" stoichiometry="1" constant="true"/>
-          <speciesReference species="M_cpd00010_c0" stoichiometry="1" constant="true"/>
-          <speciesReference species="M_cpd00020_c0" stoichiometry="1" constant="true"/>
-        </listOfReactants>
-        <listOfProducts>
-          <speciesReference species="M_cpd00004_c0" stoichiometry="1" constant="true"/>
-          <speciesReference species="M_cpd00011_c0" stoichiometry="1" constant="true"/>
-          <speciesReference species="M_cpd00022_c0" stoichiometry="1" constant="true"/>
-        </listOfProducts>
-        <fbc:geneProductAssociation>
-          <fbc:and>
-            <fbc:geneProductRef fbc:geneProduct="G_ACZ81_RS14655"/>
-            <fbc:geneProductRef fbc:geneProduct="G_ACZ81_RS14650"/>
-            <fbc:geneProductRef fbc:geneProduct="G_ACZ81_RS14645"/>
-          </fbc:and>
-        </fbc:geneProductAssociation>
-      </reaction>
-      <reaction metaid="meta_R_rxn01084_c0" sboTerm="SBO:0000176" id="R_rxn01084_c0" name="ATP:cob(I)alamin Co-beta-adenosyltransferase [c0]" reversible="true" fast="false" fbc:lowerFluxBound="cobra_default_lb" fbc:upperFluxBound="cobra_default_ub">
-        <annotation>
-          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
-            <rdf:Description rdf:about="#meta_R_rxn01084_c0">
-              <bqbiol:is>
-                <rdf:Bag>
-                  <rdf:li rdf:resource="https://identifiers.org/seed.reaction/rxn01084"/>
-                  <rdf:li rdf:resource="https://identifiers.org/bigg.reaction/CBLAT"/>
-                  <rdf:li rdf:resource="https://identifiers.org/kegg.reaction/R01492"/>
-                  <rdf:li rdf:resource="https://identifiers.org/rhea/28674"/>
-                  <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR141889"/>
-                  <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR126347"/>
-                  <rdf:li rdf:resource="https://identifiers.org/biocyc/META:COBALADENOSYLTRANS-RXN"/>
-                  <rdf:li rdf:resource="https://identifiers.org/ec-code/2.5.1.17"/>
-                </rdf:Bag>
-              </bqbiol:is>
-            </rdf:Description>
-          </rdf:RDF>
-        </annotation>
-        <listOfReactants>
-          <speciesReference species="M_cpd00002_c0" stoichiometry="1" constant="true"/>
-          <speciesReference species="M_cpd00635_c0" stoichiometry="1" constant="true"/>
-        </listOfReactants>
-        <listOfProducts>
-          <speciesReference species="M_cpd00166_c0" stoichiometry="1" constant="true"/>
-          <speciesReference species="M_cpd00421_c0" stoichiometry="1" constant="true"/>
-        </listOfProducts>
-        <fbc:geneProductAssociation>
-          <fbc:geneProductRef fbc:geneProduct="G_ACZ81_RS08145"/>
-        </fbc:geneProductAssociation>
-      </reaction>
       <reaction metaid="meta_R_rxn15395_c0" sboTerm="SBO:0000176" id="R_rxn15395_c0" name="O-Succinyl-L-homoserine succinate-lyase (adding cysteine) [c0]" reversible="false" fast="false" fbc:lowerFluxBound="cobra_0_bound" fbc:upperFluxBound="cobra_default_ub">
         <annotation>
           <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
@@ -60933,36 +59739,6 @@
         </listOfProducts>
         <fbc:geneProductAssociation>
           <fbc:geneProductRef fbc:geneProduct="G_ACZ81_RS15350"/>
-        </fbc:geneProductAssociation>
-      </reaction>
-      <reaction metaid="meta_R_rxn15249_c0" sboTerm="SBO:0000176" id="R_rxn15249_c0" name="ATP:alpha-D-glucose 6-phosphotransferase [c0]" reversible="true" fast="false" fbc:lowerFluxBound="cobra_default_lb" fbc:upperFluxBound="cobra_default_ub">
-        <annotation>
-          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
-            <rdf:Description rdf:about="#meta_R_rxn15249_c0">
-              <bqbiol:is>
-                <rdf:Bag>
-                  <rdf:li rdf:resource="https://identifiers.org/seed.reaction/rxn15249"/>
-                  <rdf:li rdf:resource="https://identifiers.org/kegg.reaction/R01786"/>
-                  <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR100284"/>
-                  <rdf:li rdf:resource="https://identifiers.org/biocyc/META:RXN-1685"/>
-                  <rdf:li rdf:resource="https://identifiers.org/ec-code/2.7.1.1"/>
-                  <rdf:li rdf:resource="https://identifiers.org/ec-code/2.7.1.2"/>
-                </rdf:Bag>
-              </bqbiol:is>
-            </rdf:Description>
-          </rdf:RDF>
-        </annotation>
-        <listOfReactants>
-          <speciesReference species="M_cpd00002_c0" stoichiometry="1" constant="true"/>
-          <speciesReference species="M_cpd19001_c0" stoichiometry="1" constant="true"/>
-        </listOfReactants>
-        <listOfProducts>
-          <speciesReference species="M_cpd00008_c0" stoichiometry="1" constant="true"/>
-          <speciesReference species="M_cpd00067_c0" stoichiometry="1" constant="true"/>
-          <speciesReference species="M_cpd19006_c0" stoichiometry="1" constant="true"/>
-        </listOfProducts>
-        <fbc:geneProductAssociation>
-          <fbc:geneProductRef fbc:geneProduct="G_ACZ81_RS11740"/>
         </fbc:geneProductAssociation>
       </reaction>
       <reaction metaid="meta_R_rxn15466_c0" sboTerm="SBO:0000176" id="R_rxn15466_c0" name="(R)-2,3-Dihydroxy-3-methylbutanoate:NADP+ oxidoreductase (isomerizing) [c0]" reversible="true" fast="false" fbc:lowerFluxBound="cobra_default_lb" fbc:upperFluxBound="cobra_default_ub">
@@ -61285,43 +60061,6 @@
             <fbc:geneProductRef fbc:geneProduct="G_ACZ81_RS18905"/>
             <fbc:geneProductRef fbc:geneProduct="G_ACZ81_RS18910"/>
             <fbc:geneProductRef fbc:geneProduct="G_ACZ81_RS16255"/>
-          </fbc:and>
-        </fbc:geneProductAssociation>
-      </reaction>
-      <reaction metaid="meta_R_rxn08192_c0" sboTerm="SBO:0000655" id="R_rxn08192_c0" name="ABC-5-RXN.cp [c0]" reversible="false" fast="false" fbc:lowerFluxBound="cobra_0_bound" fbc:upperFluxBound="cobra_default_ub">
-        <annotation>
-          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
-            <rdf:Description rdf:about="#meta_R_rxn08192_c0">
-              <bqbiol:is>
-                <rdf:Bag>
-                  <rdf:li rdf:resource="https://identifiers.org/seed.reaction/rxn08192"/>
-                  <rdf:li rdf:resource="https://identifiers.org/bigg.reaction/CBL1abc"/>
-                  <rdf:li rdf:resource="https://identifiers.org/bigg.reaction/CBL1abcpp"/>
-                  <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR135737"/>
-                  <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR96471"/>
-                  <rdf:li rdf:resource="https://identifiers.org/biocyc/META:ABC-5-RXN"/>
-                  <rdf:li rdf:resource="https://identifiers.org/biocyc/META:3.6.3.33-RXN"/>
-                  <rdf:li rdf:resource="https://identifiers.org/ec-code/3.6.3.33"/>
-                </rdf:Bag>
-              </bqbiol:is>
-            </rdf:Description>
-          </rdf:RDF>
-        </annotation>
-        <listOfReactants>
-          <speciesReference species="M_cpd00001_c0" stoichiometry="1" constant="true"/>
-          <speciesReference species="M_cpd00002_c0" stoichiometry="1" constant="true"/>
-          <speciesReference species="M_cpd00635_e0" stoichiometry="1" constant="true"/>
-        </listOfReactants>
-        <listOfProducts>
-          <speciesReference species="M_cpd00008_c0" stoichiometry="1" constant="true"/>
-          <speciesReference species="M_cpd00009_c0" stoichiometry="1" constant="true"/>
-          <speciesReference species="M_cpd00067_c0" stoichiometry="1" constant="true"/>
-          <speciesReference species="M_cpd00635_c0" stoichiometry="1" constant="true"/>
-        </listOfProducts>
-        <fbc:geneProductAssociation>
-          <fbc:and>
-            <fbc:geneProductRef fbc:geneProduct="G_ACZ81_RS06695"/>
-            <fbc:geneProductRef fbc:geneProduct="G_ACZ81_RS15375"/>
           </fbc:and>
         </fbc:geneProductAssociation>
       </reaction>
@@ -61648,36 +60387,6 @@
           </fbc:and>
         </fbc:geneProductAssociation>
       </reaction>
-      <reaction metaid="meta_R_rxn23043_c0" sboTerm="SBO:0000176" id="R_rxn23043_c0" name="thiamin phosphate synthase [c0]" reversible="false" fast="false" fbc:lowerFluxBound="cobra_0_bound" fbc:upperFluxBound="cobra_default_ub">
-        <annotation>
-          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
-            <rdf:Description rdf:about="#meta_R_rxn23043_c0">
-              <bqbiol:is>
-                <rdf:Bag>
-                  <rdf:li rdf:resource="https://identifiers.org/seed.reaction/rxn23043"/>
-                  <rdf:li rdf:resource="https://identifiers.org/rhea/47845"/>
-                  <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR114610"/>
-                  <rdf:li rdf:resource="https://identifiers.org/biocyc/META:RXN-12611"/>
-                  <rdf:li rdf:resource="https://identifiers.org/ec-code/2.5.1.3"/>
-                </rdf:Bag>
-              </bqbiol:is>
-            </rdf:Description>
-          </rdf:RDF>
-        </annotation>
-        <listOfReactants>
-          <speciesReference species="M_cpd00067_c0" stoichiometry="2" constant="true"/>
-          <speciesReference species="M_cpd02894_c0" stoichiometry="1" constant="true"/>
-          <speciesReference species="M_cpd21479_c0" stoichiometry="1" constant="true"/>
-        </listOfReactants>
-        <listOfProducts>
-          <speciesReference species="M_cpd00011_c0" stoichiometry="1" constant="true"/>
-          <speciesReference species="M_cpd00012_c0" stoichiometry="1" constant="true"/>
-          <speciesReference species="M_cpd00793_c0" stoichiometry="1" constant="true"/>
-        </listOfProducts>
-        <fbc:geneProductAssociation>
-          <fbc:geneProductRef fbc:geneProduct="G_ACZ81_RS00495"/>
-        </fbc:geneProductAssociation>
-      </reaction>
       <reaction metaid="meta_R_rxn41896_c0" sboTerm="SBO:0000176" id="R_rxn41896_c0" name="[c0]" reversible="true" fast="false" fbc:lowerFluxBound="cobra_default_lb" fbc:upperFluxBound="cobra_default_ub">
         <annotation>
           <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
@@ -61910,37 +60619,6 @@
         </listOfProducts>
         <fbc:geneProductAssociation>
           <fbc:geneProductRef fbc:geneProduct="G_ACZ81_RS15200"/>
-        </fbc:geneProductAssociation>
-      </reaction>
-      <reaction metaid="meta_R_rxn10506_c0" sboTerm="SBO:0000176" id="R_rxn10506_c0" name="2,5-diamino-6-ribitylamino-4(3H)-pyrimidinone 5&apos;-phosphate deaminase [c0]" reversible="false" fast="false" fbc:lowerFluxBound="cobra_0_bound" fbc:upperFluxBound="cobra_default_ub">
-        <annotation>
-          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
-            <rdf:Description rdf:about="#meta_R_rxn10506_c0">
-              <bqbiol:is>
-                <rdf:Bag>
-                  <rdf:li rdf:resource="https://identifiers.org/seed.reaction/rxn10506"/>
-                  <rdf:li rdf:resource="https://identifiers.org/bigg.reaction/DRTPPD"/>
-                  <rdf:li rdf:resource="https://identifiers.org/kegg.reaction/R09377"/>
-                  <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR142381"/>
-                  <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR112805"/>
-                  <rdf:li rdf:resource="https://identifiers.org/biocyc/META:RXN-10058"/>
-                  <rdf:li rdf:resource="https://identifiers.org/ec-code/3.5.4.-"/>
-                </rdf:Bag>
-              </bqbiol:is>
-            </rdf:Description>
-          </rdf:RDF>
-        </annotation>
-        <listOfReactants>
-          <speciesReference species="M_cpd00001_c0" stoichiometry="1" constant="true"/>
-          <speciesReference species="M_cpd00067_c0" stoichiometry="1" constant="true"/>
-          <speciesReference species="M_cpd15807_c0" stoichiometry="1" constant="true"/>
-        </listOfReactants>
-        <listOfProducts>
-          <speciesReference species="M_cpd00013_c0" stoichiometry="1" constant="true"/>
-          <speciesReference species="M_cpd02720_c0" stoichiometry="1" constant="true"/>
-        </listOfProducts>
-        <fbc:geneProductAssociation>
-          <fbc:geneProductRef fbc:geneProduct="G_ACZ81_RS13040"/>
         </fbc:geneProductAssociation>
       </reaction>
       <reaction metaid="meta_R_rxn41452_c0" sboTerm="SBO:0000176" id="R_rxn41452_c0" name="[c0]" reversible="true" fast="false" fbc:lowerFluxBound="cobra_default_lb" fbc:upperFluxBound="cobra_default_ub">
@@ -62763,33 +61441,6 @@
           <fbc:geneProductRef fbc:geneProduct="G_ACZ81_RS03450"/>
         </fbc:geneProductAssociation>
       </reaction>
-      <reaction metaid="meta_R_rxn23336_c0" sboTerm="SBO:0000176" id="R_rxn23336_c0" name="octanoyl:GcvH transferase [c0]" reversible="true" fast="false" fbc:lowerFluxBound="cobra_default_lb" fbc:upperFluxBound="cobra_default_ub">
-        <annotation>
-          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
-            <rdf:Description rdf:about="#meta_R_rxn23336_c0">
-              <bqbiol:is>
-                <rdf:Bag>
-                  <rdf:li rdf:resource="https://identifiers.org/seed.reaction/rxn23336"/>
-                  <rdf:li rdf:resource="https://identifiers.org/biocyc/META:RXN-13037"/>
-                  <rdf:li rdf:resource="https://identifiers.org/ec-code/2.3.1.181"/>
-                </rdf:Bag>
-              </bqbiol:is>
-            </rdf:Description>
-          </rdf:RDF>
-        </annotation>
-        <listOfReactants>
-          <speciesReference species="M_cpd11470_c0" stoichiometry="1" constant="true"/>
-          <speciesReference species="M_cpd27144_c0" stoichiometry="1" constant="true"/>
-        </listOfReactants>
-        <listOfProducts>
-          <speciesReference species="M_cpd00067_c0" stoichiometry="1" constant="true"/>
-          <speciesReference species="M_cpd11493_c0" stoichiometry="1" constant="true"/>
-          <speciesReference species="M_cpd27713_c0" stoichiometry="1" constant="true"/>
-        </listOfProducts>
-        <fbc:geneProductAssociation>
-          <fbc:geneProductRef fbc:geneProduct="G_ACZ81_RS09285"/>
-        </fbc:geneProductAssociation>
-      </reaction>
       <reaction metaid="meta_R_rxn43470_c0" sboTerm="SBO:0000176" id="R_rxn43470_c0" name="[c0]" reversible="false" fast="false" fbc:lowerFluxBound="cobra_0_bound" fbc:upperFluxBound="cobra_default_ub">
         <annotation>
           <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
@@ -62877,60 +61528,6 @@
         </listOfProducts>
         <fbc:geneProductAssociation>
           <fbc:geneProductRef fbc:geneProduct="G_ACZ81_RS00965"/>
-        </fbc:geneProductAssociation>
-      </reaction>
-      <reaction metaid="meta_R_rxn15230_c0" sboTerm="SBO:0000176" id="R_rxn15230_c0" name="Lactose galactohydrolase [c0]" reversible="true" fast="false" fbc:lowerFluxBound="cobra_default_lb" fbc:upperFluxBound="cobra_default_ub">
-        <annotation>
-          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
-            <rdf:Description rdf:about="#meta_R_rxn15230_c0">
-              <bqbiol:is>
-                <rdf:Bag>
-                  <rdf:li rdf:resource="https://identifiers.org/seed.reaction/rxn15230"/>
-                  <rdf:li rdf:resource="https://identifiers.org/kegg.reaction/R06098"/>
-                  <rdf:li rdf:resource="https://identifiers.org/kegg.reaction/R01678"/>
-                  <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR101023"/>
-                  <rdf:li rdf:resource="https://identifiers.org/ec-code/3.2.1.108"/>
-                  <rdf:li rdf:resource="https://identifiers.org/ec-code/3.2.1.23"/>
-                </rdf:Bag>
-              </bqbiol:is>
-            </rdf:Description>
-          </rdf:RDF>
-        </annotation>
-        <listOfReactants>
-          <speciesReference species="M_cpd00001_c0" stoichiometry="1" constant="true"/>
-          <speciesReference species="M_cpd00208_c0" stoichiometry="1" constant="true"/>
-        </listOfReactants>
-        <listOfProducts>
-          <speciesReference species="M_cpd00108_c0" stoichiometry="1" constant="true"/>
-          <speciesReference species="M_cpd19001_c0" stoichiometry="1" constant="true"/>
-        </listOfProducts>
-        <fbc:geneProductAssociation>
-          <fbc:geneProductRef fbc:geneProduct="G_ACZ81_RS01185"/>
-        </fbc:geneProductAssociation>
-      </reaction>
-      <reaction metaid="meta_R_rxn20583_c0" sboTerm="SBO:0000176" id="R_rxn20583_c0" name="phosphoglucose mutase [c0]" reversible="true" fast="false" fbc:lowerFluxBound="cobra_default_lb" fbc:upperFluxBound="cobra_default_ub">
-        <annotation>
-          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
-            <rdf:Description rdf:about="#meta_R_rxn20583_c0">
-              <bqbiol:is>
-                <rdf:Bag>
-                  <rdf:li rdf:resource="https://identifiers.org/seed.reaction/rxn20583"/>
-                  <rdf:li rdf:resource="https://identifiers.org/kegg.reaction/R00959"/>
-                  <rdf:li rdf:resource="https://identifiers.org/biocyc/META:PHOSPHOGLUCMUT-RXN"/>
-                  <rdf:li rdf:resource="https://identifiers.org/ec-code/5.4.2.2"/>
-                </rdf:Bag>
-              </bqbiol:is>
-            </rdf:Description>
-          </rdf:RDF>
-        </annotation>
-        <listOfReactants>
-          <speciesReference species="M_cpd00089_c0" stoichiometry="1" constant="true"/>
-        </listOfReactants>
-        <listOfProducts>
-          <speciesReference species="M_cpd19006_c0" stoichiometry="1" constant="true"/>
-        </listOfProducts>
-        <fbc:geneProductAssociation>
-          <fbc:geneProductRef fbc:geneProduct="G_ACZ81_RS07420"/>
         </fbc:geneProductAssociation>
       </reaction>
       <reaction metaid="meta_R_rxn15467_c0" sboTerm="SBO:0000176" id="R_rxn15467_c0" name="(R)-2,3-Dihydroxy-3-methylbutanoate hydro-lyase [c0]" reversible="false" fast="false" fbc:lowerFluxBound="cobra_0_bound" fbc:upperFluxBound="cobra_default_ub">
@@ -63691,35 +62288,6 @@
         </listOfProducts>
         <fbc:geneProductAssociation>
           <fbc:geneProductRef fbc:geneProduct="G_ACZ81_RS02665"/>
-        </fbc:geneProductAssociation>
-      </reaction>
-      <reaction metaid="meta_R_rxn45692_c0" sboTerm="SBO:0000176" id="R_rxn45692_c0" name="cysteine:[ThiI sulfur-carrier protein]-L-cysteine sulfurtransferase desulfurase [c0]" reversible="false" fast="false" fbc:lowerFluxBound="cobra_0_bound" fbc:upperFluxBound="cobra_default_ub">
-        <annotation>
-          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
-            <rdf:Description rdf:about="#meta_R_rxn45692_c0">
-              <bqbiol:is>
-                <rdf:Bag>
-                  <rdf:li rdf:resource="https://identifiers.org/seed.reaction/rxn45692"/>
-                  <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR122991"/>
-                  <rdf:li rdf:resource="https://identifiers.org/biocyc/META:RXN-9787"/>
-                </rdf:Bag>
-              </bqbiol:is>
-            </rdf:Description>
-          </rdf:RDF>
-        </annotation>
-        <listOfReactants>
-          <speciesReference species="M_cpd00084_c0" stoichiometry="1" constant="true"/>
-          <speciesReference species="M_cpd28205_c0" stoichiometry="1" constant="true"/>
-        </listOfReactants>
-        <listOfProducts>
-          <speciesReference species="M_cpd00035_c0" stoichiometry="1" constant="true"/>
-          <speciesReference species="M_cpd14548_c0" stoichiometry="1" constant="true"/>
-        </listOfProducts>
-        <fbc:geneProductAssociation>
-          <fbc:and>
-            <fbc:geneProductRef fbc:geneProduct="G_ACZ81_RS13515"/>
-            <fbc:geneProductRef fbc:geneProduct="G_ACZ81_RS13535"/>
-          </fbc:and>
         </fbc:geneProductAssociation>
       </reaction>
       <reaction metaid="meta_R_rxn05469_c0" sboTerm="SBO:0000655" id="R_rxn05469_c0" name="pyruvate reversible transport via proton symport [c0]" reversible="true" fast="false" fbc:lowerFluxBound="cobra_default_lb" fbc:upperFluxBound="cobra_default_ub">
@@ -64941,11 +63509,6 @@
       <reaction metaid="meta_R_EX_cpd00731_e0" sboTerm="SBO:0000627" id="R_EX_cpd00731_e0" name="Exchange for Ala-Ala [e0]" reversible="true" fast="false" fbc:lowerFluxBound="cobra_default_lb" fbc:upperFluxBound="cobra_default_ub">
         <listOfReactants>
           <speciesReference species="M_cpd00731_e0" stoichiometry="1" constant="true"/>
-        </listOfReactants>
-      </reaction>
-      <reaction metaid="meta_R_EX_cpd00635_e0" sboTerm="SBO:0000627" id="R_EX_cpd00635_e0" name="Exchange for Cbl [e0]" reversible="true" fast="false" fbc:lowerFluxBound="cobra_default_lb" fbc:upperFluxBound="cobra_default_ub">
-        <listOfReactants>
-          <speciesReference species="M_cpd00635_e0" stoichiometry="1" constant="true"/>
         </listOfReactants>
       </reaction>
       <reaction metaid="meta_R_EX_cpd00129_e0" sboTerm="SBO:0000627" id="R_EX_cpd00129_e0" name="Exchange for L-Proline [e0]" reversible="true" fast="false" fbc:lowerFluxBound="cobra_default_lb" fbc:upperFluxBound="cobra_default_ub">
@@ -73020,45 +71583,6 @@
           </rdf:RDF>
         </annotation>
       </fbc:geneProduct>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS14995" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS14995" fbc:name="ACZ81_RS14995" fbc:label="G_ACZ81_RS14995">
-        <annotation>
-          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
-            <rdf:Description rdf:about="#meta_G_ACZ81_RS14995">
-              <bqbiol:is>
-                <rdf:Bag>
-                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_061486426.1"/>
-                </rdf:Bag>
-              </bqbiol:is>
-            </rdf:Description>
-          </rdf:RDF>
-        </annotation>
-      </fbc:geneProduct>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS16400" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS16400" fbc:name="ACZ81_RS16400" fbc:label="G_ACZ81_RS16400">
-        <annotation>
-          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
-            <rdf:Description rdf:about="#meta_G_ACZ81_RS16400">
-              <bqbiol:is>
-                <rdf:Bag>
-                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014950741.1"/>
-                </rdf:Bag>
-              </bqbiol:is>
-            </rdf:Description>
-          </rdf:RDF>
-        </annotation>
-      </fbc:geneProduct>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS10190" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS10190" fbc:name="ACZ81_RS10190" fbc:label="G_ACZ81_RS10190">
-        <annotation>
-          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
-            <rdf:Description rdf:about="#meta_G_ACZ81_RS10190">
-              <bqbiol:is>
-                <rdf:Bag>
-                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014949540.1"/>
-                </rdf:Bag>
-              </bqbiol:is>
-            </rdf:Description>
-          </rdf:RDF>
-        </annotation>
-      </fbc:geneProduct>
       <fbc:geneProduct metaid="meta_G_ACZ81_RS07015" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS07015" fbc:name="ACZ81_RS07015" fbc:label="G_ACZ81_RS07015">
         <annotation>
           <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
@@ -75250,19 +73774,6 @@
               <bqbiol:is>
                 <rdf:Bag>
                   <rdf:li rdf:resource="https://identifiers.org/refseq/WP_232376013.1"/>
-                </rdf:Bag>
-              </bqbiol:is>
-            </rdf:Description>
-          </rdf:RDF>
-        </annotation>
-      </fbc:geneProduct>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS11700" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS11700" fbc:name="ACZ81_RS11700" fbc:label="G_ACZ81_RS11700">
-        <annotation>
-          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
-            <rdf:Description rdf:about="#meta_G_ACZ81_RS11700">
-              <bqbiol:is>
-                <rdf:Bag>
-                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014949842.1"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>


### PR DESCRIPTION
This pull request:

- Removes `rxn00154_c0` for being a duplicate of `rxn00011_c0`+`rxn02342_c0`+`rxn01871_c0`+`rxn01241_c0`; see [MIT1002 model's PR #107](https://github.com/C-CoMP-STC/GEM-mit1002/pull/107)
- Removes `rxn23336_c0`, `cpd27144_c0`, and `cpd27713_c0`; see [MIT1002 model's PR #126](https://github.com/C-CoMP-STC/GEM-mit1002/pull/126)
- Removes `rxn45692_c0`, `cpd14548_c0`, and `cpd28205_c0`; see [MIT1002 model's PR #128](https://github.com/C-CoMP-STC/GEM-mit1002/pull/128)
- Removes `rxn10506_c0` and `cpd15807_c0`; see [MIT1002 model's PR #137](https://github.com/C-CoMP-STC/GEM-mit1002/pull/137) (the iron-sulfur cluster biosynthesis reaction was added in #3)
- Removes `rxn09039_c0`, `cpd15359_c0`, and `cpd15361_c0`; see [MIT1002 model's PR #139](https://github.com/C-CoMP-STC/GEM-mit1002/pull/139)
- Removes `rxn02305_c0`, `rxn23043_c0`, `rxn25839_c0`, `cpd02654_c0`, and `cpd22312_c0`; see [MIT1002 model's PR #144](https://github.com/C-CoMP-STC/GEM-mit1002/pull/144) (all other changes mentioned in that PR were made in #3)
- Removes `EX_cpd00635_e0`, `rxn01084_c0`, `rxn05029_c0`, `rxn08192_c0`, `rxn42230_c0`, `cpd00635_c0`, `cpd00635_e0`, `cpd03422_c0`, `cpd27744_c0`, `cpd28070_c0`, and `cpd33817_c0`; see [MIT1002 model's PR #146](https://github.com/C-CoMP-STC/GEM-mit1002/pull/146)
- Removes `rxn07979_c0` for being a duplicate of `rxn05462_c0`; see [MIT1002 model's PR #150](https://github.com/C-CoMP-STC/GEM-mit1002/pull/150)
- Removes `cpd15371_c0` for being a duplicate of `cpd11571_c0`; see [MIT1002 model's PR #150](https://github.com/C-CoMP-STC/GEM-mit1002/pull/150)
- Removes `cpd15572_c0` for being a duplicate of `cpd11572_c0`; see [MIT1002 model's PR #150](https://github.com/C-CoMP-STC/GEM-mit1002/pull/150)
- Removes `rxn06077_c0`, `rxn07438_c0`, `rxn07439_c0`, `cpd01914_c0`, `cpd12237_c0`, `cpd14507_c0`, `cpd14720_c0`, `ACZ81_RS14995`, `ACZ81_RS16400`, `ACZ81_RS10190`, and `ACZ81_RS11700`; see [MIT1002 model's PR #182](https://github.com/C-CoMP-STC/GEM-mit1002/pull/182)
- Removes `cpd02120_c0`; see [MIT1002 model's PR #186](https://github.com/C-CoMP-STC/GEM-mit1002/pull/186)
- Removes `rxn02929_c0` for being a duplicate of `rxn39452_c0`; see [MIT1002 model's PR #186](https://github.com/C-CoMP-STC/GEM-mit1002/pull/186)
- Removes `rxn01644_c0` for being a duplicate of `rxn40037_c0`; see [MIT1002 model's PR #186](https://github.com/C-CoMP-STC/GEM-mit1002/pull/186)
- Removes `rxn07981_c0` for being a duplicate of `rxn05239_c0`; see [MIT1002 model's PR #190](https://github.com/C-CoMP-STC/GEM-mit1002/pull/190)
- Removes `cpd11836_c0` for being a duplicate of `cpd11478_c0`; see [MIT1002 model's PR #190](https://github.com/C-CoMP-STC/GEM-mit1002/pull/190)
- Removes `rxn08131_c0` for being a duplicate of `rxn20643_c0`; see [MIT1002 model's PR #192](https://github.com/C-CoMP-STC/GEM-mit1002/pull/192)
- Removes `rxn02200_c0` for being a duplicate of `rxn02503_c0`+`rxn02201_c0`; see [MIT1002 model's PR #206](https://github.com/C-CoMP-STC/GEM-mit1002/pull/206)
- Removes `rxn08353_c0` for being a duplicate of `rxn11946_c0`; see [MIT1002 model's PR #208](https://github.com/C-CoMP-STC/GEM-mit1002/pull/208)
- Removes `cpd15360_c0` for being a duplicate of `cpd03449_c0`; see [MIT1002 model's PR #208](https://github.com/C-CoMP-STC/GEM-mit1002/pull/208)
- Removes `rxn01171_c0`; see [MIT1002 model's PR #211](https://github.com/C-CoMP-STC/GEM-mit1002/pull/211)
- Removes `rxn15249_c0` for being a duplicate of `rxn00216_c0`; see [MIT1002 model's PR #211](https://github.com/C-CoMP-STC/GEM-mit1002/pull/211)
- Removes `rxn15230_c0` for being a duplicate of `rxn00816_c0`; see [MIT1002 model's PR #211](https://github.com/C-CoMP-STC/GEM-mit1002/pull/211)
- Removes `cpd00190_c0` and `cpd19001_c0` for being duplicates of `cpd00027_c0`; see [MIT1002 model's PR #211](https://github.com/C-CoMP-STC/GEM-mit1002/pull/211)
- Removes `cpd19006_c0` for being a duplicate of `cpd00079_c0`; see [MIT1002 model's PR #211](https://github.com/C-CoMP-STC/GEM-mit1002/pull/211)
- Removes `rxn01108_c0` and `rxn01109_c0` for being duplicates of `rxn04945_c0`; see [MIT1002 model's PR #211](https://github.com/C-CoMP-STC/GEM-mit1002/pull/211)
- Removes `rxn08527_c0`, `rxn08528_c0`, and `rxn09272_c0` for being duplicates of `rxn00288_c0`+`rxn10126_c0`; see [MIT1002 model's PR #212](https://github.com/C-CoMP-STC/GEM-mit1002/pull/212)
- Removes `rxn20583_c0` for being a duplicate of `rxn00704_c0`; see [MIT1002 model's PR #213](https://github.com/C-CoMP-STC/GEM-mit1002/pull/213)