### PR TITLE
Feat: copy all metabolite name changes made in MIT1002 model

### DIFF
--- a/model.xml
+++ b/model.xml
@@ -15,7 +15,7 @@
       <compartment id="e0" constant="true"/>
     </listOfCompartments>
     <listOfSpecies>
-      <species metaid="meta_M_cpd00443_c0" sboTerm="SBO:0000247" id="M_cpd00443_c0" name="ABEE [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-1" fbc:chemicalFormula="C7H6NO2">
+      <species metaid="meta_M_cpd00443_c0" sboTerm="SBO:0000247" id="M_cpd00443_c0" name="4-aminobenzoate [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-1" fbc:chemicalFormula="C7H6NO2">
         <annotation>
           <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
             <rdf:Description rdf:about="#meta_M_cpd00443_c0">
@@ -709,7 +709,7 @@
           </rdf:RDF>
         </annotation>
       </species>
-      <species metaid="meta_M_cpd11441_c0" sboTerm="SBO:0000247" id="M_cpd11441_c0" name="fa6coa [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-3" fbc:chemicalFormula="C37H63N7O17P3S">
+      <species metaid="meta_M_cpd11441_c0" sboTerm="SBO:0000247" id="M_cpd11441_c0" name="14-Methylpentadecanoyl-CoA [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-3" fbc:chemicalFormula="C37H63N7O17P3S">
         <annotation>
           <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
             <rdf:Description rdf:about="#meta_M_cpd11441_c0">
@@ -894,7 +894,7 @@
           </rdf:RDF>
         </annotation>
       </species>
-      <species metaid="meta_M_cpd03049_c0" sboTerm="SBO:0000247" id="M_cpd03049_c0" name="2-Hydroxyethyl-ThPP [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-1" fbc:chemicalFormula="C14H21N4O8P2S">
+      <species metaid="meta_M_cpd03049_c0" sboTerm="SBO:0000247" id="M_cpd03049_c0" name="2-Hydroxyethyl-TPP [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-1" fbc:chemicalFormula="C14H21N4O8P2S">
         <annotation>
           <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
             <rdf:Description rdf:about="#meta_M_cpd03049_c0">
@@ -1111,7 +1111,7 @@
           </rdf:RDF>
         </annotation>
       </species>
-      <species metaid="meta_M_cpd03114_c0" sboTerm="SBO:0000247" id="M_cpd03114_c0" name="3-Oxopalmitoyl-CoA [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-4" fbc:chemicalFormula="C37H60N7O18P3S">
+      <species metaid="meta_M_cpd03114_c0" sboTerm="SBO:0000247" id="M_cpd03114_c0" name="3-Oxohexadecanoyl-CoA [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-4" fbc:chemicalFormula="C37H60N7O18P3S">
         <annotation>
           <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
             <rdf:Description rdf:about="#meta_M_cpd03114_c0">
@@ -1130,7 +1130,7 @@
           </rdf:RDF>
         </annotation>
       </species>
-      <species metaid="meta_M_cpd11466_c0" sboTerm="SBO:0000247" id="M_cpd11466_c0" name="Myristoyl-ACP [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-2" fbc:chemicalFormula="C25H48N2O8PRS">
+      <species metaid="meta_M_cpd11466_c0" sboTerm="SBO:0000247" id="M_cpd11466_c0" name="Tetradecanoyl-ACP [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-2" fbc:chemicalFormula="C25H48N2O8PRS">
         <annotation>
           <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
             <rdf:Description rdf:about="#meta_M_cpd11466_c0">
@@ -1146,7 +1146,7 @@
           </rdf:RDF>
         </annotation>
       </species>
-      <species metaid="meta_M_cpd01695_c0" sboTerm="SBO:0000247" id="M_cpd01695_c0" name="Myristoyl-CoA [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-4" fbc:chemicalFormula="C35H58N7O17P3S">
+      <species metaid="meta_M_cpd01695_c0" sboTerm="SBO:0000247" id="M_cpd01695_c0" name="Tetradecanoyl-CoA [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-4" fbc:chemicalFormula="C35H58N7O17P3S">
         <annotation>
           <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
             <rdf:Description rdf:about="#meta_M_cpd01695_c0">
@@ -1503,7 +1503,7 @@
           </rdf:RDF>
         </annotation>
       </species>
-      <species metaid="meta_M_cpd15688_c0" sboTerm="SBO:0000247" id="M_cpd15688_c0" name="CDP-1,2-diisohexadecanoylglycerol [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-2" fbc:chemicalFormula="C44H79N3O15P2">
+      <species metaid="meta_M_cpd15688_c0" sboTerm="SBO:0000247" id="M_cpd15688_c0" name="CDP-1,2-di-14-methylpentadecanoylglycerol [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-2" fbc:chemicalFormula="C44H79N3O15P2">
         <annotation>
           <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
             <rdf:Description rdf:about="#meta_M_cpd15688_c0">
@@ -1621,7 +1621,7 @@
           </rdf:RDF>
         </annotation>
       </species>
-      <species metaid="meta_M_cpd15727_c0" sboTerm="SBO:0000247" id="M_cpd15727_c0" name="Diisohexadecanoylphosphatidylglycerol [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-1" fbc:chemicalFormula="C38H74O10P">
+      <species metaid="meta_M_cpd15727_c0" sboTerm="SBO:0000247" id="M_cpd15727_c0" name="1,2-di-14-methylpentadecanoyl-sn-glycero-3-phosphoglycerol [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-1" fbc:chemicalFormula="C38H74O10P">
         <annotation>
           <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
             <rdf:Description rdf:about="#meta_M_cpd15727_c0">
@@ -1731,7 +1731,7 @@
           </rdf:RDF>
         </annotation>
       </species>
-      <species metaid="meta_M_cpd00193_c0" sboTerm="SBO:0000247" id="M_cpd00193_c0" name="APS [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-2" fbc:chemicalFormula="C10H12N5O10PS">
+      <species metaid="meta_M_cpd00193_c0" sboTerm="SBO:0000247" id="M_cpd00193_c0" name="5&apos;-Adenylyl sulfate [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-2" fbc:chemicalFormula="C10H12N5O10PS">
         <annotation>
           <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
             <rdf:Description rdf:about="#meta_M_cpd00193_c0">
@@ -2113,7 +2113,7 @@
           </rdf:RDF>
         </annotation>
       </species>
-      <species metaid="meta_M_cpd15237_c0" sboTerm="SBO:0000247" id="M_cpd15237_c0" name="hexadecenoate [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-1" fbc:chemicalFormula="C16H29O2">
+      <species metaid="meta_M_cpd15237_c0" sboTerm="SBO:0000247" id="M_cpd15237_c0" name="(9Z)-Hexadecenoate [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-1" fbc:chemicalFormula="C16H29O2">
         <annotation>
           <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
             <rdf:Description rdf:about="#meta_M_cpd15237_c0">
@@ -2568,7 +2568,7 @@
           </rdf:RDF>
         </annotation>
       </species>
-      <species metaid="meta_M_cpd15686_c0" sboTerm="SBO:0000247" id="M_cpd15686_c0" name="CDP-1,2-diisopentadecanoylglycerol [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-2" fbc:chemicalFormula="C42H75N3O15P2">
+      <species metaid="meta_M_cpd15686_c0" sboTerm="SBO:0000247" id="M_cpd15686_c0" name="CDP-1,2-di-13-methyltetradecanoylglycerol [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-2" fbc:chemicalFormula="C42H75N3O15P2">
         <annotation>
           <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
             <rdf:Description rdf:about="#meta_M_cpd15686_c0">
@@ -2673,7 +2673,7 @@
           </rdf:RDF>
         </annotation>
       </species>
-      <species metaid="meta_M_cpd11439_c0" sboTerm="SBO:0000247" id="M_cpd11439_c0" name="fa4coa [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-3" fbc:chemicalFormula="C36H61N7O17P3S">
+      <species metaid="meta_M_cpd11439_c0" sboTerm="SBO:0000247" id="M_cpd11439_c0" name="12-Methyltetradecanoyl-CoA [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-3" fbc:chemicalFormula="C36H61N7O17P3S">
         <annotation>
           <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
             <rdf:Description rdf:about="#meta_M_cpd11439_c0">
@@ -2687,7 +2687,7 @@
           </rdf:RDF>
         </annotation>
       </species>
-      <species metaid="meta_M_cpd15675_c0" sboTerm="SBO:0000247" id="M_cpd15675_c0" name="1-anteisopentadecanoyl-sn-glycerol 3-phosphate [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-1" fbc:chemicalFormula="C18H36O7P">
+      <species metaid="meta_M_cpd15675_c0" sboTerm="SBO:0000247" id="M_cpd15675_c0" name="1-12-methyltetradecanoyl-sn-glycerol-3-phosphate [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-1" fbc:chemicalFormula="C18H36O7P">
         <annotation>
           <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
             <rdf:Description rdf:about="#meta_M_cpd15675_c0">
@@ -2735,7 +2735,7 @@
           </rdf:RDF>
         </annotation>
       </species>
-      <species metaid="meta_M_cpd15682_c0" sboTerm="SBO:0000247" id="M_cpd15682_c0" name="1,2-diisohexadecanoyl-sn-glycerol 3-phosphate [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-1" fbc:chemicalFormula="C35H68O8P">
+      <species metaid="meta_M_cpd15682_c0" sboTerm="SBO:0000247" id="M_cpd15682_c0" name="1,2-di-14-methylpentadecanoyl-sn-glycerol-3-phosphate [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-1" fbc:chemicalFormula="C35H68O8P">
         <annotation>
           <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
             <rdf:Description rdf:about="#meta_M_cpd15682_c0">
@@ -2786,7 +2786,7 @@
           </rdf:RDF>
         </annotation>
       </species>
-      <species metaid="meta_M_cpd11483_c0" sboTerm="SBO:0000247" id="M_cpd11483_c0" name="(R)-3-Hydroxyoctanoyl-[acyl-carrier protein] [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-2" fbc:chemicalFormula="C19H36N2O9PRS">
+      <species metaid="meta_M_cpd11483_c0" sboTerm="SBO:0000247" id="M_cpd11483_c0" name="(3R)-3-Hydroxyoctanoyl-ACP [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-2" fbc:chemicalFormula="C19H36N2O9PRS">
         <annotation>
           <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
             <rdf:Description rdf:about="#meta_M_cpd11483_c0">
@@ -2802,7 +2802,7 @@
           </rdf:RDF>
         </annotation>
       </species>
-      <species metaid="meta_M_cpd11471_c0" sboTerm="SBO:0000247" id="M_cpd11471_c0" name="(2E)-Octenoyl-[acp] [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-2" fbc:chemicalFormula="C19H34N2O8PRS">
+      <species metaid="meta_M_cpd11471_c0" sboTerm="SBO:0000247" id="M_cpd11471_c0" name="(2E)-Octenoyl-ACP [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-2" fbc:chemicalFormula="C19H34N2O8PRS">
         <annotation>
           <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
             <rdf:Description rdf:about="#meta_M_cpd11471_c0">
@@ -2819,7 +2819,7 @@
           </rdf:RDF>
         </annotation>
       </species>
-      <species metaid="meta_M_cpd11432_c0" sboTerm="SBO:0000247" id="M_cpd11432_c0" name="fa11coa [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-3" fbc:chemicalFormula="C38H65N7O17P3S">
+      <species metaid="meta_M_cpd11432_c0" sboTerm="SBO:0000247" id="M_cpd11432_c0" name="15-Methylhexadecanoyl-CoA [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-3" fbc:chemicalFormula="C38H65N7O17P3S">
         <annotation>
           <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
             <rdf:Description rdf:about="#meta_M_cpd11432_c0">
@@ -2833,7 +2833,7 @@
           </rdf:RDF>
         </annotation>
       </species>
-      <species metaid="meta_M_cpd15671_c0" sboTerm="SBO:0000247" id="M_cpd15671_c0" name="1-isoheptadecanoyl-sn-glycerol 3-phosphate [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-1" fbc:chemicalFormula="C20H40O7P">
+      <species metaid="meta_M_cpd15671_c0" sboTerm="SBO:0000247" id="M_cpd15671_c0" name="1-14-methylpentadecanoyl-sn-glycerol-3-phosphate [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-1" fbc:chemicalFormula="C20H40O7P">
         <annotation>
           <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
             <rdf:Description rdf:about="#meta_M_cpd15671_c0">
@@ -2964,7 +2964,7 @@
           </rdf:RDF>
         </annotation>
       </species>
-      <species metaid="meta_M_cpd11513_c0" sboTerm="SBO:0000247" id="M_cpd11513_c0" name="12-methyl-3-hydroxy-tetra-decanoyl-ACP [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-1" fbc:chemicalFormula="C26H49N2O9PRS">
+      <species metaid="meta_M_cpd11513_c0" sboTerm="SBO:0000247" id="M_cpd11513_c0" name="(3R)-3-hydroxy-12-methyltetradecanoyl-ACP [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-1" fbc:chemicalFormula="C26H49N2O9PRS">
         <annotation>
           <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
             <rdf:Description rdf:about="#meta_M_cpd11513_c0">
@@ -2978,7 +2978,7 @@
           </rdf:RDF>
         </annotation>
       </species>
-      <species metaid="meta_M_cpd11514_c0" sboTerm="SBO:0000247" id="M_cpd11514_c0" name="12-methyl-trans-tetra-dec-2-enoyl-ACP [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-1" fbc:chemicalFormula="C26H47N2O8PRS">
+      <species metaid="meta_M_cpd11514_c0" sboTerm="SBO:0000247" id="M_cpd11514_c0" name="(2E)-12-methyltetradecenoyl-ACP [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-1" fbc:chemicalFormula="C26H47N2O8PRS">
         <annotation>
           <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
             <rdf:Description rdf:about="#meta_M_cpd11514_c0">
@@ -3208,7 +3208,7 @@
           </rdf:RDF>
         </annotation>
       </species>
-      <species metaid="meta_M_cpd15685_c0" sboTerm="SBO:0000247" id="M_cpd15685_c0" name="CDP-1,2-diisotetradecanoylglycerol [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-2" fbc:chemicalFormula="C40H71N3O15P2">
+      <species metaid="meta_M_cpd15685_c0" sboTerm="SBO:0000247" id="M_cpd15685_c0" name="CDP-1,2-di-12-methyltridecanoylglycerol [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-2" fbc:chemicalFormula="C40H71N3O15P2">
         <annotation>
           <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
             <rdf:Description rdf:about="#meta_M_cpd15685_c0">
@@ -3310,7 +3310,7 @@
           </rdf:RDF>
         </annotation>
       </species>
-      <species metaid="meta_M_cpd11505_c0" sboTerm="SBO:0000247" id="M_cpd11505_c0" name="8-methyl-3-hydroxy-decanoyl-ACP [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-1" fbc:chemicalFormula="C22H41N2O9PRS">
+      <species metaid="meta_M_cpd11505_c0" sboTerm="SBO:0000247" id="M_cpd11505_c0" name="(3R)-3-hydroxy-8-methyldecanoyl-ACP [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-1" fbc:chemicalFormula="C22H41N2O9PRS">
         <annotation>
           <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
             <rdf:Description rdf:about="#meta_M_cpd11505_c0">
@@ -3324,7 +3324,7 @@
           </rdf:RDF>
         </annotation>
       </species>
-      <species metaid="meta_M_cpd11506_c0" sboTerm="SBO:0000247" id="M_cpd11506_c0" name="8-methyl-trans-dec-2-enoyl-ACP [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-1" fbc:chemicalFormula="C22H39N2O8PRS">
+      <species metaid="meta_M_cpd11506_c0" sboTerm="SBO:0000247" id="M_cpd11506_c0" name="(2E)-8-methyldecenoyl-ACP [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-1" fbc:chemicalFormula="C22H39N2O8PRS">
         <annotation>
           <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
             <rdf:Description rdf:about="#meta_M_cpd11506_c0">
@@ -3584,7 +3584,7 @@
           </rdf:RDF>
         </annotation>
       </species>
-      <species metaid="meta_M_cpd01741_c0" sboTerm="SBO:0000247" id="M_cpd01741_c0" name="ddca [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-1" fbc:chemicalFormula="C12H23O2">
+      <species metaid="meta_M_cpd01741_c0" sboTerm="SBO:0000247" id="M_cpd01741_c0" name="Dodecanoate [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-1" fbc:chemicalFormula="C12H23O2">
         <annotation>
           <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
             <rdf:Description rdf:about="#meta_M_cpd01741_c0">
@@ -3817,7 +3817,7 @@
           </rdf:RDF>
         </annotation>
       </species>
-      <species metaid="meta_M_cpd15308_c0" sboTerm="SBO:0000247" id="M_cpd15308_c0" name="1,2-Diacyl-sn-glycerol ditetradec-7-enoyl [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="0" fbc:chemicalFormula="C31H56O5">
+      <species metaid="meta_M_cpd15308_c0" sboTerm="SBO:0000247" id="M_cpd15308_c0" name="1,2-di-(7Z)-tetradecenoylglycerol [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="0" fbc:chemicalFormula="C31H56O5">
         <annotation>
           <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
             <rdf:Description rdf:about="#meta_M_cpd15308_c0">
@@ -3832,7 +3832,7 @@
           </rdf:RDF>
         </annotation>
       </species>
-      <species metaid="meta_M_cpd15523_c0" sboTerm="SBO:0000247" id="M_cpd15523_c0" name="1,2-ditetradec-7-enoyl-sn-glycerol 3-phosphate [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-1" fbc:chemicalFormula="C31H56O8P">
+      <species metaid="meta_M_cpd15523_c0" sboTerm="SBO:0000247" id="M_cpd15523_c0" name="1,2-di-(7Z)-tetradecenoyl-sn-glycerol-3-phosphate [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-1" fbc:chemicalFormula="C31H56O8P">
         <annotation>
           <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
             <rdf:Description rdf:about="#meta_M_cpd15523_c0">
@@ -3933,7 +3933,7 @@
           </rdf:RDF>
         </annotation>
       </species>
-      <species metaid="meta_M_cpd15702_c0" sboTerm="SBO:0000247" id="M_cpd15702_c0" name="1,2-Dianteisoheptadecanoyl-sn-glycerol [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="0" fbc:chemicalFormula="C37H72O5">
+      <species metaid="meta_M_cpd15702_c0" sboTerm="SBO:0000247" id="M_cpd15702_c0" name="1,2-di-14-methylhexadecanoylglycerol [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="0" fbc:chemicalFormula="C37H72O5">
         <annotation>
           <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
             <rdf:Description rdf:about="#meta_M_cpd15702_c0">
@@ -3947,7 +3947,7 @@
           </rdf:RDF>
         </annotation>
       </species>
