### PR TITLE
Feat: add GPRs for rxn01637_c0 and rxn03087_c0

### DIFF
--- a/model.xml
+++ b/model.xml
@@ -62930,6 +62930,9 @@
           <speciesReference species="M_cpd00024_c0" stoichiometry="1" constant="true"/>
           <speciesReference species="M_cpd02698_c0" stoichiometry="1" constant="true"/>
         </listOfProducts>
+        <fbc:geneProductAssociation>
+          <fbc:geneProductRef fbc:geneProduct="G_ACZ81_RS01905"/>
+        </fbc:geneProductAssociation>
       </reaction>
       <reaction metaid="meta_R_rxn01637_c0" sboTerm="SBO:0000176" id="R_rxn01637_c0" name="N2-Acetyl-L-ornithine:2-oxoglutarate aminotransferase" reversible="true" fast="false" fbc:lowerFluxBound="cobra_default_lb" fbc:upperFluxBound="cobra_default_ub">
         <annotation>
@@ -62958,6 +62961,9 @@
           <speciesReference species="M_cpd00024_c0" stoichiometry="1" constant="true"/>
           <speciesReference species="M_cpd00342_c0" stoichiometry="1" constant="true"/>
         </listOfProducts>
+        <fbc:geneProductAssociation>
+          <fbc:geneProductRef fbc:geneProduct="G_ACZ81_RS01905"/>
+        </fbc:geneProductAssociation>
       </reaction>
       <reaction metaid="meta_R_rxn16823_c0" sboTerm="SBO:0000176" id="R_rxn16823_c0" name="thiazole tautomerase" reversible="false" fast="false" fbc:lowerFluxBound="cobra_0_bound" fbc:upperFluxBound="cobra_default_ub">
         <annotation>
@@ -64440,7 +64446,7 @@
           </rdf:RDF>
         </annotation>
       </fbc:geneProduct>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS01905" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS01905" fbc:name="ACZ81_RS01905" fbc:label="G_ACZ81_RS01905">
+      <fbc:geneProduct metaid="meta_G_ACZ81_RS01905" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS01905" fbc:name="argD" fbc:label="G_ACZ81_RS01905">
         <annotation>
           <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
             <rdf:Description rdf:about="#meta_G_ACZ81_RS01905">


### PR DESCRIPTION
#### Main improvements in this PR:

This pull request:

- Adds new gene `ACZ81_RS01905` (argD) to the model
- Sets the currently empty GPR of `rxn01637_c0` to `ACZ81_RS01905`
- Sets the currently empty GPR of `rxn03087_c0` to `ACZ81_RS01905`

See [PR #263 in the MIT1002 repository](https://github.com/C-CoMP-STC/GEM-mit1002/pull/263); `ACZ81_RS01905` is the reciprocal best BLAST hit of `WP_049588781.1`, and eggNOG annotated both genes with the same functions.

**I hereby confirm that I have:**
- [X] Made my edits to the model on the XML file
- [ ] Tested my code on my own computer for running the model
- [X] Selected `develop` as a target branch
- [ ] Any removed reactions and metabolites have been moved to the corresponding deprecated identifier lists