-      <species metaid="meta_M_cpd15678_c0" sboTerm="SBO:0000247" id="M_cpd15678_c0" name="1,2-dianteisoheptadecanoyl-sn-glycerol 3-phosphate [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-1" fbc:chemicalFormula="C37H72O8P">
+      <species metaid="meta_M_cpd15678_c0" sboTerm="SBO:0000247" id="M_cpd15678_c0" name="1,2-di-14-methylhexadecanoyl-sn-glycerol-3-phosphate [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-1" fbc:chemicalFormula="C37H72O8P">
         <annotation>
           <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
             <rdf:Description rdf:about="#meta_M_cpd15678_c0">
@@ -4336,7 +4336,7 @@
           </rdf:RDF>
         </annotation>
       </species>
-      <species metaid="meta_M_cpd15422_c0" sboTerm="SBO:0000247" id="M_cpd15422_c0" name="CDP-1,2-ditetradec-7-enoylglycerol [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-2" fbc:chemicalFormula="C40H67N3O15P2">
+      <species metaid="meta_M_cpd15422_c0" sboTerm="SBO:0000247" id="M_cpd15422_c0" name="CDP-1,2-di-(7Z)-tetradecenoylglycerol [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-2" fbc:chemicalFormula="C40H67N3O15P2">
         <annotation>
           <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
             <rdf:Description rdf:about="#meta_M_cpd15422_c0">
@@ -4444,7 +4444,7 @@
           </rdf:RDF>
         </annotation>
       </species>
-      <species metaid="meta_M_cpd15357_c0" sboTerm="SBO:0000247" id="M_cpd15357_c0" name="2-octadec-11-enoyl-sn-glycerol 3-phosphate [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-1" fbc:chemicalFormula="C21H40O7P">
+      <species metaid="meta_M_cpd15357_c0" sboTerm="SBO:0000247" id="M_cpd15357_c0" name="2-(11Z)-octadecenoyl-sn-glycerol-3-phosphate [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-1" fbc:chemicalFormula="C21H40O7P">
         <annotation>
           <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
             <rdf:Description rdf:about="#meta_M_cpd15357_c0">
@@ -4459,7 +4459,7 @@
           </rdf:RDF>
         </annotation>
       </species>
-      <species metaid="meta_M_cpd15269_c0" sboTerm="SBO:0000247" id="M_cpd15269_c0" name="octadecenoate [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-1" fbc:chemicalFormula="C18H33O2">
+      <species metaid="meta_M_cpd15269_c0" sboTerm="SBO:0000247" id="M_cpd15269_c0" name="(11Z)-Octadecenoate [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-1" fbc:chemicalFormula="C18H33O2">
         <annotation>
           <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
             <rdf:Description rdf:about="#meta_M_cpd15269_c0">
@@ -4510,7 +4510,7 @@
           </rdf:RDF>
         </annotation>
       </species>
-      <species metaid="meta_M_cpd11492_c0" sboTerm="SBO:0000247" id="M_cpd11492_c0" name="Malonyl-acyl-carrierprotein- [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-2" fbc:chemicalFormula="C14H24N2O10PRS">
+      <species metaid="meta_M_cpd11492_c0" sboTerm="SBO:0000247" id="M_cpd11492_c0" name="Malonyl-ACP [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-2" fbc:chemicalFormula="C14H24N2O10PRS">
         <annotation>
           <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
             <rdf:Description rdf:about="#meta_M_cpd11492_c0">
@@ -4529,7 +4529,7 @@
           </rdf:RDF>
         </annotation>
       </species>
-      <species metaid="meta_M_cpd11486_c0" sboTerm="SBO:0000247" id="M_cpd11486_c0" name="3-Oxohexanoyl-[acp] [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-2" fbc:chemicalFormula="C17H30N2O9PRS">
+      <species metaid="meta_M_cpd11486_c0" sboTerm="SBO:0000247" id="M_cpd11486_c0" name="3-Oxohexanoyl-ACP [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-2" fbc:chemicalFormula="C17H30N2O9PRS">
         <annotation>
           <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
             <rdf:Description rdf:about="#meta_M_cpd11486_c0">
@@ -4661,7 +4661,7 @@
           </rdf:RDF>
         </annotation>
       </species>
-      <species metaid="meta_M_cpd11522_c0" sboTerm="SBO:0000247" id="M_cpd11522_c0" name="5-methyl-3-hydroxy-hexanoyl-ACP [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-1" fbc:chemicalFormula="C18H33N2O9PRS">
+      <species metaid="meta_M_cpd11522_c0" sboTerm="SBO:0000247" id="M_cpd11522_c0" name="(3R)-3-hydroxy-5-methylhexanoyl-ACP [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-1" fbc:chemicalFormula="C18H33N2O9PRS">
         <annotation>
           <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
             <rdf:Description rdf:about="#meta_M_cpd11522_c0">
@@ -4675,7 +4675,7 @@
           </rdf:RDF>
         </annotation>
       </species>
-      <species metaid="meta_M_cpd11523_c0" sboTerm="SBO:0000247" id="M_cpd11523_c0" name="5-methyl-trans-hex-2-enoyl-ACP [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-1" fbc:chemicalFormula="C18H31N2O8PRS">
+      <species metaid="meta_M_cpd11523_c0" sboTerm="SBO:0000247" id="M_cpd11523_c0" name="(2E)-5-methylhexenoyl-ACP [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-1" fbc:chemicalFormula="C18H31N2O8PRS">
         <annotation>
           <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
             <rdf:Description rdf:about="#meta_M_cpd11523_c0">
@@ -4709,7 +4709,7 @@
           </rdf:RDF>
         </annotation>
       </species>
-      <species metaid="meta_M_cpd11421_c0" sboTerm="SBO:0000247" id="M_cpd11421_c0" name="trdrd [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="0" fbc:chemicalFormula="C6H9NO2R2S2">
+      <species metaid="meta_M_cpd11421_c0" sboTerm="SBO:0000247" id="M_cpd11421_c0" name="Reduced thioredoxin [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="0" fbc:chemicalFormula="C6H9NO2R2S2">
         <annotation>
           <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
             <rdf:Description rdf:about="#meta_M_cpd11421_c0">
@@ -4766,7 +4766,7 @@
           </rdf:RDF>
         </annotation>
       </species>
-      <species metaid="meta_M_cpd11420_c0" sboTerm="SBO:0000247" id="M_cpd11420_c0" name="trdox [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="0" fbc:chemicalFormula="C6H7NO2R2S2">
+      <species metaid="meta_M_cpd11420_c0" sboTerm="SBO:0000247" id="M_cpd11420_c0" name="Oxidized thioredoxin [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="0" fbc:chemicalFormula="C6H7NO2R2S2">
         <annotation>
           <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
             <rdf:Description rdf:about="#meta_M_cpd11420_c0">
@@ -4888,7 +4888,7 @@
           </rdf:RDF>
         </annotation>
       </species>
-      <species metaid="meta_M_cpd03189_c0" sboTerm="SBO:0000247" id="M_cpd03189_c0" name="3-Carboxy-1-hydroxypropyl-ThPP [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-2" fbc:chemicalFormula="C16H22N4O10P2S">
+      <species metaid="meta_M_cpd03189_c0" sboTerm="SBO:0000247" id="M_cpd03189_c0" name="3-Carboxy-1-hydroxypropyl-TPP [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-2" fbc:chemicalFormula="C16H22N4O10P2S">
         <annotation>
           <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
             <rdf:Description rdf:about="#meta_M_cpd03189_c0">
@@ -4924,7 +4924,7 @@
           </rdf:RDF>
         </annotation>
       </species>
-      <species metaid="meta_M_cpd15239_c0" sboTerm="SBO:0000247" id="M_cpd15239_c0" name="Hexadecenoyl-ACP [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-1" fbc:chemicalFormula="C27H49N2O8PRS">
+      <species metaid="meta_M_cpd15239_c0" sboTerm="SBO:0000247" id="M_cpd15239_c0" name="(9Z)-Hexadecenoyl-ACP [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-1" fbc:chemicalFormula="C27H49N2O8PRS">
         <annotation>
           <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
             <rdf:Description rdf:about="#meta_M_cpd15239_c0">
@@ -4939,7 +4939,7 @@
           </rdf:RDF>
         </annotation>
       </species>
-      <species metaid="meta_M_cpd15418_c0" sboTerm="SBO:0000247" id="M_cpd15418_c0" name="CDP-1,2-dihexadec-9-enoylglycerol [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-2" fbc:chemicalFormula="C44H75N3O15P2">
+      <species metaid="meta_M_cpd15418_c0" sboTerm="SBO:0000247" id="M_cpd15418_c0" name="CDP-1,2-di-(9Z)-hexadecenoylglycerol [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-2" fbc:chemicalFormula="C44H75N3O15P2">
         <annotation>
           <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
             <rdf:Description rdf:about="#meta_M_cpd15418_c0">
@@ -5083,7 +5083,7 @@
           </rdf:RDF>
         </annotation>
       </species>
-      <species metaid="meta_M_cpd00239_c0" sboTerm="SBO:0000247" id="M_cpd00239_c0" name="H2S [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-1" fbc:chemicalFormula="HS">
+      <species metaid="meta_M_cpd00239_c0" sboTerm="SBO:0000247" id="M_cpd00239_c0" name="Bisulfide (HS-) [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-1" fbc:chemicalFormula="HS">
         <annotation>
           <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
             <rdf:Description rdf:about="#meta_M_cpd00239_c0">
@@ -5296,7 +5296,7 @@
           </rdf:RDF>
         </annotation>
       </species>
-      <species metaid="meta_M_cpd00508_c0" sboTerm="SBO:0000247" id="M_cpd00508_c0" name="3MOP [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-1" fbc:chemicalFormula="C6H9O3">
+      <species metaid="meta_M_cpd00508_c0" sboTerm="SBO:0000247" id="M_cpd00508_c0" name="3-methyl-2-oxopentoate [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-1" fbc:chemicalFormula="C6H9O3">
         <annotation>
           <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
             <rdf:Description rdf:about="#meta_M_cpd00508_c0">
@@ -5633,7 +5633,7 @@
           </rdf:RDF>
         </annotation>
       </species>
-      <species metaid="meta_M_cpd11490_c0" sboTerm="SBO:0000247" id="M_cpd11490_c0" name="3-oxooctanoyl-acp [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-2" fbc:chemicalFormula="C19H34N2O9PRS">
+      <species metaid="meta_M_cpd11490_c0" sboTerm="SBO:0000247" id="M_cpd11490_c0" name="3-Oxooctanoyl-ACP [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-2" fbc:chemicalFormula="C19H34N2O9PRS">
         <annotation>
           <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
             <rdf:Description rdf:about="#meta_M_cpd11490_c0">
@@ -5834,7 +5834,7 @@
           </rdf:RDF>
         </annotation>
       </species>
-      <species metaid="meta_M_cpd11526_c0" sboTerm="SBO:0000247" id="M_cpd11526_c0" name="7-methyl-3-hydroxy-octanoyl-ACP [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-1" fbc:chemicalFormula="C20H37N2O9PRS">
+      <species metaid="meta_M_cpd11526_c0" sboTerm="SBO:0000247" id="M_cpd11526_c0" name="(3R)-3-hydroxy-7-methyloctanoyl-ACP [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-1" fbc:chemicalFormula="C20H37N2O9PRS">
         <annotation>
           <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
             <rdf:Description rdf:about="#meta_M_cpd11526_c0">
@@ -5848,7 +5848,7 @@
           </rdf:RDF>
         </annotation>
       </species>
-      <species metaid="meta_M_cpd11527_c0" sboTerm="SBO:0000247" id="M_cpd11527_c0" name="7-methyl-trans-oct-2-enoyl-ACP [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-1" fbc:chemicalFormula="C20H35N2O8PRS">
+      <species metaid="meta_M_cpd11527_c0" sboTerm="SBO:0000247" id="M_cpd11527_c0" name="(2E)-7-methyloctenoyl-ACP [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-1" fbc:chemicalFormula="C20H35N2O8PRS">
         <annotation>
           <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
             <rdf:Description rdf:about="#meta_M_cpd11527_c0">
@@ -6309,7 +6309,7 @@
           </rdf:RDF>
         </annotation>
       </species>
-      <species metaid="meta_M_cpd11469_c0" sboTerm="SBO:0000247" id="M_cpd11469_c0" name="(2E)-Dodecenoyl-[acp] [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-2" fbc:chemicalFormula="C23H41N2O8PRS">
+      <species metaid="meta_M_cpd11469_c0" sboTerm="SBO:0000247" id="M_cpd11469_c0" name="(2E)-Dodecenoyl-ACP [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-2" fbc:chemicalFormula="C23H41N2O8PRS">
         <annotation>
           <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
             <rdf:Description rdf:about="#meta_M_cpd11469_c0">
@@ -6481,7 +6481,7 @@
           </rdf:RDF>
         </annotation>
       </species>
-      <species metaid="meta_M_cpd15328_c0" sboTerm="SBO:0000247" id="M_cpd15328_c0" name="1-octadec-11-enoyl-sn-glycerol 3-phosphate [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-1" fbc:chemicalFormula="C21H40O7P">
+      <species metaid="meta_M_cpd15328_c0" sboTerm="SBO:0000247" id="M_cpd15328_c0" name="1-(11Z)-octadecenoyl-sn-glycerol-3-phosphate [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-1" fbc:chemicalFormula="C21H40O7P">
         <annotation>
           <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
             <rdf:Description rdf:about="#meta_M_cpd15328_c0">
@@ -6534,7 +6534,7 @@
           </rdf:RDF>
         </annotation>
       </species>
-      <species metaid="meta_M_cpd15687_c0" sboTerm="SBO:0000247" id="M_cpd15687_c0" name="CDP-1,2-dianteisopentadecanoylglycerol [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-2" fbc:chemicalFormula="C42H75N3O15P2">
+      <species metaid="meta_M_cpd15687_c0" sboTerm="SBO:0000247" id="M_cpd15687_c0" name="CDP-1,2-di-12-methyltetradecanoylglycerol [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-2" fbc:chemicalFormula="C42H75N3O15P2">
         <annotation>
           <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
             <rdf:Description rdf:about="#meta_M_cpd15687_c0">
@@ -6788,7 +6788,7 @@
           </rdf:RDF>
         </annotation>
       </species>
-      <species metaid="meta_M_cpd11478_c0" sboTerm="SBO:0000247" id="M_cpd11478_c0" name="(R)-3-Hydroxybutanoyl-[acyl-carrier protein] [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-1" fbc:chemicalFormula="C15H27N2O9PRS">
+      <species metaid="meta_M_cpd11478_c0" sboTerm="SBO:0000247" id="M_cpd11478_c0" name="(3R)-3-Hydroxybutanoyl-ACP [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-1" fbc:chemicalFormula="C15H27N2O9PRS">
         <annotation>
           <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
             <rdf:Description rdf:about="#meta_M_cpd11478_c0">
@@ -6804,7 +6804,7 @@
           </rdf:RDF>
         </annotation>
       </species>
-      <species metaid="meta_M_cpd11465_c0" sboTerm="SBO:0000247" id="M_cpd11465_c0" name="But-2-enoyl-[acyl-carrier protein] [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-1" fbc:chemicalFormula="C15H25N2O8PRS">
+      <species metaid="meta_M_cpd11465_c0" sboTerm="SBO:0000247" id="M_cpd11465_c0" name="(2E)-Butenoyl-ACP [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-1" fbc:chemicalFormula="C15H25N2O8PRS">
         <annotation>
           <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
             <rdf:Description rdf:about="#meta_M_cpd11465_c0">
@@ -7122,7 +7122,7 @@
           </rdf:RDF>
         </annotation>
       </species>
-      <species metaid="meta_M_cpd15539_c0" sboTerm="SBO:0000247" id="M_cpd15539_c0" name="Phosphatidylglycerol dihexadec-9-enoyl [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-1" fbc:chemicalFormula="C38H70O10P">
+      <species metaid="meta_M_cpd15539_c0" sboTerm="SBO:0000247" id="M_cpd15539_c0" name="1,2-di-(9Z)-hexadecenoyl-sn-glycero-3-phosphoglycerol [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-1" fbc:chemicalFormula="C38H70O10P">
         <annotation>
           <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
             <rdf:Description rdf:about="#meta_M_cpd15539_c0">
@@ -7261,7 +7261,7 @@
           </rdf:RDF>
         </annotation>
       </species>
-      <species metaid="meta_M_cpd00214_c0" sboTerm="SBO:0000247" id="M_cpd00214_c0" name="Palmitate [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-1" fbc:chemicalFormula="C16H31O2">
+      <species metaid="meta_M_cpd00214_c0" sboTerm="SBO:0000247" id="M_cpd00214_c0" name="Hexadecanoate [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-1" fbc:chemicalFormula="C16H31O2">
         <annotation>
           <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
             <rdf:Description rdf:about="#meta_M_cpd00214_c0">
@@ -7280,7 +7280,7 @@
           </rdf:RDF>
         </annotation>
       </species>
-      <species metaid="meta_M_cpd11570_c0" sboTerm="SBO:0000247" id="M_cpd11570_c0" name="3-Oxooctodecanoyl-ACP [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-1" fbc:chemicalFormula="C29H53N2O9PRS">
+      <species metaid="meta_M_cpd11570_c0" sboTerm="SBO:0000247" id="M_cpd11570_c0" name="3-Oxooctadecanoyl-ACP [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-1" fbc:chemicalFormula="C29H53N2O9PRS">
         <annotation>
           <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
             <rdf:Description rdf:about="#meta_M_cpd11570_c0">
@@ -7294,7 +7294,7 @@
           </rdf:RDF>
         </annotation>
       </species>
-      <species metaid="meta_M_cpd11571_c0" sboTerm="SBO:0000247" id="M_cpd11571_c0" name="3-Hydroxyoctodecanoyl-ACP [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-1" fbc:chemicalFormula="C29H55N2O9PRS">
+      <species metaid="meta_M_cpd11571_c0" sboTerm="SBO:0000247" id="M_cpd11571_c0" name="(3R)-3-Hydroxyoctadecanoyl-ACP [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-1" fbc:chemicalFormula="C29H55N2O9PRS">
         <annotation>
           <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
             <rdf:Description rdf:about="#meta_M_cpd11571_c0">
@@ -7383,7 +7383,7 @@
           </rdf:RDF>
         </annotation>
       </species>
-      <species metaid="meta_M_cpd15679_c0" sboTerm="SBO:0000247" id="M_cpd15679_c0" name="1,2-diisotetradecanoyl-sn-glycerol 3-phosphate [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-1" fbc:chemicalFormula="C31H60O8P">
+      <species metaid="meta_M_cpd15679_c0" sboTerm="SBO:0000247" id="M_cpd15679_c0" name="1,2-di-12-methyltridecanoyl-sn-glycerol-3-phosphate [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-1" fbc:chemicalFormula="C31H60O8P">
         <annotation>
           <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
             <rdf:Description rdf:about="#meta_M_cpd15679_c0">
@@ -7468,7 +7468,7 @@
           </rdf:RDF>
         </annotation>
       </species>
-      <species metaid="meta_M_cpd15322_c0" sboTerm="SBO:0000247" id="M_cpd15322_c0" name="1-Acyl-sn-glycero-3-phosphoglycerol hexadec-9-enoyl [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-1" fbc:chemicalFormula="C22H42O9P">
+      <species metaid="meta_M_cpd15322_c0" sboTerm="SBO:0000247" id="M_cpd15322_c0" name="1-(9Z)-hexadecenoyl-sn-glycero-3-phosphoglycerol [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-1" fbc:chemicalFormula="C22H42O9P">
         <annotation>
           <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
             <rdf:Description rdf:about="#meta_M_cpd15322_c0">
@@ -7536,7 +7536,7 @@
           </rdf:RDF>
         </annotation>
       </species>
-      <species metaid="meta_M_cpd15343_c0" sboTerm="SBO:0000247" id="M_cpd15343_c0" name="2-Acyl-sn-glycero-3-phosphoglycerol dodecanoyl [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-1" fbc:chemicalFormula="C18H36O9P">
+      <species metaid="meta_M_cpd15343_c0" sboTerm="SBO:0000247" id="M_cpd15343_c0" name="2-dodecanoyl-sn-glycero-3-phosphoglycerol [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-1" fbc:chemicalFormula="C18H36O9P">
         <annotation>
           <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
             <rdf:Description rdf:about="#meta_M_cpd15343_c0">
@@ -7777,7 +7777,7 @@
           </rdf:RDF>
         </annotation>
       </species>
-      <species metaid="meta_M_cpd11484_c0" sboTerm="SBO:0000247" id="M_cpd11484_c0" name="HMA [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-1" fbc:chemicalFormula="C25H47N2O9PRS">
+      <species metaid="meta_M_cpd11484_c0" sboTerm="SBO:0000247" id="M_cpd11484_c0" name="(3R)-3-Hydroxytetradecanoyl-ACP [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-1" fbc:chemicalFormula="C25H47N2O9PRS">
         <annotation>
           <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
             <rdf:Description rdf:about="#meta_M_cpd11484_c0">
@@ -7794,7 +7794,7 @@
           </rdf:RDF>
         </annotation>
       </species>
-      <species metaid="meta_M_cpd11467_c0" sboTerm="SBO:0000247" id="M_cpd11467_c0" name="(2E)-Tetradecenoyl-[acp] [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-2" fbc:chemicalFormula="C25H45N2O8PRS">
+      <species metaid="meta_M_cpd11467_c0" sboTerm="SBO:0000247" id="M_cpd11467_c0" name="(2E)-Tetradecenoyl-ACP [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-2" fbc:chemicalFormula="C25H45N2O8PRS">
         <annotation>
           <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
             <rdf:Description rdf:about="#meta_M_cpd11467_c0">
@@ -7878,7 +7878,7 @@
           </rdf:RDF>
         </annotation>
       </species>
-      <species metaid="meta_M_cpd15704_c0" sboTerm="SBO:0000247" id="M_cpd15704_c0" name="1,2-Diisopentadecanoyl-sn-glycerol [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="0" fbc:chemicalFormula="C33H64O5">
+      <species metaid="meta_M_cpd15704_c0" sboTerm="SBO:0000247" id="M_cpd15704_c0" name="1,2-di-13-methyltetradecanoylglycerol [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="0" fbc:chemicalFormula="C33H64O5">
         <annotation>
           <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
             <rdf:Description rdf:about="#meta_M_cpd15704_c0">
@@ -7892,7 +7892,7 @@
           </rdf:RDF>
         </annotation>
       </species>
-      <species metaid="meta_M_cpd15680_c0" sboTerm="SBO:0000247" id="M_cpd15680_c0" name="1,2-diisopentadecanoyl-sn-glycerol 3-phosphate [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-1" fbc:chemicalFormula="C33H64O8P">
+      <species metaid="meta_M_cpd15680_c0" sboTerm="SBO:0000247" id="M_cpd15680_c0" name="1,2-di-13-methyltetradecanoyl-sn-glycerol-3-phosphate [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-1" fbc:chemicalFormula="C33H64O8P">
         <annotation>
           <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
             <rdf:Description rdf:about="#meta_M_cpd15680_c0">
@@ -8137,7 +8137,7 @@
           </rdf:RDF>
         </annotation>
       </species>
-      <species metaid="meta_M_cpd11489_c0" sboTerm="SBO:0000247" id="M_cpd11489_c0" name="3-oxododecanoyl-acp [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-2" fbc:chemicalFormula="C23H42N2O9PRS">
+      <species metaid="meta_M_cpd11489_c0" sboTerm="SBO:0000247" id="M_cpd11489_c0" name="3-Oxododecanoyl-ACP [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-2" fbc:chemicalFormula="C23H42N2O9PRS">
         <annotation>
           <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
             <rdf:Description rdf:about="#meta_M_cpd11489_c0">
@@ -8270,7 +8270,7 @@
           </rdf:RDF>
         </annotation>
       </species>
-      <species metaid="meta_M_cpd11476_c0" sboTerm="SBO:0000247" id="M_cpd11476_c0" name="hexadecanoyl-acp [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-2" fbc:chemicalFormula="C27H51N2O8PRS">
+      <species metaid="meta_M_cpd11476_c0" sboTerm="SBO:0000247" id="M_cpd11476_c0" name="Hexadecanoyl-ACP [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-2" fbc:chemicalFormula="C27H51N2O8PRS">
         <annotation>
           <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
             <rdf:Description rdf:about="#meta_M_cpd11476_c0">
@@ -8286,7 +8286,7 @@
           </rdf:RDF>
         </annotation>
       </species>
-      <species metaid="meta_M_cpd00134_c0" sboTerm="SBO:0000247" id="M_cpd00134_c0" name="Palmitoyl-CoA [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-4" fbc:chemicalFormula="C37H62N7O17P3S">
+      <species metaid="meta_M_cpd00134_c0" sboTerm="SBO:0000247" id="M_cpd00134_c0" name="Hexadecanoyl-CoA [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-4" fbc:chemicalFormula="C37H62N7O17P3S">
         <annotation>
           <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
             <rdf:Description rdf:about="#meta_M_cpd00134_c0">
@@ -8305,7 +8305,7 @@
           </rdf:RDF>
         </annotation>
       </species>
-      <species metaid="meta_M_cpd15312_c0" sboTerm="SBO:0000247" id="M_cpd15312_c0" name="1,2-Diacyl-sn-glycerol dioctadec-11-enoyl [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="0" fbc:chemicalFormula="C39H72O5">
+      <species metaid="meta_M_cpd15312_c0" sboTerm="SBO:0000247" id="M_cpd15312_c0" name="1,2-di-(11Z)-octadecenoylglycerol [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="0" fbc:chemicalFormula="C39H72O5">
         <annotation>
           <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
             <rdf:Description rdf:about="#meta_M_cpd15312_c0">
@@ -8320,7 +8320,7 @@
           </rdf:RDF>
         </annotation>
       </species>
-      <species metaid="meta_M_cpd15527_c0" sboTerm="SBO:0000247" id="M_cpd15527_c0" name="1,2-dioctadec-11-enoyl-sn-glycerol 3-phosphate [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-1" fbc:chemicalFormula="C39H72O8P">
+      <species metaid="meta_M_cpd15527_c0" sboTerm="SBO:0000247" id="M_cpd15527_c0" name="1,2-di-(11Z)-octadecenoyl-sn-glycerol-3-phosphate [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-1" fbc:chemicalFormula="C39H72O8P">
         <annotation>
           <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
             <rdf:Description rdf:about="#meta_M_cpd15527_c0">
@@ -8516,7 +8516,7 @@
           </rdf:RDF>
         </annotation>
       </species>
-      <species metaid="meta_M_cpd15420_c0" sboTerm="SBO:0000247" id="M_cpd15420_c0" name="CDP-1,2-dioctadec-11-enoylglycerol [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-2" fbc:chemicalFormula="C48H83N3O15P2">
+      <species metaid="meta_M_cpd15420_c0" sboTerm="SBO:0000247" id="M_cpd15420_c0" name="CDP-1,2-di-(11Z)-octadecenoylglycerol [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-2" fbc:chemicalFormula="C48H83N3O15P2">
         <annotation>
           <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
             <rdf:Description rdf:about="#meta_M_cpd15420_c0">
@@ -8615,7 +8615,7 @@
           </rdf:RDF>
         </annotation>
       </species>
-      <species metaid="meta_M_cpd01080_c0" sboTerm="SBO:0000247" id="M_cpd01080_c0" name="ocdca [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-1" fbc:chemicalFormula="C18H35O2">
+      <species metaid="meta_M_cpd01080_c0" sboTerm="SBO:0000247" id="M_cpd01080_c0" name="Octadecanoate [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-1" fbc:chemicalFormula="C18H35O2">
         <annotation>
           <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
             <rdf:Description rdf:about="#meta_M_cpd01080_c0">
@@ -8673,7 +8673,7 @@
           </rdf:RDF>
         </annotation>
       </species>
-      <species metaid="meta_M_cpd11437_c0" sboTerm="SBO:0000247" id="M_cpd11437_c0" name="fa3coa [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-3" fbc:chemicalFormula="C36H61N7O17P3S">
+      <species metaid="meta_M_cpd11437_c0" sboTerm="SBO:0000247" id="M_cpd11437_c0" name="13-Methyltetradecanoyl-CoA [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-3" fbc:chemicalFormula="C36H61N7O17P3S">
         <annotation>
           <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
             <rdf:Description rdf:about="#meta_M_cpd11437_c0">
@@ -8687,7 +8687,7 @@
           </rdf:RDF>
         </annotation>
       </species>
-      <species metaid="meta_M_cpd15674_c0" sboTerm="SBO:0000247" id="M_cpd15674_c0" name="1-isopentadecanoyl-sn-glycerol 3-phosphate [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-1" fbc:chemicalFormula="C18H36O7P">
+      <species metaid="meta_M_cpd15674_c0" sboTerm="SBO:0000247" id="M_cpd15674_c0" name="1-13-methyltetradecanoyl-sn-glycerol-3-phosphate [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-1" fbc:chemicalFormula="C18H36O7P">
         <annotation>
           <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
             <rdf:Description rdf:about="#meta_M_cpd15674_c0">
@@ -8701,7 +8701,7 @@
           </rdf:RDF>
         </annotation>
       </species>
-      <species metaid="meta_M_cpd11491_c0" sboTerm="SBO:0000247" id="M_cpd11491_c0" name="3-oxotetradecanoyl-acp [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-2" fbc:chemicalFormula="C25H46N2O9PRS">
+      <species metaid="meta_M_cpd11491_c0" sboTerm="SBO:0000247" id="M_cpd11491_c0" name="3-Oxotetradecanoyl-ACP [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-2" fbc:chemicalFormula="C25H46N2O9PRS">
         <annotation>
           <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
             <rdf:Description rdf:about="#meta_M_cpd11491_c0">
@@ -8794,7 +8794,7 @@
           </rdf:RDF>
         </annotation>
       </species>
-      <species metaid="meta_M_cpd00327_c0" sboTerm="SBO:0000247" id="M_cpd00327_c0" name="strcoa [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-4" fbc:chemicalFormula="C39H66N7O17P3S">
+      <species metaid="meta_M_cpd00327_c0" sboTerm="SBO:0000247" id="M_cpd00327_c0" name="Octadecanoyl-CoA [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-4" fbc:chemicalFormula="C39H66N7O17P3S">
         <annotation>
           <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
             <rdf:Description rdf:about="#meta_M_cpd00327_c0">
@@ -9473,7 +9473,7 @@
           </rdf:RDF>
         </annotation>
       </species>
-      <species metaid="meta_M_cpd03847_c0" sboTerm="SBO:0000247" id="M_cpd03847_c0" name="Myristic acid [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-1" fbc:chemicalFormula="C14H27O2">
+      <species metaid="meta_M_cpd03847_c0" sboTerm="SBO:0000247" id="M_cpd03847_c0" name="Tetradecanoate [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-1" fbc:chemicalFormula="C14H27O2">
         <annotation>
           <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
             <rdf:Description rdf:about="#meta_M_cpd03847_c0">
@@ -9511,7 +9511,7 @@
           </rdf:RDF>
         </annotation>
       </species>
-      <species metaid="meta_M_cpd11534_c0" sboTerm="SBO:0000247" id="M_cpd11534_c0" name="11-methyl-3-hydroxy-dodecanoyl-ACP [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-1" fbc:chemicalFormula="C24H45N2O9PRS">
+      <species metaid="meta_M_cpd11534_c0" sboTerm="SBO:0000247" id="M_cpd11534_c0" name="(3R)-3-hydroxy-11-methyldodecanoyl-ACP [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-1" fbc:chemicalFormula="C24H45N2O9PRS">
         <annotation>
           <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
             <rdf:Description rdf:about="#meta_M_cpd11534_c0">
@@ -9525,7 +9525,7 @@
           </rdf:RDF>
         </annotation>
       </species>
-      <species metaid="meta_M_cpd11535_c0" sboTerm="SBO:0000247" id="M_cpd11535_c0" name="11-methyl-trans-dodec-2-enoyl-ACP [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-1" fbc:chemicalFormula="C24H43N2O8PRS">
+      <species metaid="meta_M_cpd11535_c0" sboTerm="SBO:0000247" id="M_cpd11535_c0" name="(2E)-11-methyldodecenoyl-ACP [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-1" fbc:chemicalFormula="C24H43N2O8PRS">
         <annotation>
           <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
             <rdf:Description rdf:about="#meta_M_cpd11535_c0">
@@ -9658,7 +9658,7 @@
           </rdf:RDF>
         </annotation>
       </species>
-      <species metaid="meta_M_cpd02882_c0" sboTerm="SBO:0000247" id="M_cpd02882_c0" name="4--1-D-Ribitylamino-5-aminouracil [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="0" fbc:chemicalFormula="C9H16N4O6">
+      <species metaid="meta_M_cpd02882_c0" sboTerm="SBO:0000247" id="M_cpd02882_c0" name="5-Amino-6-(1-D-ribitylamino)uracil [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="0" fbc:chemicalFormula="C9H16N4O6">
         <annotation>
           <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
             <rdf:Description rdf:about="#meta_M_cpd02882_c0">
@@ -9748,7 +9748,7 @@
           </rdf:RDF>
         </annotation>
       </species>
-      <species metaid="meta_M_cpd11501_c0" sboTerm="SBO:0000247" id="M_cpd11501_c0" name="6-methyl-3-hydroxy-octanoyl-ACP [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-1" fbc:chemicalFormula="C20H37N2O9PRS">
+      <species metaid="meta_M_cpd11501_c0" sboTerm="SBO:0000247" id="M_cpd11501_c0" name="(3R)-3-hydroxy-6-methyloctanoyl-ACP [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-1" fbc:chemicalFormula="C20H37N2O9PRS">
         <annotation>
           <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
             <rdf:Description rdf:about="#meta_M_cpd11501_c0">
@@ -9762,7 +9762,7 @@
           </rdf:RDF>
         </annotation>
       </species>
-      <species metaid="meta_M_cpd11502_c0" sboTerm="SBO:0000247" id="M_cpd11502_c0" name="6-methyl-trans-oct-2-enoyl-ACP [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-1" fbc:chemicalFormula="C20H35N2O8PRS">
+      <species metaid="meta_M_cpd11502_c0" sboTerm="SBO:0000247" id="M_cpd11502_c0" name="(2E)-6-methyloctenoyl-ACP [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-1" fbc:chemicalFormula="C20H35N2O8PRS">
         <annotation>
           <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
             <rdf:Description rdf:about="#meta_M_cpd11502_c0">
@@ -9867,7 +9867,7 @@
           </rdf:RDF>
         </annotation>
       </species>
-      <species metaid="meta_M_cpd00214_e0" sboTerm="SBO:0000247" id="M_cpd00214_e0" name="Palmitate [e0]" compartment="e0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-1" fbc:chemicalFormula="C16H31O2">
+      <species metaid="meta_M_cpd00214_e0" sboTerm="SBO:0000247" id="M_cpd00214_e0" name="Hexadecanoate [e0]" compartment="e0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-1" fbc:chemicalFormula="C16H31O2">
         <annotation>
           <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
             <rdf:Description rdf:about="#meta_M_cpd00214_e0">
@@ -10001,7 +10001,7 @@
           </rdf:RDF>
         </annotation>
       </species>
-      <species metaid="meta_M_cpd11475_c0" sboTerm="SBO:0000247" id="M_cpd11475_c0" name="(2E)-Decenoyl-[acp] [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-2" fbc:chemicalFormula="C21H37N2O8PRS">
+      <species metaid="meta_M_cpd11475_c0" sboTerm="SBO:0000247" id="M_cpd11475_c0" name="(2E)-Decenoyl-ACP [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-2" fbc:chemicalFormula="C21H37N2O8PRS">
         <annotation>
           <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
             <rdf:Description rdf:about="#meta_M_cpd11475_c0">
@@ -10192,7 +10192,7 @@
           </rdf:RDF>
         </annotation>
       </species>
-      <species metaid="meta_M_cpd15366_c0" sboTerm="SBO:0000247" id="M_cpd15366_c0" name="(R)-3-hydroxy-cis-dodec-5-enoyl-[acyl-carrier protein] [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-1" fbc:chemicalFormula="C23H41N2O9PRS">
+      <species metaid="meta_M_cpd15366_c0" sboTerm="SBO:0000247" id="M_cpd15366_c0" name="(3R,5Z)-3-Hydroxydodecenoyl-ACP [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-1" fbc:chemicalFormula="C23H41N2O9PRS">
         <annotation>
           <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
             <rdf:Description rdf:about="#meta_M_cpd15366_c0">
@@ -10207,7 +10207,7 @@
           </rdf:RDF>
         </annotation>
       </species>
-      <species metaid="meta_M_cpd15569_c0" sboTerm="SBO:0000247" id="M_cpd15569_c0" name="trans-3-cis-5-dodecenoyl-[acyl-carrier protein] [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-1" fbc:chemicalFormula="C23H39N2O8PRS">
+      <species metaid="meta_M_cpd15569_c0" sboTerm="SBO:0000247" id="M_cpd15569_c0" name="(3E,5Z)-Dodecadienoyl-ACP [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-1" fbc:chemicalFormula="C23H39N2O8PRS">
         <annotation>
           <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
             <rdf:Description rdf:about="#meta_M_cpd15569_c0">
@@ -10278,7 +10278,7 @@
           </rdf:RDF>
         </annotation>
       </species>
-      <species metaid="meta_M_cpd15684_c0" sboTerm="SBO:0000247" id="M_cpd15684_c0" name="CDP-1,2-dianteisoheptadecanoylglycerol [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-2" fbc:chemicalFormula="C46H83N3O15P2">
+      <species metaid="meta_M_cpd15684_c0" sboTerm="SBO:0000247" id="M_cpd15684_c0" name="CDP-1,2-di-14-methylhexadecanoylglycerol [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-2" fbc:chemicalFormula="C46H83N3O15P2">
         <annotation>
           <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
             <rdf:Description rdf:about="#meta_M_cpd15684_c0">
@@ -10306,7 +10306,7 @@
           </rdf:RDF>
         </annotation>
       </species>
-      <species metaid="meta_M_cpd11481_c0" sboTerm="SBO:0000247" id="M_cpd11481_c0" name="R-3-hydroxypalmitoyl-acyl-carrierprotein- [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-1" fbc:chemicalFormula="C27H51N2O9PRS">
+      <species metaid="meta_M_cpd11481_c0" sboTerm="SBO:0000247" id="M_cpd11481_c0" name="(3R)-3-Hydroxyhexadecanoyl-ACP [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-1" fbc:chemicalFormula="C27H51N2O9PRS">
         <annotation>
           <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
             <rdf:Description rdf:about="#meta_M_cpd11481_c0">
@@ -10322,7 +10322,7 @@
           </rdf:RDF>
         </annotation>
       </species>
-      <species metaid="meta_M_cpd11485_c0" sboTerm="SBO:0000247" id="M_cpd11485_c0" name="3-oxohexadecanoyl-acp [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-2" fbc:chemicalFormula="C27H50N2O9PRS">
+      <species metaid="meta_M_cpd11485_c0" sboTerm="SBO:0000247" id="M_cpd11485_c0" name="3-Oxohexadecanoyl-ACP [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-2" fbc:chemicalFormula="C27H50N2O9PRS">
         <annotation>
           <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
             <rdf:Description rdf:about="#meta_M_cpd11485_c0">
@@ -10647,7 +10647,7 @@
           </rdf:RDF>
         </annotation>
       </species>
-      <species metaid="meta_M_cpd15323_c0" sboTerm="SBO:0000247" id="M_cpd15323_c0" name="1-Acyl-sn-glycero-3-phosphoglycerol octadecanoyl [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-1" fbc:chemicalFormula="C24H48O9P">
+      <species metaid="meta_M_cpd15323_c0" sboTerm="SBO:0000247" id="M_cpd15323_c0" name="1-octadecanoyl-sn-glycero-3-phosphoglycerol [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-1" fbc:chemicalFormula="C24H48O9P">
         <annotation>
           <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
             <rdf:Description rdf:about="#meta_M_cpd15323_c0">
@@ -10700,7 +10700,7 @@
           </rdf:RDF>
         </annotation>
       </species>
-      <species metaid="meta_M_cpd15370_c0" sboTerm="SBO:0000247" id="M_cpd15370_c0" name="(R)-3-hydroxy-cis-vacc-11-enoyl-[acyl-carrier protein] [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-1" fbc:chemicalFormula="C29H53N2O9PRS">
+      <species metaid="meta_M_cpd15370_c0" sboTerm="SBO:0000247" id="M_cpd15370_c0" name="(3R,11Z)-3-Hydroxyoctadecenoyl-ACP [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-1" fbc:chemicalFormula="C29H53N2O9PRS">
         <annotation>
           <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
             <rdf:Description rdf:about="#meta_M_cpd15370_c0">
@@ -10715,7 +10715,7 @@
           </rdf:RDF>
         </annotation>
       </species>
-      <species metaid="meta_M_cpd15568_c0" sboTerm="SBO:0000247" id="M_cpd15568_c0" name="trans-3-cis-11-vacceoyl-[acyl-carrier protein] [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-1" fbc:chemicalFormula="C29H51N2O8PRS">
+      <species metaid="meta_M_cpd15568_c0" sboTerm="SBO:0000247" id="M_cpd15568_c0" name="(3E,11Z)-Octadecadienoyl-ACP [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-1" fbc:chemicalFormula="C29H51N2O8PRS">
         <annotation>
           <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
             <rdf:Description rdf:about="#meta_M_cpd15568_c0">
@@ -10744,7 +10744,7 @@
           </rdf:RDF>
         </annotation>
       </species>
-      <species metaid="meta_M_cpd15330_c0" sboTerm="SBO:0000247" id="M_cpd15330_c0" name="1-tetradec-7-enoyl-sn-glycerol 3-phosphate [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-1" fbc:chemicalFormula="C17H32O7P">
+      <species metaid="meta_M_cpd15330_c0" sboTerm="SBO:0000247" id="M_cpd15330_c0" name="1-(7Z)-tetradecenoyl-sn-glycerol-3-phosphate [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-1" fbc:chemicalFormula="C17H32O7P">
         <annotation>
           <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
             <rdf:Description rdf:about="#meta_M_cpd15330_c0">
@@ -10759,7 +10759,7 @@
           </rdf:RDF>
         </annotation>
       </species>
-      <species metaid="meta_M_cpd15298_c0" sboTerm="SBO:0000247" id="M_cpd15298_c0" name="tetradecenoate [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-1" fbc:chemicalFormula="C14H25O2">
+      <species metaid="meta_M_cpd15298_c0" sboTerm="SBO:0000247" id="M_cpd15298_c0" name="(7Z)-Tetradecenoate [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-1" fbc:chemicalFormula="C14H25O2">
         <annotation>
           <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
             <rdf:Description rdf:about="#meta_M_cpd15298_c0">
@@ -10928,7 +10928,7 @@
           </rdf:RDF>
         </annotation>
       </species>
-      <species metaid="meta_M_cpd15354_c0" sboTerm="SBO:0000247" id="M_cpd15354_c0" name="2-hexadec-9-enoyl-sn-glycerol 3-phosphate [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-1" fbc:chemicalFormula="C19H36O7P">
+      <species metaid="meta_M_cpd15354_c0" sboTerm="SBO:0000247" id="M_cpd15354_c0" name="2-(9Z)-hexadecenoyl-sn-glycerol-3-phosphate [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-1" fbc:chemicalFormula="C19H36O7P">
         <annotation>
           <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
             <rdf:Description rdf:about="#meta_M_cpd15354_c0">
@@ -10963,7 +10963,7 @@
           </rdf:RDF>
         </annotation>
       </species>
-      <species metaid="meta_M_cpd11517_c0" sboTerm="SBO:0000247" id="M_cpd11517_c0" name="14-methyl-3-hydroxy-hexa-decanoyl-ACP [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-1" fbc:chemicalFormula="C28H53N2O9PRS">
+      <species metaid="meta_M_cpd11517_c0" sboTerm="SBO:0000247" id="M_cpd11517_c0" name="(3R)-3-hydroxy-14-methylhexadecanoyl-ACP [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-1" fbc:chemicalFormula="C28H53N2O9PRS">
         <annotation>
           <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
             <rdf:Description rdf:about="#meta_M_cpd11517_c0">
@@ -10977,7 +10977,7 @@
           </rdf:RDF>
         </annotation>
       </species>
-      <species metaid="meta_M_cpd11518_c0" sboTerm="SBO:0000247" id="M_cpd11518_c0" name="14-methyl-trans-hexa-dec-2-enoyl-ACP [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-1" fbc:chemicalFormula="C28H51N2O8PRS">
+      <species metaid="meta_M_cpd11518_c0" sboTerm="SBO:0000247" id="M_cpd11518_c0" name="(2E)-14-methylhexadecenoyl-ACP [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-1" fbc:chemicalFormula="C28H51N2O8PRS">
         <annotation>
           <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
             <rdf:Description rdf:about="#meta_M_cpd11518_c0">
@@ -10991,7 +10991,7 @@
           </rdf:RDF>
         </annotation>
       </species>
-      <species metaid="meta_M_cpd11480_c0" sboTerm="SBO:0000247" id="M_cpd11480_c0" name="D-3-Hydroxydodecanoyl-[acp] [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-2" fbc:chemicalFormula="C23H43N2O9PRS">
+      <species metaid="meta_M_cpd11480_c0" sboTerm="SBO:0000247" id="M_cpd11480_c0" name="(3R)-3-Hydroxydodecanoyl-ACP [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-2" fbc:chemicalFormula="C23H43N2O9PRS">
         <annotation>
           <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
             <rdf:Description rdf:about="#meta_M_cpd11480_c0">
@@ -11319,7 +11319,7 @@
           </rdf:RDF>
         </annotation>
       </species>
-      <species metaid="meta_M_cpd15538_c0" sboTerm="SBO:0000247" id="M_cpd15538_c0" name="Phosphatidylglycerol dihexadecanoyl [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-1" fbc:chemicalFormula="C38H74O10P">
+      <species metaid="meta_M_cpd15538_c0" sboTerm="SBO:0000247" id="M_cpd15538_c0" name="1,2-dihexadecanoyl-sn-glycero-3-phosphoglycerol [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-1" fbc:chemicalFormula="C38H74O10P">
         <annotation>
           <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
             <rdf:Description rdf:about="#meta_M_cpd15538_c0">
@@ -11334,7 +11334,7 @@
           </rdf:RDF>
         </annotation>
       </species>
-      <species metaid="meta_M_cpd15346_c0" sboTerm="SBO:0000247" id="M_cpd15346_c0" name="2-Acyl-sn-glycero-3-phosphoglycerol hexadecanoyl [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-1" fbc:chemicalFormula="C22H44O9P">
+      <species metaid="meta_M_cpd15346_c0" sboTerm="SBO:0000247" id="M_cpd15346_c0" name="2-hexadecanoyl-sn-glycero-3-phosphoglycerol [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-1" fbc:chemicalFormula="C22H44O9P">
         <annotation>
           <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
             <rdf:Description rdf:about="#meta_M_cpd15346_c0">
@@ -11738,7 +11738,7 @@
           </rdf:RDF>
         </annotation>
       </species>
-      <species metaid="meta_M_cpd11542_c0" sboTerm="SBO:0000247" id="M_cpd11542_c0" name="15-methyl-3-hydroxy-hexa-decanoyl-ACP [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-1" fbc:chemicalFormula="C28H53N2O9PRS">
+      <species metaid="meta_M_cpd11542_c0" sboTerm="SBO:0000247" id="M_cpd11542_c0" name="(3R)-3-hydroxy-15-methylhexadecanoyl-ACP [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-1" fbc:chemicalFormula="C28H53N2O9PRS">
         <annotation>
           <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
             <rdf:Description rdf:about="#meta_M_cpd11542_c0">
@@ -11752,7 +11752,7 @@
           </rdf:RDF>
         </annotation>
       </species>
-      <species metaid="meta_M_cpd11543_c0" sboTerm="SBO:0000247" id="M_cpd11543_c0" name="15-methyl-trans-hexa-dec-2-enoyl-ACP [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-1" fbc:chemicalFormula="C28H51N2O8PRS">
+      <species metaid="meta_M_cpd11543_c0" sboTerm="SBO:0000247" id="M_cpd11543_c0" name="(2E)-15-methylhexadecenoyl-ACP [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-1" fbc:chemicalFormula="C28H51N2O8PRS">
         <annotation>
           <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
             <rdf:Description rdf:about="#meta_M_cpd11543_c0">
@@ -11815,7 +11815,7 @@
           </rdf:RDF>
         </annotation>
       </species>
-      <species metaid="meta_M_cpd11434_c0" sboTerm="SBO:0000247" id="M_cpd11434_c0" name="fa12coa [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-3" fbc:chemicalFormula="C38H65N7O17P3S">
+      <species metaid="meta_M_cpd11434_c0" sboTerm="SBO:0000247" id="M_cpd11434_c0" name="14-Methylhexadecanoyl-CoA [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-3" fbc:chemicalFormula="C38H65N7O17P3S">
         <annotation>
           <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
             <rdf:Description rdf:about="#meta_M_cpd11434_c0">
@@ -12120,7 +12120,7 @@
           </rdf:RDF>
         </annotation>
       </species>
-      <species metaid="meta_M_cpd15369_c0" sboTerm="SBO:0000247" id="M_cpd15369_c0" name="(R)-3-hydroxy-cis-palm-9-eoyl-[acyl-carrier protein] [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-1" fbc:chemicalFormula="C27H49N2O9PRS">
+      <species metaid="meta_M_cpd15369_c0" sboTerm="SBO:0000247" id="M_cpd15369_c0" name="(3R,9Z)-3-Hydroxyhexadecenoyl-ACP [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-1" fbc:chemicalFormula="C27H49N2O9PRS">
         <annotation>
           <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
             <rdf:Description rdf:about="#meta_M_cpd15369_c0">
@@ -12135,7 +12135,7 @@
           </rdf:RDF>
         </annotation>
       </species>
-      <species metaid="meta_M_cpd15571_c0" sboTerm="SBO:0000247" id="M_cpd15571_c0" name="trans-3-cis-9-palmitoleoyl-[acyl-carrier protein] [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-1" fbc:chemicalFormula="C27H47N2O8PRS">
+      <species metaid="meta_M_cpd15571_c0" sboTerm="SBO:0000247" id="M_cpd15571_c0" name="(3E,9Z)-Hexadecadienoyl-ACP [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-1" fbc:chemicalFormula="C27H47N2O8PRS">
         <annotation>
           <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
             <rdf:Description rdf:about="#meta_M_cpd15571_c0">
@@ -12250,7 +12250,7 @@
           </rdf:RDF>
         </annotation>
       </species>
-      <species metaid="meta_M_cpd15540_c0" sboTerm="SBO:0000247" id="M_cpd15540_c0" name="Phosphatidylglycerol dioctadecanoyl [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-1" fbc:chemicalFormula="C42H82O10P">
+      <species metaid="meta_M_cpd15540_c0" sboTerm="SBO:0000247" id="M_cpd15540_c0" name="1,2-dioctadecanoyl-sn-glycero-3-phosphoglycerol [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-1" fbc:chemicalFormula="C42H82O10P">
         <annotation>
           <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
             <rdf:Description rdf:about="#meta_M_cpd15540_c0">
@@ -12284,7 +12284,7 @@
           </rdf:RDF>
         </annotation>
       </species>
-      <species metaid="meta_M_cpd15348_c0" sboTerm="SBO:0000247" id="M_cpd15348_c0" name="2-Acyl-sn-glycero-3-phosphoglycerol octadecanoyl [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-1" fbc:chemicalFormula="C24H48O9P">
+      <species metaid="meta_M_cpd15348_c0" sboTerm="SBO:0000247" id="M_cpd15348_c0" name="2-octadecanoyl-sn-glycero-3-phosphoglycerol [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-1" fbc:chemicalFormula="C24H48O9P">
         <annotation>
           <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
             <rdf:Description rdf:about="#meta_M_cpd15348_c0">
@@ -12333,7 +12333,7 @@
           </rdf:RDF>
         </annotation>
       </species>
-      <species metaid="meta_M_cpd15537_c0" sboTerm="SBO:0000247" id="M_cpd15537_c0" name="Phosphatidylglycerol ditetradec-7-enoyl [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-1" fbc:chemicalFormula="C34H62O10P">
+      <species metaid="meta_M_cpd15537_c0" sboTerm="SBO:0000247" id="M_cpd15537_c0" name="1,2-di-(7Z)-tetradecenoyl-sn-glycero-3-phosphoglycerol [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-1" fbc:chemicalFormula="C34H62O10P">
         <annotation>
           <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
             <rdf:Description rdf:about="#meta_M_cpd15537_c0">
@@ -12348,7 +12348,7 @@
           </rdf:RDF>
         </annotation>
       </species>
-      <species metaid="meta_M_cpd15320_c0" sboTerm="SBO:0000247" id="M_cpd15320_c0" name="1-Acyl-sn-glycero-3-phosphoglycerol tetradec-7-enoyl [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-1" fbc:chemicalFormula="C20H38O9P">
+      <species metaid="meta_M_cpd15320_c0" sboTerm="SBO:0000247" id="M_cpd15320_c0" name="1-(7Z)-tetradecenoyl-sn-glycero-3-phosphoglycerol [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-1" fbc:chemicalFormula="C20H38O9P">
         <annotation>
           <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
             <rdf:Description rdf:about="#meta_M_cpd15320_c0">
@@ -12401,7 +12401,7 @@
           </rdf:RDF>
         </annotation>
       </species>
-      <species metaid="meta_M_cpd11482_c0" sboTerm="SBO:0000247" id="M_cpd11482_c0" name="(R)-3-Hydroxydecanoyl-[acyl-carrier protein] [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-2" fbc:chemicalFormula="C21H40N2O9PRS">
+      <species metaid="meta_M_cpd11482_c0" sboTerm="SBO:0000247" id="M_cpd11482_c0" name="(3R)-3-Hydroxydecanoyl-ACP [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-2" fbc:chemicalFormula="C21H40N2O9PRS">
         <annotation>
           <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
             <rdf:Description rdf:about="#meta_M_cpd11482_c0">
@@ -12418,7 +12418,7 @@
           </rdf:RDF>
         </annotation>
       </species>
-      <species metaid="meta_M_cpd11487_c0" sboTerm="SBO:0000247" id="M_cpd11487_c0" name="3-oxodecanoyl-acp [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-2" fbc:chemicalFormula="C21H38N2O9PRS">
+      <species metaid="meta_M_cpd11487_c0" sboTerm="SBO:0000247" id="M_cpd11487_c0" name="3-Oxodecanoyl-ACP [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-2" fbc:chemicalFormula="C21H38N2O9PRS">
         <annotation>
           <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
             <rdf:Description rdf:about="#meta_M_cpd11487_c0">
@@ -12468,7 +12468,7 @@
           </rdf:RDF>
         </annotation>
       </species>
-      <species metaid="meta_M_cpd15722_c0" sboTerm="SBO:0000247" id="M_cpd15722_c0" name="Diisoheptadecanoylphosphatidylglycerol [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-1" fbc:chemicalFormula="C40H78O10P">
+      <species metaid="meta_M_cpd15722_c0" sboTerm="SBO:0000247" id="M_cpd15722_c0" name="1,2-di-15-methylhexadecanoyl-sn-glycero-3-phosphoglycerol [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-1" fbc:chemicalFormula="C40H78O10P">
         <annotation>
           <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
             <rdf:Description rdf:about="#meta_M_cpd15722_c0">
@@ -12482,7 +12482,7 @@
           </rdf:RDF>
         </annotation>
       </species>
-      <species metaid="meta_M_cpd15525_c0" sboTerm="SBO:0000247" id="M_cpd15525_c0" name="1,2-dihexadec-9-enoyl-sn-glycerol 3-phosphate [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-1" fbc:chemicalFormula="C35H64O8P">
+      <species metaid="meta_M_cpd15525_c0" sboTerm="SBO:0000247" id="M_cpd15525_c0" name="1,2-(9Z)-hexadecenoyl-sn-glycerol-3-phosphate [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-1" fbc:chemicalFormula="C35H64O8P">
         <annotation>
           <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
             <rdf:Description rdf:about="#meta_M_cpd15525_c0">
@@ -12554,7 +12554,7 @@
           </rdf:RDF>
         </annotation>
       </species>
-      <species metaid="meta_M_cpd15681_c0" sboTerm="SBO:0000247" id="M_cpd15681_c0" name="1,2-dianteisopentadecanoyl-sn-glycerol 3-phosphate [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-1" fbc:chemicalFormula="C33H64O8P">
+      <species metaid="meta_M_cpd15681_c0" sboTerm="SBO:0000247" id="M_cpd15681_c0" name="1,2-di-12-methyltetradecanoyl-sn-glycerol-3-phosphate [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-1" fbc:chemicalFormula="C33H64O8P">
         <annotation>
           <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
             <rdf:Description rdf:about="#meta_M_cpd15681_c0">
@@ -12568,7 +12568,7 @@
           </rdf:RDF>
         </annotation>
       </species>
-      <species metaid="meta_M_cpd11479_c0" sboTerm="SBO:0000247" id="M_cpd11479_c0" name="D-3-Hydroxyhexanoyl-[acp] [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-2" fbc:chemicalFormula="C17H31N2O9PRS">
+      <species metaid="meta_M_cpd11479_c0" sboTerm="SBO:0000247" id="M_cpd11479_c0" name="(3R)-3-Hydroxyhexanoyl-ACP [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-2" fbc:chemicalFormula="C17H31N2O9PRS">
         <annotation>
           <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
             <rdf:Description rdf:about="#meta_M_cpd11479_c0">
@@ -12901,7 +12901,7 @@
           </rdf:RDF>
         </annotation>
       </species>
-      <species metaid="meta_M_cpd15706_c0" sboTerm="SBO:0000247" id="M_cpd15706_c0" name="1,2-Diisohexadecanoyl-sn-glycerol [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="0" fbc:chemicalFormula="C35H68O5">
+      <species metaid="meta_M_cpd15706_c0" sboTerm="SBO:0000247" id="M_cpd15706_c0" name="1,2-di-14-methylpentadecanoylglycerol [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="0" fbc:chemicalFormula="C35H68O5">
         <annotation>
           <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
             <rdf:Description rdf:about="#meta_M_cpd15706_c0">
@@ -12915,7 +12915,7 @@
           </rdf:RDF>
         </annotation>
       </species>
-      <species metaid="meta_M_cpd15345_c0" sboTerm="SBO:0000247" id="M_cpd15345_c0" name="2-Acyl-sn-glycero-3-phosphoglycerol tetradec-7-enoyl [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-1" fbc:chemicalFormula="C20H38O9P">
+      <species metaid="meta_M_cpd15345_c0" sboTerm="SBO:0000247" id="M_cpd15345_c0" name="2-(7Z)-tetradecenoyl-sn-glycero-3-phosphoglycerol [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-1" fbc:chemicalFormula="C20H38O9P">
         <annotation>
           <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
             <rdf:Description rdf:about="#meta_M_cpd15345_c0">
@@ -12987,7 +12987,7 @@
           </rdf:RDF>
         </annotation>
       </species>
-      <species metaid="meta_M_cpd15311_c0" sboTerm="SBO:0000247" id="M_cpd15311_c0" name="1,2-Diacyl-sn-glycerol dioctadecanoyl [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="0" fbc:chemicalFormula="C39H76O5">
+      <species metaid="meta_M_cpd15311_c0" sboTerm="SBO:0000247" id="M_cpd15311_c0" name="1,2-dioctadecanoylglycerol [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="0" fbc:chemicalFormula="C39H76O5">
         <annotation>
           <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
             <rdf:Description rdf:about="#meta_M_cpd15311_c0">
@@ -13442,7 +13442,7 @@
           </rdf:RDF>
         </annotation>
       </species>
-      <species metaid="meta_M_cpd15344_c0" sboTerm="SBO:0000247" id="M_cpd15344_c0" name="2-Acyl-sn-glycero-3-phosphoglycerol tetradecanoyl [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-1" fbc:chemicalFormula="C20H40O9P">
+      <species metaid="meta_M_cpd15344_c0" sboTerm="SBO:0000247" id="M_cpd15344_c0" name="2-tetradecanoyl-sn-glycero-3-phosphoglycerol [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-1" fbc:chemicalFormula="C20H40O9P">
         <annotation>
           <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
             <rdf:Description rdf:about="#meta_M_cpd15344_c0">
@@ -13600,7 +13600,7 @@
           </rdf:RDF>
         </annotation>
       </species>
-      <species metaid="meta_M_cpd03584_c0" sboTerm="SBO:0000247" id="M_cpd03584_c0" name="UDP-3-O-(beta-hydroxymyristoyl)-D-glucosamine [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-1" fbc:chemicalFormula="C29H50N3O18P2">
+      <species metaid="meta_M_cpd03584_c0" sboTerm="SBO:0000247" id="M_cpd03584_c0" name="UDP-3-O-(3-hydroxytetradecanoyl)-D-glucosamine [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-1" fbc:chemicalFormula="C29H50N3O18P2">
         <annotation>
           <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
             <rdf:Description rdf:about="#meta_M_cpd03584_c0">
@@ -13677,7 +13677,7 @@
           </rdf:RDF>
         </annotation>
       </species>
-      <species metaid="meta_M_cpd00200_c0" sboTerm="SBO:0000247" id="M_cpd00200_c0" name="4MOP [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-1" fbc:chemicalFormula="C6H9O3">
+      <species metaid="meta_M_cpd00200_c0" sboTerm="SBO:0000247" id="M_cpd00200_c0" name="4-Methyl-2-oxopentanoate [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-1" fbc:chemicalFormula="C6H9O3">
         <annotation>
           <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
             <rdf:Description rdf:about="#meta_M_cpd00200_c0">
@@ -13957,7 +13957,7 @@
           </rdf:RDF>
         </annotation>
       </species>
-      <species metaid="meta_M_cpd11825_c0" sboTerm="SBO:0000247" id="M_cpd11825_c0" name="Octadecenoyl-ACP [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-1" fbc:chemicalFormula="C29H53N2O8PRS">
+      <species metaid="meta_M_cpd11825_c0" sboTerm="SBO:0000247" id="M_cpd11825_c0" name="(11Z)-Octadecenoyl-ACP [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-1" fbc:chemicalFormula="C29H53N2O8PRS">
         <annotation>
           <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
             <rdf:Description rdf:about="#meta_M_cpd11825_c0">
@@ -13973,7 +13973,7 @@
           </rdf:RDF>
         </annotation>
       </species>
-      <species metaid="meta_M_cpd15726_c0" sboTerm="SBO:0000247" id="M_cpd15726_c0" name="Dianteisopentadecanoylphosphatidylglycerol [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-1" fbc:chemicalFormula="C36H70O10P">
+      <species metaid="meta_M_cpd15726_c0" sboTerm="SBO:0000247" id="M_cpd15726_c0" name="1,2-di-12-methyltetradecanoyl-sn-glycero-3-phosphoglycerol [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-1" fbc:chemicalFormula="C36H70O10P">
         <annotation>
           <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
             <rdf:Description rdf:about="#meta_M_cpd15726_c0">
@@ -14044,7 +14044,7 @@
           </rdf:RDF>
         </annotation>
       </species>
-      <species metaid="meta_M_cpd11538_c0" sboTerm="SBO:0000247" id="M_cpd11538_c0" name="13-methyl-3-hydroxy-tetra-decanoyl-ACP [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-1" fbc:chemicalFormula="C26H49N2O9PRS">
+      <species metaid="meta_M_cpd11538_c0" sboTerm="SBO:0000247" id="M_cpd11538_c0" name="(3R)-3-hydroxy-13-methyltetradecanoyl-ACP [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-1" fbc:chemicalFormula="C26H49N2O9PRS">
         <annotation>
           <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
             <rdf:Description rdf:about="#meta_M_cpd11538_c0">
@@ -14058,7 +14058,7 @@
           </rdf:RDF>
         </annotation>
       </species>
-      <species metaid="meta_M_cpd11539_c0" sboTerm="SBO:0000247" id="M_cpd11539_c0" name="13-methyl-trans-tetra-dec-2-enoyl-ACP [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-1" fbc:chemicalFormula="C26H47N2O8PRS">
+      <species metaid="meta_M_cpd11539_c0" sboTerm="SBO:0000247" id="M_cpd11539_c0" name="(2E)-13-methyltetradecenoyl-ACP [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-1" fbc:chemicalFormula="C26H47N2O8PRS">
         <annotation>
           <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
             <rdf:Description rdf:about="#meta_M_cpd11539_c0">
@@ -14131,7 +14131,7 @@
           </rdf:RDF>
         </annotation>
       </species>
-      <species metaid="meta_M_cpd15701_c0" sboTerm="SBO:0000247" id="M_cpd15701_c0" name="1,2-Diisoheptadecanoyl-sn-glycerol [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="0" fbc:chemicalFormula="C37H72O5">
+      <species metaid="meta_M_cpd15701_c0" sboTerm="SBO:0000247" id="M_cpd15701_c0" name="1,2-di-15-methylhexadecanoylglycerol [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="0" fbc:chemicalFormula="C37H72O5">
         <annotation>
           <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
             <rdf:Description rdf:about="#meta_M_cpd15701_c0">
@@ -14145,7 +14145,7 @@
           </rdf:RDF>
         </annotation>
       </species>
-      <species metaid="meta_M_cpd15677_c0" sboTerm="SBO:0000247" id="M_cpd15677_c0" name="1,2-diisoheptadecanoyl-sn-glycerol 3-phosphate [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-1" fbc:chemicalFormula="C37H72O8P">
+      <species metaid="meta_M_cpd15677_c0" sboTerm="SBO:0000247" id="M_cpd15677_c0" name="1,2-di-15-methylhexadecanoyl-sn-glycerol-3-phosphate [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-1" fbc:chemicalFormula="C37H72O8P">
         <annotation>
           <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
             <rdf:Description rdf:about="#meta_M_cpd15677_c0">
@@ -14159,7 +14159,7 @@
           </rdf:RDF>
         </annotation>
       </species>
-      <species metaid="meta_M_cpd11435_c0" sboTerm="SBO:0000247" id="M_cpd11435_c0" name="fa1coa [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-3" fbc:chemicalFormula="C35H59N7O17P3S">
+      <species metaid="meta_M_cpd11435_c0" sboTerm="SBO:0000247" id="M_cpd11435_c0" name="12-Methyltridecanoyl-CoA [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-3" fbc:chemicalFormula="C35H59N7O17P3S">
         <annotation>
           <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
             <rdf:Description rdf:about="#meta_M_cpd11435_c0">
@@ -14173,7 +14173,7 @@
           </rdf:RDF>
         </annotation>
       </species>
-      <species metaid="meta_M_cpd15673_c0" sboTerm="SBO:0000247" id="M_cpd15673_c0" name="1-isotetradecanoyl-sn-glycerol 3-phosphate [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-1" fbc:chemicalFormula="C17H34O7P">
+      <species metaid="meta_M_cpd15673_c0" sboTerm="SBO:0000247" id="M_cpd15673_c0" name="1-12-methyltridecanoyl-sn-glycerol-3-phosphate [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-1" fbc:chemicalFormula="C17H34O7P">
         <annotation>
           <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
             <rdf:Description rdf:about="#meta_M_cpd15673_c0">
@@ -14278,7 +14278,7 @@
           </rdf:RDF>
         </annotation>
       </species>
-      <species metaid="meta_M_cpd00342_c0" sboTerm="SBO:0000247" id="M_cpd00342_c0" name="N-Acetylornithine [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="0" fbc:chemicalFormula="C7H14N2O3">
+      <species metaid="meta_M_cpd00342_c0" sboTerm="SBO:0000247" id="M_cpd00342_c0" name="N-acetylornithine [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="0" fbc:chemicalFormula="C7H14N2O3">
         <annotation>
           <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
             <rdf:Description rdf:about="#meta_M_cpd00342_c0">
@@ -14311,7 +14311,7 @@
           </rdf:RDF>
         </annotation>
       </species>
-      <species metaid="meta_M_cpd15723_c0" sboTerm="SBO:0000247" id="M_cpd15723_c0" name="Dianteisoheptadecanoylphosphatidylglycerol [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-1" fbc:chemicalFormula="C40H78O10P">
+      <species metaid="meta_M_cpd15723_c0" sboTerm="SBO:0000247" id="M_cpd15723_c0" name="1,2-di-14-methylhexadecanoyl-sn-glycero-3-phosphoglycerol [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-1" fbc:chemicalFormula="C40H78O10P">
         <annotation>
           <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
             <rdf:Description rdf:about="#meta_M_cpd15723_c0">
@@ -14436,7 +14436,7 @@
           </rdf:RDF>
         </annotation>
       </species>
-      <species metaid="meta_M_cpd11509_c0" sboTerm="SBO:0000247" id="M_cpd11509_c0" name="10-methyl-3-hydroxy-dodecanoyl-ACP [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-1" fbc:chemicalFormula="C24H45N2O9PRS">
+      <species metaid="meta_M_cpd11509_c0" sboTerm="SBO:0000247" id="M_cpd11509_c0" name="(3R)-3-hydroxy-10-methyldodecanoyl-ACP [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-1" fbc:chemicalFormula="C24H45N2O9PRS">
         <annotation>
           <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
             <rdf:Description rdf:about="#meta_M_cpd11509_c0">
@@ -14450,7 +14450,7 @@
           </rdf:RDF>
         </annotation>
       </species>
-      <species metaid="meta_M_cpd11510_c0" sboTerm="SBO:0000247" id="M_cpd11510_c0" name="10-methyl-trans-dodec-2-enoyl-ACP [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-1" fbc:chemicalFormula="C24H43N2O8PRS">
+      <species metaid="meta_M_cpd11510_c0" sboTerm="SBO:0000247" id="M_cpd11510_c0" name="(2E)-10-methyldodecenoyl-ACP [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-1" fbc:chemicalFormula="C24H43N2O8PRS">
         <annotation>
           <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
             <rdf:Description rdf:about="#meta_M_cpd11510_c0">
@@ -14464,7 +14464,7 @@
           </rdf:RDF>
         </annotation>
       </species>
-      <species metaid="meta_M_cpd15349_c0" sboTerm="SBO:0000247" id="M_cpd15349_c0" name="2-Acyl-sn-glycero-3-phosphoglycerol octadec-11-enoyl [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-1" fbc:chemicalFormula="C24H46O9P">
+      <species metaid="meta_M_cpd15349_c0" sboTerm="SBO:0000247" id="M_cpd15349_c0" name="2-(11Z)-octadecenoyl-sn-glycero-3-phosphoglycerol [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-1" fbc:chemicalFormula="C24H46O9P">
         <annotation>
           <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
             <rdf:Description rdf:about="#meta_M_cpd15349_c0">
@@ -14479,7 +14479,7 @@
           </rdf:RDF>
         </annotation>
       </species>
-      <species metaid="meta_M_cpd11473_c0" sboTerm="SBO:0000247" id="M_cpd11473_c0" name="(2E)-Hexenoyl-[acp] [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-1" fbc:chemicalFormula="C17H29N2O8PRS">
+      <species metaid="meta_M_cpd11473_c0" sboTerm="SBO:0000247" id="M_cpd11473_c0" name="(2E)-Hexenoyl-ACP [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-1" fbc:chemicalFormula="C17H29N2O8PRS">
         <annotation>
           <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
             <rdf:Description rdf:about="#meta_M_cpd11473_c0">
@@ -14605,7 +14605,7 @@
           </rdf:RDF>
         </annotation>
       </species>
-      <species metaid="meta_M_cpd15536_c0" sboTerm="SBO:0000247" id="M_cpd15536_c0" name="Phosphatidylglycerol ditetradecanoyl [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-1" fbc:chemicalFormula="C34H66O10P">
+      <species metaid="meta_M_cpd15536_c0" sboTerm="SBO:0000247" id="M_cpd15536_c0" name="1,2-ditetradecanoyl-sn-glycero-3-phosphoglycerol [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-1" fbc:chemicalFormula="C34H66O10P">
         <annotation>
           <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
             <rdf:Description rdf:about="#meta_M_cpd15536_c0">
@@ -14722,7 +14722,7 @@
           </rdf:RDF>
         </annotation>
       </species>
-      <species metaid="meta_M_cpd15321_c0" sboTerm="SBO:0000247" id="M_cpd15321_c0" name="1-Acyl-sn-glycero-3-phosphoglycerol hexadecanoyl [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-1" fbc:chemicalFormula="C22H44O9P">
+      <species metaid="meta_M_cpd15321_c0" sboTerm="SBO:0000247" id="M_cpd15321_c0" name="1-hexadecanoyl-sn-glycero-3-phosphoglycerol [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-1" fbc:chemicalFormula="C22H44O9P">
         <annotation>
           <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
             <rdf:Description rdf:about="#meta_M_cpd15321_c0">
@@ -14813,7 +14813,7 @@
           </rdf:RDF>
         </annotation>
       </species>
-      <species metaid="meta_M_cpd15676_c0" sboTerm="SBO:0000247" id="M_cpd15676_c0" name="1-isohexadecanoyl-sn-glycerol 3-phosphate [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-1" fbc:chemicalFormula="C19H38O7P">
+      <species metaid="meta_M_cpd15676_c0" sboTerm="SBO:0000247" id="M_cpd15676_c0" name="1-14-methylpentadecanoyl-sn-glycerol-3-phosphate [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-1" fbc:chemicalFormula="C19H38O7P">
         <annotation>
           <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
             <rdf:Description rdf:about="#meta_M_cpd15676_c0">
@@ -14865,7 +14865,7 @@
           </rdf:RDF>
         </annotation>
       </species>
-      <species metaid="meta_M_cpd02886_c0" sboTerm="SBO:0000247" id="M_cpd02886_c0" name="UDP-3-O-(beta-hydroxymyristoyl)-N-acetylglucosamine [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-2" fbc:chemicalFormula="C31H51N3O19P2">
+      <species metaid="meta_M_cpd02886_c0" sboTerm="SBO:0000247" id="M_cpd02886_c0" name="UDP-3-O-(3-hydroxytetradecanoyl)-N-acetylglucosamine [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-2" fbc:chemicalFormula="C31H51N3O19P2">
         <annotation>
           <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
             <rdf:Description rdf:about="#meta_M_cpd02886_c0">
@@ -14922,7 +14922,7 @@
           </rdf:RDF>
         </annotation>
       </species>
-      <species metaid="meta_M_cpd15705_c0" sboTerm="SBO:0000247" id="M_cpd15705_c0" name="1,2-Dianteisopentadecanoyl-sn-glycerol [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="0" fbc:chemicalFormula="C33H64O5">
+      <species metaid="meta_M_cpd15705_c0" sboTerm="SBO:0000247" id="M_cpd15705_c0" name="1,2-di-12-methyltetradecanoylglycerol [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="0" fbc:chemicalFormula="C33H64O5">
         <annotation>
           <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
             <rdf:Description rdf:about="#meta_M_cpd15705_c0">
@@ -15167,7 +15167,7 @@
           </rdf:RDF>
         </annotation>
       </species>
-      <species metaid="meta_M_cpd11530_c0" sboTerm="SBO:0000247" id="M_cpd11530_c0" name="9-methyl-3-hydroxy-decanoyl-ACP [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-1" fbc:chemicalFormula="C22H41N2O9PRS">
+      <species metaid="meta_M_cpd11530_c0" sboTerm="SBO:0000247" id="M_cpd11530_c0" name="(3R)-3-hydroxy-9-methyldecanoyl-ACP [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-1" fbc:chemicalFormula="C22H41N2O9PRS">
         <annotation>
           <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
             <rdf:Description rdf:about="#meta_M_cpd11530_c0">
@@ -15181,7 +15181,7 @@
           </rdf:RDF>
         </annotation>
       </species>
-      <species metaid="meta_M_cpd11531_c0" sboTerm="SBO:0000247" id="M_cpd11531_c0" name="9-methyl-trans-dec-2-enoyl-ACP [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-1" fbc:chemicalFormula="C22H39N2O8PRS">
+      <species metaid="meta_M_cpd11531_c0" sboTerm="SBO:0000247" id="M_cpd11531_c0" name="(2E)-9-methyldecenoyl-ACP [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-1" fbc:chemicalFormula="C22H39N2O8PRS">
         <annotation>
           <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
             <rdf:Description rdf:about="#meta_M_cpd11531_c0">
@@ -15457,7 +15457,7 @@
           </rdf:RDF>
         </annotation>
       </species>
-      <species metaid="meta_M_cpd03847_e0" sboTerm="SBO:0000247" id="M_cpd03847_e0" name="Myristic acid [e0]" compartment="e0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-1" fbc:chemicalFormula="C14H27O2">
+      <species metaid="meta_M_cpd03847_e0" sboTerm="SBO:0000247" id="M_cpd03847_e0" name="Tetradecanoate [c0] [e0]" compartment="e0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-1" fbc:chemicalFormula="C14H27O2">
         <annotation>
           <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
             <rdf:Description rdf:about="#meta_M_cpd03847_e0">
@@ -15726,7 +15726,7 @@
           </rdf:RDF>
         </annotation>
       </species>
-      <species metaid="meta_M_cpd15535_c0" sboTerm="SBO:0000247" id="M_cpd15535_c0" name="Phosphatidylglycerol didodecanoyl [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-1" fbc:chemicalFormula="C30H58O10P">
+      <species metaid="meta_M_cpd15535_c0" sboTerm="SBO:0000247" id="M_cpd15535_c0" name="1,2-didodecanoyl-sn-glycero-3-phosphoglycerol [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-1" fbc:chemicalFormula="C30H58O10P">
         <annotation>
           <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
             <rdf:Description rdf:about="#meta_M_cpd15535_c0">
@@ -15780,7 +15780,7 @@
           </rdf:RDF>
         </annotation>
       </species>
-      <species metaid="meta_M_cpd15318_c0" sboTerm="SBO:0000247" id="M_cpd15318_c0" name="1-Acyl-sn-glycero-3-phosphoglycerol dodecanoyl [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-1" fbc:chemicalFormula="C18H36O9P">
+      <species metaid="meta_M_cpd15318_c0" sboTerm="SBO:0000247" id="M_cpd15318_c0" name="1-dodecanoyl-sn-glycero-3-phosphoglycerol [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-1" fbc:chemicalFormula="C18H36O9P">
         <annotation>
           <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
             <rdf:Description rdf:about="#meta_M_cpd15318_c0">
@@ -15812,7 +15812,7 @@
           </rdf:RDF>
         </annotation>
       </species>
-      <species metaid="meta_M_cpd11572_c0" sboTerm="SBO:0000247" id="M_cpd11572_c0" name="trans-Octodec-2-enoyl-ACP [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-1" fbc:chemicalFormula="C29H53N2O8PRS">
+      <species metaid="meta_M_cpd11572_c0" sboTerm="SBO:0000247" id="M_cpd11572_c0" name="(2E)-Octadecenoyl-ACP [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-1" fbc:chemicalFormula="C29H53N2O8PRS">
         <annotation>
           <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
             <rdf:Description rdf:about="#meta_M_cpd11572_c0">
@@ -15855,7 +15855,7 @@
           </rdf:RDF>
         </annotation>
       </species>
-      <species metaid="meta_M_cpd15724_c0" sboTerm="SBO:0000247" id="M_cpd15724_c0" name="Diisotetradecanoylphosphatidylglycerol [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-1" fbc:chemicalFormula="C34H66O10P">
+      <species metaid="meta_M_cpd15724_c0" sboTerm="SBO:0000247" id="M_cpd15724_c0" name="1,2-di-12-methyltridecanoyl-sn-glycero-3-phosphoglycerol [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-1" fbc:chemicalFormula="C34H66O10P">
         <annotation>
           <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
             <rdf:Description rdf:about="#meta_M_cpd15724_c0">
@@ -15869,7 +15869,7 @@
           </rdf:RDF>
         </annotation>
       </species>
-      <species metaid="meta_M_cpd15683_c0" sboTerm="SBO:0000247" id="M_cpd15683_c0" name="CDP-1,2-diisoheptadecanoylglycerol [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-2" fbc:chemicalFormula="C46H83N3O15P2">
+      <species metaid="meta_M_cpd15683_c0" sboTerm="SBO:0000247" id="M_cpd15683_c0" name="CDP-1,2-di-15-methylhexadecanoylglycerol [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-2" fbc:chemicalFormula="C46H83N3O15P2">
         <annotation>
           <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
             <rdf:Description rdf:about="#meta_M_cpd15683_c0">
@@ -16075,7 +16075,7 @@
           </rdf:RDF>
         </annotation>
       </species>
-      <species metaid="meta_M_cpd08210_c0" sboTerm="SBO:0000247" id="M_cpd08210_c0" name="ADC [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-1" fbc:chemicalFormula="C10H10NO5">
+      <species metaid="meta_M_cpd08210_c0" sboTerm="SBO:0000247" id="M_cpd08210_c0" name="4-amino-4-deoxychorismate [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-1" fbc:chemicalFormula="C10H10NO5">
         <annotation>
           <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
             <rdf:Description rdf:about="#meta_M_cpd08210_c0">
@@ -16397,7 +16397,7 @@
           </rdf:RDF>
         </annotation>
       </species>
-      <species metaid="meta_M_cpd15294_c0" sboTerm="SBO:0000247" id="M_cpd15294_c0" name="Tetradecenoyl-ACP [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-1" fbc:chemicalFormula="C25H45N2O8PRS">
+      <species metaid="meta_M_cpd15294_c0" sboTerm="SBO:0000247" id="M_cpd15294_c0" name="(7Z)-Tetradecenoyl-ACP [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-1" fbc:chemicalFormula="C25H45N2O8PRS">
         <annotation>
           <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
             <rdf:Description rdf:about="#meta_M_cpd15294_c0">
@@ -16431,7 +16431,7 @@
           </rdf:RDF>
         </annotation>
       </species>
-      <species metaid="meta_M_cpd15672_c0" sboTerm="SBO:0000247" id="M_cpd15672_c0" name="1-anteisoheptadecanoyl-sn-glycerol 3-phosphate [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-1" fbc:chemicalFormula="C20H40O7P">
+      <species metaid="meta_M_cpd15672_c0" sboTerm="SBO:0000247" id="M_cpd15672_c0" name="1-13-methylpentadecanoyl-sn-glycerol-3-phosphate [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-1" fbc:chemicalFormula="C20H40O7P">
         <annotation>
           <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
             <rdf:Description rdf:about="#meta_M_cpd15672_c0">
@@ -16645,7 +16645,7 @@
           </rdf:RDF>
         </annotation>
       </species>
-      <species metaid="meta_M_cpd11477_c0" sboTerm="SBO:0000247" id="M_cpd11477_c0" name="(2E)-Hexadecenoyl-[acp] [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-2" fbc:chemicalFormula="C27H49N2O8PRS">
+      <species metaid="meta_M_cpd11477_c0" sboTerm="SBO:0000247" id="M_cpd11477_c0" name="(2E)-Hexadecenoyl-ACP [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-2" fbc:chemicalFormula="C27H49N2O8PRS">
         <annotation>
           <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
             <rdf:Description rdf:about="#meta_M_cpd11477_c0">
@@ -16662,7 +16662,7 @@
           </rdf:RDF>
         </annotation>
       </species>
-      <species metaid="meta_M_cpd11497_c0" sboTerm="SBO:0000247" id="M_cpd11497_c0" name="4-methyl-3-hydroxy-hexanoyl-ACP [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-1" fbc:chemicalFormula="C18H33N2O9PRS">
+      <species metaid="meta_M_cpd11497_c0" sboTerm="SBO:0000247" id="M_cpd11497_c0" name="(3R)-3-hydroxy-4-methylhexanoyl-ACP [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-1" fbc:chemicalFormula="C18H33N2O9PRS">
         <annotation>
           <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
             <rdf:Description rdf:about="#meta_M_cpd11497_c0">
@@ -16676,7 +16676,7 @@
           </rdf:RDF>
         </annotation>
       </species>
-      <species metaid="meta_M_cpd11498_c0" sboTerm="SBO:0000247" id="M_cpd11498_c0" name="4-methyl-trans-hex-2-enoyl-ACP [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-1" fbc:chemicalFormula="C18H31N2O8PRS">
+      <species metaid="meta_M_cpd11498_c0" sboTerm="SBO:0000247" id="M_cpd11498_c0" name="(2E)-4-methylhexenoyl-ACP [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-1" fbc:chemicalFormula="C18H31N2O8PRS">
         <annotation>
           <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
             <rdf:Description rdf:about="#meta_M_cpd11498_c0">
@@ -17101,7 +17101,7 @@
           </rdf:RDF>
         </annotation>
       </species>
-      <species metaid="meta_M_cpd15326_c0" sboTerm="SBO:0000247" id="M_cpd15326_c0" name="1-hexadec-9-enoyl-sn-glycerol 3-phosphate [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-1" fbc:chemicalFormula="C19H36O7P">
+      <species metaid="meta_M_cpd15326_c0" sboTerm="SBO:0000247" id="M_cpd15326_c0" name="1-(9Z)-hexadecenoyl-sn-glycerol-3-phosphate [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-1" fbc:chemicalFormula="C19H36O7P">
         <annotation>
           <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
             <rdf:Description rdf:about="#meta_M_cpd15326_c0">
@@ -17159,7 +17159,7 @@
           </rdf:RDF>
         </annotation>
       </species>
-      <species metaid="meta_M_cpd15319_c0" sboTerm="SBO:0000247" id="M_cpd15319_c0" name="1-Acyl-sn-glycero-3-phosphoglycerol tetradecanoyl [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-1" fbc:chemicalFormula="C20H40O9P">
+      <species metaid="meta_M_cpd15319_c0" sboTerm="SBO:0000247" id="M_cpd15319_c0" name="1-tetradecanoyl-sn-glycero-3-phosphoglycerol [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-1" fbc:chemicalFormula="C20H40O9P">
         <annotation>
           <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
             <rdf:Description rdf:about="#meta_M_cpd15319_c0">
@@ -17242,7 +17242,7 @@
           </rdf:RDF>
         </annotation>
       </species>
-      <species metaid="meta_M_cpd15362_c0" sboTerm="SBO:0000247" id="M_cpd15362_c0" name="2-tetradec-7-enoyl-sn-glycerol 3-phosphate [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-1" fbc:chemicalFormula="C17H32O7P">
+      <species metaid="meta_M_cpd15362_c0" sboTerm="SBO:0000247" id="M_cpd15362_c0" name="2-(7Z)-tetradecenoyl-sn-glycerol-3-phosphate [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-1" fbc:chemicalFormula="C17H32O7P">
         <annotation>
           <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
             <rdf:Description rdf:about="#meta_M_cpd15362_c0">
@@ -17353,7 +17353,7 @@
           </rdf:RDF>
         </annotation>
       </species>
-      <species metaid="meta_M_cpd15306_c0" sboTerm="SBO:0000247" id="M_cpd15306_c0" name="1,2-Diacyl-sn-glycerol didodecanoyl [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="0" fbc:chemicalFormula="C27H52O5">
+      <species metaid="meta_M_cpd15306_c0" sboTerm="SBO:0000247" id="M_cpd15306_c0" name="1,2-didodecanoylglycerol [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="0" fbc:chemicalFormula="C27H52O5">
         <annotation>
           <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
             <rdf:Description rdf:about="#meta_M_cpd15306_c0">
@@ -17515,7 +17515,7 @@
           </rdf:RDF>
         </annotation>
       </species>
-      <species metaid="meta_M_cpd00461_c0" sboTerm="SBO:0000247" id="M_cpd00461_c0" name="Oxopent-4-enoate [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-1" fbc:chemicalFormula="C5H5O3">
+      <species metaid="meta_M_cpd00461_c0" sboTerm="SBO:0000247" id="M_cpd00461_c0" name="2-Hydroxy-2,4-pentadienoate [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-1" fbc:chemicalFormula="C5H5O3">
         <annotation>
           <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
             <rdf:Description rdf:about="#meta_M_cpd00461_c0">
@@ -18192,7 +18192,7 @@
           </rdf:RDF>
         </annotation>
       </species>
-      <species metaid="meta_M_cpd15368_c0" sboTerm="SBO:0000247" id="M_cpd15368_c0" name="(R)-3-hydroxy-cis-myristol-7-eoyl-[acyl-carrier protein] [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-1" fbc:chemicalFormula="C25H45N2O9PRS">
+      <species metaid="meta_M_cpd15368_c0" sboTerm="SBO:0000247" id="M_cpd15368_c0" name="(3R,7Z)-3-Hydroxytetradecenoyl-ACP [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-1" fbc:chemicalFormula="C25H45N2O9PRS">
         <annotation>
           <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
             <rdf:Description rdf:about="#meta_M_cpd15368_c0">
@@ -18207,7 +18207,7 @@
           </rdf:RDF>
         </annotation>
       </species>
-      <species metaid="meta_M_cpd15570_c0" sboTerm="SBO:0000247" id="M_cpd15570_c0" name="trans-3-cis-7-myristoleoyl-[acyl-carrier protein] [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-1" fbc:chemicalFormula="C25H43N2O8PRS">
+      <species metaid="meta_M_cpd15570_c0" sboTerm="SBO:0000247" id="M_cpd15570_c0" name="(3E,7Z)-Tetradecadienoyl-ACP [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-1" fbc:chemicalFormula="C25H43N2O8PRS">
         <annotation>
           <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
             <rdf:Description rdf:about="#meta_M_cpd15570_c0">
@@ -18535,7 +18535,7 @@
           </rdf:RDF>
         </annotation>
       </species>
-      <species metaid="meta_M_cpd15541_c0" sboTerm="SBO:0000247" id="M_cpd15541_c0" name="Phosphatidylglycerol dioctadec-11-enoyl [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-1" fbc:chemicalFormula="C42H78O10P">
+      <species metaid="meta_M_cpd15541_c0" sboTerm="SBO:0000247" id="M_cpd15541_c0" name="1,2-di-(11Z)-octadecenoyl-sn-glycero-3-phosphoglycerol [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-1" fbc:chemicalFormula="C42H78O10P">
         <annotation>
           <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
             <rdf:Description rdf:about="#meta_M_cpd15541_c0">
@@ -18704,7 +18704,7 @@
           </rdf:RDF>
         </annotation>
       </species>
-      <species metaid="meta_M_cpd15725_c0" sboTerm="SBO:0000247" id="M_cpd15725_c0" name="Diisopentadecanoylphosphatidylglycerol [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-1" fbc:chemicalFormula="C36H70O10P">
+      <species metaid="meta_M_cpd15725_c0" sboTerm="SBO:0000247" id="M_cpd15725_c0" name="1,2-di-13-methyltetradecanoyl-sn-glycero-3-phosphoglycerol [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-1" fbc:chemicalFormula="C36H70O10P">
         <annotation>
           <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
             <rdf:Description rdf:about="#meta_M_cpd15725_c0">
@@ -18736,7 +18736,7 @@
           </rdf:RDF>
         </annotation>
       </species>
-      <species metaid="meta_M_cpd15324_c0" sboTerm="SBO:0000247" id="M_cpd15324_c0" name="1-Acyl-sn-glycero-3-phosphoglycerol octadec-11-enoyl [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-1" fbc:chemicalFormula="C24H46O9P">
+      <species metaid="meta_M_cpd15324_c0" sboTerm="SBO:0000247" id="M_cpd15324_c0" name="1-(11Z)-octadecenoyl-sn-glycero-3-phosphoglycerol [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-1" fbc:chemicalFormula="C24H46O9P">
         <annotation>
           <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
             <rdf:Description rdf:about="#meta_M_cpd15324_c0">
@@ -18772,7 +18772,7 @@
           </rdf:RDF>
         </annotation>
       </species>
-      <species metaid="meta_M_cpd15703_c0" sboTerm="SBO:0000247" id="M_cpd15703_c0" name="1,2-Diisotetradecanoyl-sn-glycerol [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="0" fbc:chemicalFormula="C31H60O5">
+      <species metaid="meta_M_cpd15703_c0" sboTerm="SBO:0000247" id="M_cpd15703_c0" name="1,2-di-12-methyltridecanoylglycerol [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="0" fbc:chemicalFormula="C31H60O5">
         <annotation>
           <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
             <rdf:Description rdf:about="#meta_M_cpd15703_c0">
@@ -18910,7 +18910,7 @@
           </rdf:RDF>
         </annotation>
       </species>
-      <species metaid="meta_M_cpd15347_c0" sboTerm="SBO:0000247" id="M_cpd15347_c0" name="2-Acyl-sn-glycero-3-phosphoglycerol hexadec-9-enoyl [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-1" fbc:chemicalFormula="C22H42O9P">
+      <species metaid="meta_M_cpd15347_c0" sboTerm="SBO:0000247" id="M_cpd15347_c0" name="2-(9Z)-hexadecenoyl-sn-glycero-3-phosphoglycerol [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-1" fbc:chemicalFormula="C22H42O9P">
         <annotation>
           <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
             <rdf:Description rdf:about="#meta_M_cpd15347_c0">
@@ -18978,7 +18978,7 @@
           </rdf:RDF>
         </annotation>
       </species>
-      <species metaid="meta_M_cpd15307_c0" sboTerm="SBO:0000247" id="M_cpd15307_c0" name="1,2-Diacyl-sn-glycerol ditetradecanoyl [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="0" fbc:chemicalFormula="C31H60O5">
+      <species metaid="meta_M_cpd15307_c0" sboTerm="SBO:0000247" id="M_cpd15307_c0" name="1,2-ditetradecanoylglycerol [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="0" fbc:chemicalFormula="C31H60O5">
         <annotation>
           <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
             <rdf:Description rdf:about="#meta_M_cpd15307_c0">
@@ -19062,7 +19062,7 @@
           </rdf:RDF>
         </annotation>
       </species>
-      <species metaid="meta_M_cpd15310_c0" sboTerm="SBO:0000247" id="M_cpd15310_c0" name="1,2-Diacyl-sn-glycerol dihexadec-9-enoyl [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="0" fbc:chemicalFormula="C35H64O5">
+      <species metaid="meta_M_cpd15310_c0" sboTerm="SBO:0000247" id="M_cpd15310_c0" name="1,2-di-(9Z)-hexadecenoylglycerol [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="0" fbc:chemicalFormula="C35H64O5">
         <annotation>
           <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
             <rdf:Description rdf:about="#meta_M_cpd15310_c0">
@@ -19164,7 +19164,7 @@
           </rdf:RDF>
         </annotation>
       </species>
-      <species metaid="meta_M_cpd21088_c0" sboTerm="SBO:0000247" id="M_cpd21088_c0" name="Pimelyl-[acyl-carrier protein] methyl ester [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="0" fbc:chemicalFormula="C8H13O3RS">
+      <species metaid="meta_M_cpd21088_c0" sboTerm="SBO:0000247" id="M_cpd21088_c0" name="Pimeloyl-ACP methyl ester [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="0" fbc:chemicalFormula="C8H13O3RS">
         <annotation>
           <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
             <rdf:Description rdf:about="#meta_M_cpd21088_c0">
@@ -19180,7 +19180,7 @@
           </rdf:RDF>
         </annotation>
       </species>
-      <species metaid="meta_M_cpd21087_c0" sboTerm="SBO:0000247" id="M_cpd21087_c0" name="Pimelyl-[acyl-carrier protein] [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="0" fbc:chemicalFormula="C7H11O3RS">
+      <species metaid="meta_M_cpd21087_c0" sboTerm="SBO:0000247" id="M_cpd21087_c0" name="Pimeloyl-ACP [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="0" fbc:chemicalFormula="C7H11O3RS">
         <annotation>
           <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
             <rdf:Description rdf:about="#meta_M_cpd21087_c0">
@@ -19288,7 +19288,7 @@
           </rdf:RDF>
         </annotation>
       </species>
-      <species metaid="meta_M_cpd12489_c0" sboTerm="SBO:0000247" id="M_cpd12489_c0" name="cis-3-Decenoyl-[acyl-carrier protein] [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-2" fbc:chemicalFormula="C21H37N2O8PRS">
+      <species metaid="meta_M_cpd12489_c0" sboTerm="SBO:0000247" id="M_cpd12489_c0" name="(3Z)-Decenoyl-ACP [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-2" fbc:chemicalFormula="C21H37N2O8PRS">
         <annotation>
           <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
             <rdf:Description rdf:about="#meta_M_cpd12489_c0">
@@ -19340,7 +19340,7 @@
           </rdf:RDF>
         </annotation>
       </species>
-      <species metaid="meta_M_cpd36635_c0" sboTerm="SBO:0000247" id="M_cpd36635_c0" name="Malonyl-acp-methyl-ester [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="0" fbc:chemicalFormula="C18H30N3O11PR2S">
+      <species metaid="meta_M_cpd36635_c0" sboTerm="SBO:0000247" id="M_cpd36635_c0" name="Malonyl-ACP-methyl-ester [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="0" fbc:chemicalFormula="C18H30N3O11PR2S">
         <annotation>
           <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
             <rdf:Description rdf:about="#meta_M_cpd36635_c0">
@@ -19354,7 +19354,7 @@
           </rdf:RDF>
         </annotation>
       </species>
-      <species metaid="meta_M_cpd22028_c0" sboTerm="SBO:0000247" id="M_cpd22028_c0" name="3-Ketopimeloyl-ACP-methyl-esters [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="0" fbc:chemicalFormula="C22H36N3O12PR2S">
+      <species metaid="meta_M_cpd22028_c0" sboTerm="SBO:0000247" id="M_cpd22028_c0" name="3-Ketopimeloyl-ACP-methyl-ester [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="0" fbc:chemicalFormula="C22H36N3O12PR2S">
         <annotation>
           <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
             <rdf:Description rdf:about="#meta_M_cpd22028_c0">
@@ -19369,7 +19369,7 @@
           </rdf:RDF>
         </annotation>
       </species>
-      <species metaid="meta_M_cpd22065_c0" sboTerm="SBO:0000247" id="M_cpd22065_c0" name="3-hydroxypimeloyl-ACP-methyl-esters [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="0" fbc:chemicalFormula="C22H38N3O12PR2S">
+      <species metaid="meta_M_cpd22065_c0" sboTerm="SBO:0000247" id="M_cpd22065_c0" name="(3R)-3-Hydroxypimeloyl-ACP-methyl-ester [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="0" fbc:chemicalFormula="C22H38N3O12PR2S">
         <annotation>
           <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
             <rdf:Description rdf:about="#meta_M_cpd22065_c0">
@@ -19778,7 +19778,7 @@
           </rdf:RDF>
         </annotation>
       </species>
-      <species metaid="meta_M_cpd27021_c0" sboTerm="SBO:0000247" id="M_cpd27021_c0" name="Enoylpimeloyl-ACP-methyl-esters [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="0" fbc:chemicalFormula="C22H36N3O11PR2S">
+      <species metaid="meta_M_cpd27021_c0" sboTerm="SBO:0000247" id="M_cpd27021_c0" name="(2E)-Enoylpimeloyl-ACP-methyl-ester [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="0" fbc:chemicalFormula="C22H36N3O11PR2S">
         <annotation>
           <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
             <rdf:Description rdf:about="#meta_M_cpd27021_c0">
@@ -19919,7 +19919,7 @@
           </rdf:RDF>
         </annotation>
       </species>
-      <species metaid="meta_M_cpd27020_c0" sboTerm="SBO:0000247" id="M_cpd27020_c0" name="Enoylglutaryl-ACP-methyl-esters [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="0" fbc:chemicalFormula="C20H32N3O11PR2S">
+      <species metaid="meta_M_cpd27020_c0" sboTerm="SBO:0000247" id="M_cpd27020_c0" name="(2E)-Enoylglutaryl-ACP-methyl-ester [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="0" fbc:chemicalFormula="C20H32N3O11PR2S">
         <annotation>
           <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
             <rdf:Description rdf:about="#meta_M_cpd27020_c0">
@@ -20546,7 +20546,7 @@
           </rdf:RDF>
         </annotation>
       </species>
-      <species metaid="meta_M_cpd27180_c0" sboTerm="SBO:0000247" id="M_cpd27180_c0" name="Glutaryl-ACP-methyl-esters [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="0" fbc:chemicalFormula="C20H34N3O11PR2S">
+      <species metaid="meta_M_cpd27180_c0" sboTerm="SBO:0000247" id="M_cpd27180_c0" name="Glutaryl-ACP-methyl-ester [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="0" fbc:chemicalFormula="C20H34N3O11PR2S">
         <annotation>
           <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
             <rdf:Description rdf:about="#meta_M_cpd27180_c0">
@@ -21039,7 +21039,7 @@
           </rdf:RDF>
         </annotation>
       </species>
-      <species metaid="meta_M_cpd00239_e0" sboTerm="SBO:0000247" id="M_cpd00239_e0" name="H2S [e0]" compartment="e0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-1" fbc:chemicalFormula="HS">
+      <species metaid="meta_M_cpd00239_e0" sboTerm="SBO:0000247" id="M_cpd00239_e0" name="Bisulfide (HS-) [e0]" compartment="e0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-1" fbc:chemicalFormula="HS">
         <annotation>
           <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
             <rdf:Description rdf:about="#meta_M_cpd00239_e0">


### PR DESCRIPTION
This pull request:

- Changes name of `cpd00443_c0` from ABEE [c0] to 4-aminobenzoate [c0]
- Changes name of `cpd11441_c0` from fa6coa [c0] to 14-Methylpentadecanoyl-CoA [c0]
- Changes name of `cpd03049_c0` from 2-Hydroxyethyl-ThPP [c0] to 2-Hydroxyethyl-TPP [c0]
- Changes name of `cpd03114_c0` from 3-Oxopalmitoyl-CoA [c0] to 3-Oxohexadecanoyl-CoA [c0]
- Changes name of `cpd11466_c0` from Myristoyl-ACP [c0] to Tetradecanoyl-ACP [c0]
- Changes name of `cpd01695_c0` from Myristoyl-CoA [c0] to Tetradecanoyl-CoA [c0]
- Changes name of `cpd15688_c0` from CDP-1,2-diisohexadecanoylglycerol [c0] to CDP-1,2-di-14-methylpentadecanoylglycerol [c0]
- Changes name of `cpd15727_c0` from Diisohexadecanoylphosphatidylglycerol [c0] to 1,2-di-14-methylpentadecanoyl-sn-glycero-3-phosphoglycerol [c0]
- Changes name of `cpd00193_c0` from APS [c0] to 5'-Adenylyl sulfate [c0]
- Changes name of `cpd15237_c0` from hexadecenoate [c0] to (9Z)-Hexadecenoate [c0]
- Changes name of `cpd15686_c0` from CDP-1,2-diisopentadecanoylglycerol [c0] to CDP-1,2-di-13-methyltetradecanoylglycerol [c0]
- Changes name of `cpd11439_c0` from fa4coa [c0] to 12-Methyltetradecanoyl-CoA [c0]
- Changes name of `cpd15675_c0` from 1-anteisopentadecanoyl-sn-glycerol 3-phosphate [c0] to 1-12-methyltetradecanoyl-sn-glycerol-3-phosphate [c0]
- Changes name of `cpd15682_c0` from 1,2-diisohexadecanoyl-sn-glycerol 3-phosphate [c0] to 1,2-di-14-methylpentadecanoyl-sn-glycerol-3-phosphate [c0]
- Changes name of `cpd11483_c0` from (R)-3-Hydroxyoctanoyl-[acyl-carrier protein] [c0] to (3R)-3-Hydroxyoctanoyl-ACP [c0]
- Changes name of `cpd11471_c0` from (2E)-Octenoyl-[acp] [c0] to (2E)-Octenoyl-ACP [c0]
- Changes name of `cpd11432_c0` from fa11coa [c0] to 15-Methylhexadecanoyl-CoA [c0]
- Changes name of `cpd15671_c0` from 1-isoheptadecanoyl-sn-glycerol 3-phosphate [c0] to 1-14-methylpentadecanoyl-sn-glycerol-3-phosphate [c0]
- Changes name of `cpd11513_c0` from 12-methyl-3-hydroxy-tetra-decanoyl-ACP [c0] to (3R)-3-hydroxy-12-methyltetradecanoyl-ACP [c0]
- Changes name of `cpd11514_c0` from 12-methyl-trans-tetra-dec-2-enoyl-ACP [c0] to (2E)-12-methyltetradecenoyl-ACP [c0]
- Changes name of `cpd15685_c0` from CDP-1,2-diisotetradecanoylglycerol [c0] to CDP-1,2-di-12-methyltridecanoylglycerol [c0]
- Changes name of `cpd11505_c0` from 8-methyl-3-hydroxy-decanoyl-ACP [c0] to (3R)-3-hydroxy-8-methyldecanoyl-ACP [c0]
- Changes name of `cpd11506_c0` from 8-methyl-trans-dec-2-enoyl-ACP [c0] to (2E)-8-methyldecenoyl-ACP [c0]
- Changes name of `cpd01741_c0` from ddca [c0] to Dodecanoate [c0]
- Changes name of `cpd15308_c0` from 1,2-Diacyl-sn-glycerol ditetradec-7-enoyl [c0] to 1,2-di-(7Z)-tetradecenoylglycerol [c0]
- Changes name of `cpd15523_c0` from 1,2-ditetradec-7-enoyl-sn-glycerol 3-phosphate [c0] to 1,2-di-(7Z)-tetradecenoyl-sn-glycerol-3-phosphate [c0]
- Changes name of `cpd15702_c0` from 1,2-Dianteisoheptadecanoyl-sn-glycerol [c0] to 1,2-di-14-methylhexadecanoylglycerol [c0]
- Changes name of `cpd15678_c0` from 1,2-dianteisoheptadecanoyl-sn-glycerol 3-phosphate [c0] to 1,2-di-14-methylhexadecanoyl-sn-glycerol-3-phosphate [c0]
- Changes name of `cpd15422_c0` from CDP-1,2-ditetradec-7-enoylglycerol [c0] to CDP-1,2-di-(7Z)-tetradecenoylglycerol [c0]
- Changes name of `cpd15357_c0` from 2-octadec-11-enoyl-sn-glycerol 3-phosphate [c0] to 2-(11Z)-octadecenoyl-sn-glycerol-3-phosphate [c0]
- Changes name of `cpd15269_c0` from octadecenoate [c0] to (11Z)-Octadecenoate [c0]
- Changes name of `cpd11492_c0` from Malonyl-acyl-carrierprotein- [c0] to Malonyl-ACP [c0]
- Changes name of `cpd11486_c0` from 3-Oxohexanoyl-[acp] [c0] to 3-Oxohexanoyl-ACP [c0]
- Changes name of `cpd11522_c0` from 5-methyl-3-hydroxy-hexanoyl-ACP [c0] to (3R)-3-hydroxy-5-methylhexanoyl-ACP [c0]
- Changes name of `cpd11523_c0` from 5-methyl-trans-hex-2-enoyl-ACP [c0] to (2E)-5-methylhexenoyl-ACP [c0]
- Changes name of `cpd11421_c0` from trdrd [c0] to Reduced thioredoxin [c0]
- Changes name of `cpd11420_c0` from trdox [c0] to Oxidized thioredoxin [c0]
- Changes name of `cpd03189_c0` from 3-Carboxy-1-hydroxypropyl-ThPP [c0] to 3-Carboxy-1-hydroxypropyl-TPP [c0]
- Changes name of `cpd15239_c0` from Hexadecenoyl-ACP [c0] to (9Z)-Hexadecenoyl-ACP [c0]
- Changes name of `cpd15418_c0` from CDP-1,2-dihexadec-9-enoylglycerol [c0] to CDP-1,2-di-(9Z)-hexadecenoylglycerol [c0]
- Changes name of `cpd00239_c0` from H2S [c0] to Bisulfide (HS-) [c0]
- Changes name of `cpd00508_c0` from 3MOP [c0] to 3-methyl-2-oxopentoate [c0]
- Changes name of `cpd11490_c0` from 3-oxooctanoyl-acp [c0] to 3-Oxooctanoyl-ACP [c0]
- Changes name of `cpd11526_c0` from 7-methyl-3-hydroxy-octanoyl-ACP [c0] to (3R)-3-hydroxy-7-methyloctanoyl-ACP [c0]
- Changes name of `cpd11527_c0` from 7-methyl-trans-oct-2-enoyl-ACP [c0] to (2E)-7-methyloctenoyl-ACP [c0]
- Changes name of `cpd11469_c0` from (2E)-Dodecenoyl-[acp] [c0] to (2E)-Dodecenoyl-ACP [c0]
- Changes name of `cpd15328_c0` from 1-octadec-11-enoyl-sn-glycerol 3-phosphate [c0] to 1-(11Z)-octadecenoyl-sn-glycerol-3-phosphate [c0]
- Changes name of `cpd15687_c0` from CDP-1,2-dianteisopentadecanoylglycerol [c0] to CDP-1,2-di-12-methyltetradecanoylglycerol [c0]
- Changes name of `cpd11478_c0` from (R)-3-Hydroxybutanoyl-[acyl-carrier protein] [c0] to (3R)-3-Hydroxybutanoyl-ACP [c0]
- Changes name of `cpd11465_c0` from But-2-enoyl-[acyl-carrier protein] [c0] to (2E)-Butenoyl-ACP [c0]
- Changes name of `cpd15539_c0` from Phosphatidylglycerol dihexadec-9-enoyl [c0] to 1,2-di-(9Z)-hexadecenoyl-sn-glycero-3-phosphoglycerol [c0]
- Changes name of `cpd00214_c0` from Palmitate [c0] to Hexadecanoate [c0]
- Changes name of `cpd11570_c0` from 3-Oxooctodecanoyl-ACP [c0] to 3-Oxooctadecanoyl-ACP [c0]
- Changes name of `cpd11571_c0` from 3-Hydroxyoctodecanoyl-ACP [c0] to (3R)-3-Hydroxyoctadecanoyl-ACP [c0]
- Changes name of `cpd15679_c0` from 1,2-diisotetradecanoyl-sn-glycerol 3-phosphate [c0] to 1,2-di-12-methyltridecanoyl-sn-glycerol-3-phosphate [c0]
- Changes name of `cpd15322_c0` from 1-Acyl-sn-glycero-3-phosphoglycerol hexadec-9-enoyl [c0] to 1-(9Z)-hexadecenoyl-sn-glycero-3-phosphoglycerol [c0]
- Changes name of `cpd15343_c0` from 2-Acyl-sn-glycero-3-phosphoglycerol dodecanoyl [c0] to 2-dodecanoyl-sn-glycero-3-phosphoglycerol [c0]
- Changes name of `cpd11484_c0` from HMA [c0] to (3R)-3-Hydroxytetradecanoyl-ACP [c0]
- Changes name of `cpd11467_c0` from (2E)-Tetradecenoyl-[acp] [c0] to (2E)-Tetradecenoyl-ACP [c0]
- Changes name of `cpd15704_c0` from 1,2-Diisopentadecanoyl-sn-glycerol [c0] to 1,2-di-13-methyltetradecanoylglycerol [c0]
- Changes name of `cpd15680_c0` from 1,2-diisopentadecanoyl-sn-glycerol 3-phosphate [c0] to 1,2-di-13-methyltetradecanoyl-sn-glycerol-3-phosphate [c0]
- Changes name of `cpd11489_c0` from 3-oxododecanoyl-acp [c0] to 3-Oxododecanoyl-ACP [c0]
- Changes name of `cpd11476_c0` from hexadecanoyl-acp [c0] to Hexadecanoyl-ACP [c0]
- Changes name of `cpd00134_c0` from Palmitoyl-CoA [c0] to Hexadecanoyl-CoA [c0]
- Changes name of `cpd15312_c0` from 1,2-Diacyl-sn-glycerol dioctadec-11-enoyl [c0] to 1,2-di-(11Z)-octadecenoylglycerol [c0]
- Changes name of `cpd15527_c0` from 1,2-dioctadec-11-enoyl-sn-glycerol 3-phosphate [c0] to 1,2-di-(11Z)-octadecenoyl-sn-glycerol-3-phosphate [c0]
- Changes name of `cpd15420_c0` from CDP-1,2-dioctadec-11-enoylglycerol [c0] to CDP-1,2-di-(11Z)-octadecenoylglycerol [c0]
- Changes name of `cpd01080_c0` from ocdca [c0] to Octadecanoate [c0]
- Changes name of `cpd11437_c0` from fa3coa [c0] to 13-Methyltetradecanoyl-CoA [c0]
- Changes name of `cpd15674_c0` from 1-isopentadecanoyl-sn-glycerol 3-phosphate [c0] to 1-13-methyltetradecanoyl-sn-glycerol-3-phosphate [c0]
- Changes name of `cpd11491_c0` from 3-oxotetradecanoyl-acp [c0] to 3-Oxotetradecanoyl-ACP [c0]
- Changes name of `cpd00327_c0` from strcoa [c0] to Octadecanoyl-CoA [c0]
- Changes name of `cpd03847_c0` from Myristic acid [c0] to Tetradecanoate [c0]
- Changes name of `cpd11534_c0` from 11-methyl-3-hydroxy-dodecanoyl-ACP [c0] to (3R)-3-hydroxy-11-methyldodecanoyl-ACP [c0]
- Changes name of `cpd11535_c0` from 11-methyl-trans-dodec-2-enoyl-ACP [c0] to (2E)-11-methyldodecenoyl-ACP [c0]
- Changes name of `cpd02882_c0` from 4--1-D-Ribitylamino-5-aminouracil [c0] to 5-Amino-6-(1-D-ribitylamino)uracil [c0]
- Changes name of `cpd11501_c0` from 6-methyl-3-hydroxy-octanoyl-ACP [c0] to (3R)-3-hydroxy-6-methyloctanoyl-ACP [c0]
- Changes name of `cpd11502_c0` from 6-methyl-trans-oct-2-enoyl-ACP [c0] to (2E)-6-methyloctenoyl-ACP [c0]
- Changes name of `cpd00214_e0` from Palmitate [e0] to Hexadecanoate [e0]
- Changes name of `cpd11475_c0` from (2E)-Decenoyl-[acp] [c0] to (2E)-Decenoyl-ACP [c0]
- Changes name of `cpd15366_c0` from (R)-3-hydroxy-cis-dodec-5-enoyl-[acyl-carrier protein] [c0] to (3R,5Z)-3-Hydroxydodecenoyl-ACP [c0]
- Changes name of `cpd15569_c0` from trans-3-cis-5-dodecenoyl-[acyl-carrier protein] [c0] to (3E,5Z)-Dodecadienoyl-ACP [c0]
- Changes name of `cpd15684_c0` from CDP-1,2-dianteisoheptadecanoylglycerol [c0] to CDP-1,2-di-14-methylhexadecanoylglycerol [c0]
- Changes name of `cpd11481_c0` from R-3-hydroxypalmitoyl-acyl-carrierprotein- [c0] to (3R)-3-Hydroxyhexadecanoyl-ACP [c0]
- Changes name of `cpd11485_c0` from 3-oxohexadecanoyl-acp [c0] to 3-Oxohexadecanoyl-ACP [c0]
- Changes name of `cpd15323_c0` from 1-Acyl-sn-glycero-3-phosphoglycerol octadecanoyl [c0] to 1-octadecanoyl-sn-glycero-3-phosphoglycerol [c0]
- Changes name of `cpd15370_c0` from (R)-3-hydroxy-cis-vacc-11-enoyl-[acyl-carrier protein] [c0] to (3R,11Z)-3-Hydroxyoctadecenoyl-ACP [c0]
- Changes name of `cpd15568_c0` from trans-3-cis-11-vacceoyl-[acyl-carrier protein] [c0] to (3E,11Z)-Octadecadienoyl-ACP [c0]
- Changes name of `cpd15330_c0` from 1-tetradec-7-enoyl-sn-glycerol 3-phosphate [c0] to 1-(7Z)-tetradecenoyl-sn-glycerol-3-phosphate [c0]
- Changes name of `cpd15298_c0` from tetradecenoate [c0] to (7Z)-Tetradecenoate [c0]
- Changes name of `cpd15354_c0` from 2-hexadec-9-enoyl-sn-glycerol 3-phosphate [c0] to 2-(9Z)-hexadecenoyl-sn-glycerol-3-phosphate [c0]
- Changes name of `cpd11517_c0` from 14-methyl-3-hydroxy-hexa-decanoyl-ACP [c0] to (3R)-3-hydroxy-14-methylhexadecanoyl-ACP [c0]
- Changes name of `cpd11518_c0` from 14-methyl-trans-hexa-dec-2-enoyl-ACP [c0] to (2E)-14-methylhexadecenoyl-ACP [c0]
- Changes name of `cpd11480_c0` from D-3-Hydroxydodecanoyl-[acp] [c0] to (3R)-3-Hydroxydodecanoyl-ACP [c0]
- Changes name of `cpd15538_c0` from Phosphatidylglycerol dihexadecanoyl [c0] to 1,2-dihexadecanoyl-sn-glycero-3-phosphoglycerol [c0]
- Changes name of `cpd15346_c0` from 2-Acyl-sn-glycero-3-phosphoglycerol hexadecanoyl [c0] to 2-hexadecanoyl-sn-glycero-3-phosphoglycerol [c0]
- Changes name of `cpd11542_c0` from 15-methyl-3-hydroxy-hexa-decanoyl-ACP [c0] to (3R)-3-hydroxy-15-methylhexadecanoyl-ACP [c0]
- Changes name of `cpd11543_c0` from 15-methyl-trans-hexa-dec-2-enoyl-ACP [c0] to (2E)-15-methylhexadecenoyl-ACP [c0]
- Changes name of `cpd11434_c0` from fa12coa [c0] to 14-Methylhexadecanoyl-CoA [c0]
- Changes name of `cpd15369_c0` from (R)-3-hydroxy-cis-palm-9-eoyl-[acyl-carrier protein] [c0] to (3R,9Z)-3-Hydroxyhexadecenoyl-ACP [c0]
- Changes name of `cpd15571_c0` from trans-3-cis-9-palmitoleoyl-[acyl-carrier protein] [c0] to (3E,9Z)-Hexadecadienoyl-ACP [c0]
- Changes name of `cpd15540_c0` from Phosphatidylglycerol dioctadecanoyl [c0] to 1,2-dioctadecanoyl-sn-glycero-3-phosphoglycerol [c0]
- Changes name of `cpd15348_c0` from 2-Acyl-sn-glycero-3-phosphoglycerol octadecanoyl [c0] to 2-octadecanoyl-sn-glycero-3-phosphoglycerol [c0]
- Changes name of `cpd15537_c0` from Phosphatidylglycerol ditetradec-7-enoyl [c0] to 1,2-di-(7Z)-tetradecenoyl-sn-glycero-3-phosphoglycerol [c0]
- Changes name of `cpd15320_c0` from 1-Acyl-sn-glycero-3-phosphoglycerol tetradec-7-enoyl [c0] to 1-(7Z)-tetradecenoyl-sn-glycero-3-phosphoglycerol [c0]
- Changes name of `cpd11482_c0` from (R)-3-Hydroxydecanoyl-[acyl-carrier protein] [c0] to (3R)-3-Hydroxydecanoyl-ACP [c0]
- Changes name of `cpd11487_c0` from 3-oxodecanoyl-acp [c0] to 3-Oxodecanoyl-ACP [c0]
- Changes name of `cpd15722_c0` from Diisoheptadecanoylphosphatidylglycerol [c0] to 1,2-di-15-methylhexadecanoyl-sn-glycero-3-phosphoglycerol [c0]
- Changes name of `cpd15525_c0` from 1,2-dihexadec-9-enoyl-sn-glycerol 3-phosphate [c0] to 1,2-(9Z)-hexadecenoyl-sn-glycerol-3-phosphate [c0]
- Changes name of `cpd15681_c0` from 1,2-dianteisopentadecanoyl-sn-glycerol 3-phosphate [c0] to 1,2-di-12-methyltetradecanoyl-sn-glycerol-3-phosphate [c0]
- Changes name of `cpd11479_c0` from D-3-Hydroxyhexanoyl-[acp] [c0] to (3R)-3-Hydroxyhexanoyl-ACP [c0]
- Changes name of `cpd15706_c0` from 1,2-Diisohexadecanoyl-sn-glycerol [c0] to 1,2-di-14-methylpentadecanoylglycerol [c0]
- Changes name of `cpd15345_c0` from 2-Acyl-sn-glycero-3-phosphoglycerol tetradec-7-enoyl [c0] to 2-(7Z)-tetradecenoyl-sn-glycero-3-phosphoglycerol [c0]
- Changes name of `cpd15311_c0` from 1,2-Diacyl-sn-glycerol dioctadecanoyl [c0] to 1,2-dioctadecanoylglycerol [c0]
- Changes name of `cpd15344_c0` from 2-Acyl-sn-glycero-3-phosphoglycerol tetradecanoyl [c0] to 2-tetradecanoyl-sn-glycero-3-phosphoglycerol [c0]
- Changes name of `cpd03584_c0` from UDP-3-O-(beta-hydroxymyristoyl)-D-glucosamine [c0] to UDP-3-O-(3-hydroxytetradecanoyl)-D-glucosamine [c0]
- Changes name of `cpd00200_c0` from 4MOP [c0] to 4-Methyl-2-oxopentanoate [c0]
- Changes name of `cpd11825_c0` from Octadecenoyl-ACP [c0] to (11Z)-Octadecenoyl-ACP [c0]
- Changes name of `cpd15726_c0` from Dianteisopentadecanoylphosphatidylglycerol [c0] to 1,2-di-12-methyltetradecanoyl-sn-glycero-3-phosphoglycerol [c0]
- Changes name of `cpd11538_c0` from 13-methyl-3-hydroxy-tetra-decanoyl-ACP [c0] to (3R)-3-hydroxy-13-methyltetradecanoyl-ACP [c0]
- Changes name of `cpd11539_c0` from 13-methyl-trans-tetra-dec-2-enoyl-ACP [c0] to (2E)-13-methyltetradecenoyl-ACP [c0]
- Changes name of `cpd15701_c0` from 1,2-Diisoheptadecanoyl-sn-glycerol [c0] to 1,2-di-15-methylhexadecanoylglycerol [c0]
- Changes name of `cpd15677_c0` from 1,2-diisoheptadecanoyl-sn-glycerol 3-phosphate [c0] to 1,2-di-15-methylhexadecanoyl-sn-glycerol-3-phosphate [c0]
- Changes name of `cpd11435_c0` from fa1coa [c0] to 12-Methyltridecanoyl-CoA [c0]
- Changes name of `cpd15673_c0` from 1-isotetradecanoyl-sn-glycerol 3-phosphate [c0] to 1-12-methyltridecanoyl-sn-glycerol-3-phosphate [c0]
- Changes name of `cpd00342_c0` from N-Acetylornithine [c0] to N-acetylornithine [c0]
- Changes name of `cpd15723_c0` from Dianteisoheptadecanoylphosphatidylglycerol [c0] to 1,2-di-14-methylhexadecanoyl-sn-glycero-3-phosphoglycerol [c0]
- Changes name of `cpd11509_c0` from 10-methyl-3-hydroxy-dodecanoyl-ACP [c0] to (3R)-3-hydroxy-10-methyldodecanoyl-ACP [c0]
- Changes name of `cpd11510_c0` from 10-methyl-trans-dodec-2-enoyl-ACP [c0] to (2E)-10-methyldodecenoyl-ACP [c0]
- Changes name of `cpd15349_c0` from 2-Acyl-sn-glycero-3-phosphoglycerol octadec-11-enoyl [c0] to 2-(11Z)-octadecenoyl-sn-glycero-3-phosphoglycerol [c0]
- Changes name of `cpd11473_c0` from (2E)-Hexenoyl-[acp] [c0] to (2E)-Hexenoyl-ACP [c0]
- Changes name of `cpd15536_c0` from Phosphatidylglycerol ditetradecanoyl [c0] to 1,2-ditetradecanoyl-sn-glycero-3-phosphoglycerol [c0]
- Changes name of `cpd15321_c0` from 1-Acyl-sn-glycero-3-phosphoglycerol hexadecanoyl [c0] to 1-hexadecanoyl-sn-glycero-3-phosphoglycerol [c0]
- Changes name of `cpd15676_c0` from 1-isohexadecanoyl-sn-glycerol 3-phosphate [c0] to 1-14-methylpentadecanoyl-sn-glycerol-3-phosphate [c0]
- Changes name of `cpd02886_c0` from UDP-3-O-(beta-hydroxymyristoyl)-N-acetylglucosamine [c0] to UDP-3-O-(3-hydroxytetradecanoyl)-N-acetylglucosamine [c0]
- Changes name of `cpd15705_c0` from 1,2-Dianteisopentadecanoyl-sn-glycerol [c0] to 1,2-di-12-methyltetradecanoylglycerol [c0]
- Changes name of `cpd11530_c0` from 9-methyl-3-hydroxy-decanoyl-ACP [c0] to (3R)-3-hydroxy-9-methyldecanoyl-ACP [c0]
- Changes name of `cpd11531_c0` from 9-methyl-trans-dec-2-enoyl-ACP [c0] to (2E)-9-methyldecenoyl-ACP [c0]
- Changes name of `cpd03847_e0` from Myristic acid [e0] to Tetradecanoate [c0] [e0]
- Changes name of `cpd15535_c0` from Phosphatidylglycerol didodecanoyl [c0] to 1,2-didodecanoyl-sn-glycero-3-phosphoglycerol [c0]
- Changes name of `cpd15318_c0` from 1-Acyl-sn-glycero-3-phosphoglycerol dodecanoyl [c0] to 1-dodecanoyl-sn-glycero-3-phosphoglycerol [c0]
- Changes name of `cpd11572_c0` from trans-Octodec-2-enoyl-ACP [c0] to (2E)-Octadecenoyl-ACP [c0]
- Changes name of `cpd15724_c0` from Diisotetradecanoylphosphatidylglycerol [c0] to 1,2-di-12-methyltridecanoyl-sn-glycero-3-phosphoglycerol [c0]
- Changes name of `cpd15683_c0` from CDP-1,2-diisoheptadecanoylglycerol [c0] to CDP-1,2-di-15-methylhexadecanoylglycerol [c0]
- Changes name of `cpd08210_c0` from ADC [c0] to 4-amino-4-deoxychorismate [c0]
- Changes name of `cpd15294_c0` from Tetradecenoyl-ACP [c0] to (7Z)-Tetradecenoyl-ACP [c0]
- Changes name of `cpd15672_c0` from 1-anteisoheptadecanoyl-sn-glycerol 3-phosphate [c0] to 1-13-methylpentadecanoyl-sn-glycerol-3-phosphate [c0]
- Changes name of `cpd11477_c0` from (2E)-Hexadecenoyl-[acp] [c0] to (2E)-Hexadecenoyl-ACP [c0]
- Changes name of `cpd11497_c0` from 4-methyl-3-hydroxy-hexanoyl-ACP [c0] to (3R)-3-hydroxy-4-methylhexanoyl-ACP [c0]
- Changes name of `cpd11498_c0` from 4-methyl-trans-hex-2-enoyl-ACP [c0] to (2E)-4-methylhexenoyl-ACP [c0]
- Changes name of `cpd15326_c0` from 1-hexadec-9-enoyl-sn-glycerol 3-phosphate [c0] to 1-(9Z)-hexadecenoyl-sn-glycerol-3-phosphate [c0]
- Changes name of `cpd15319_c0` from 1-Acyl-sn-glycero-3-phosphoglycerol tetradecanoyl [c0] to 1-tetradecanoyl-sn-glycero-3-phosphoglycerol [c0]
- Changes name of `cpd15362_c0` from 2-tetradec-7-enoyl-sn-glycerol 3-phosphate [c0] to 2-(7Z)-tetradecenoyl-sn-glycerol-3-phosphate [c0]
- Changes name of `cpd15306_c0` from 1,2-Diacyl-sn-glycerol didodecanoyl [c0] to 1,2-didodecanoylglycerol [c0]
- Changes name of `cpd00461_c0` from Oxopent-4-enoate [c0] to 2-Hydroxy-2,4-pentadienoate [c0]
- Changes name of `cpd15368_c0` from (R)-3-hydroxy-cis-myristol-7-eoyl-[acyl-carrier protein] [c0] to (3R,7Z)-3-Hydroxytetradecenoyl-ACP [c0]
- Changes name of `cpd15570_c0` from trans-3-cis-7-myristoleoyl-[acyl-carrier protein] [c0] to (3E,7Z)-Tetradecadienoyl-ACP [c0]
- Changes name of `cpd15541_c0` from Phosphatidylglycerol dioctadec-11-enoyl [c0] to 1,2-di-(11Z)-octadecenoyl-sn-glycero-3-phosphoglycerol [c0]
- Changes name of `cpd15725_c0` from Diisopentadecanoylphosphatidylglycerol [c0] to 1,2-di-13-methyltetradecanoyl-sn-glycero-3-phosphoglycerol [c0]
- Changes name of `cpd15324_c0` from 1-Acyl-sn-glycero-3-phosphoglycerol octadec-11-enoyl [c0] to 1-(11Z)-octadecenoyl-sn-glycero-3-phosphoglycerol [c0]
- Changes name of `cpd15703_c0` from 1,2-Diisotetradecanoyl-sn-glycerol [c0] to 1,2-di-12-methyltridecanoylglycerol [c0]
- Changes name of `cpd15347_c0` from 2-Acyl-sn-glycero-3-phosphoglycerol hexadec-9-enoyl [c0] to 2-(9Z)-hexadecenoyl-sn-glycero-3-phosphoglycerol [c0]
- Changes name of `cpd15307_c0` from 1,2-Diacyl-sn-glycerol ditetradecanoyl [c0] to 1,2-ditetradecanoylglycerol [c0]
- Changes name of `cpd15310_c0` from 1,2-Diacyl-sn-glycerol dihexadec-9-enoyl [c0] to 1,2-di-(9Z)-hexadecenoylglycerol [c0]
- Changes name of `cpd21088_c0` from Pimelyl-[acyl-carrier protein] methyl ester [c0] to Pimeloyl-ACP methyl ester [c0]
- Changes name of `cpd21087_c0` from Pimelyl-[acyl-carrier protein] [c0] to Pimeloyl-ACP [c0]
- Changes name of `cpd12489_c0` from cis-3-Decenoyl-[acyl-carrier protein] [c0] to (3Z)-Decenoyl-ACP [c0]
- Changes name of `cpd36635_c0` from Malonyl-acp-methyl-ester [c0] to Malonyl-ACP-methyl-ester [c0]
- Changes name of `cpd22028_c0` from 3-Ketopimeloyl-ACP-methyl-esters [c0] to 3-Ketopimeloyl-ACP-methyl-ester [c0]
- Changes name of `cpd22065_c0` from 3-hydroxypimeloyl-ACP-methyl-esters [c0] to (3R)-3-Hydroxypimeloyl-ACP-methyl-ester [c0]
- Changes name of `cpd27021_c0` from Enoylpimeloyl-ACP-methyl-esters [c0] to (2E)-Enoylpimeloyl-ACP-methyl-ester [c0]
- Changes name of `cpd27020_c0` from Enoylglutaryl-ACP-methyl-esters [c0] to (2E)-Enoylglutaryl-ACP-methyl-ester [c0]
- Changes name of `cpd27180_c0` from Glutaryl-ACP-methyl-esters [c0] to Glutaryl-ACP-methyl-ester [c0]
- Changes name of `cpd00239_e0` from H2S [e0] to Bisulfide (HS-) [e0]

These are all of the metabolite name changes that I made in [the MIT1002 model](https://github.com/C-CoMP-STC/GEM-mit1002) (for metabolites that appear in both models)