### PR TITLE
fix: change rxn12822 into rxn05760 to fix charge imbalance

### DIFF
--- a/model.xml
+++ b/model.xml
@@ -45734,10 +45734,10 @@
           <fbc:geneProductRef fbc:geneProduct="G_ACZ81_RS14460"/>
         </fbc:geneProductAssociation>
       </reaction>
-      <reaction metaid="meta_R_rxn12822_c0" sboTerm="SBO:0000176" id="R_rxn12822_c0" name="L-glutamate:ferredoxin oxidoreductase (transaminating) [c0]" reversible="true" fast="false" fbc:lowerFluxBound="cobra_default_lb" fbc:upperFluxBound="cobra_default_ub">
+      <reaction metaid="meta_R_rxn05760_c0" sboTerm="SBO:0000176" id="R_rxn05760_c0" name="L-glutamate:ferredoxin oxidoreductase (transaminating) [c0]" reversible="true" fast="false" fbc:lowerFluxBound="cobra_default_lb" fbc:upperFluxBound="cobra_default_ub">
         <annotation>
           <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
-            <rdf:Description rdf:about="#meta_R_rxn12822_c0">
+            <rdf:Description rdf:about="#meta_R_rxn05760_c0">
               <bqbiol:is>
                 <rdf:Bag>
                   <rdf:li rdf:resource="https://identifiers.org/seed.reaction/rxn12822"/>
@@ -45752,13 +45752,13 @@
         </annotation>
         <listOfReactants>
           <speciesReference species="M_cpd00023_c0" stoichiometry="2" constant="true"/>
-          <speciesReference species="M_cpd11621_c0" stoichiometry="2" constant="true"/>
+          <speciesReference species="M_cpd11621_c0" stoichiometry="1" constant="true"/>
         </listOfReactants>
         <listOfProducts>
           <speciesReference species="M_cpd00024_c0" stoichiometry="1" constant="true"/>
           <speciesReference species="M_cpd00053_c0" stoichiometry="1" constant="true"/>
           <speciesReference species="M_cpd00067_c0" stoichiometry="2" constant="true"/>
-          <speciesReference species="M_cpd11620_c0" stoichiometry="2" constant="true"/>
+          <speciesReference species="M_cpd11620_c0" stoichiometry="1" constant="true"/>
         </listOfProducts>
         <fbc:geneProductAssociation>
           <fbc:geneProductRef fbc:geneProduct="G_ACZ81_RS10350"/>


### PR DESCRIPTION
#### Main improvements in this PR:

- Changes the coefficients of Oxidizedferredoxin (`cpd11621_c0`) and Reducedferredoxin (`cpd11620_c0`) in `rxn12822_c0` from 2 to 1
- Changes the ID of `rxn12822_c0` to `rxn05760_c0`

See [PR #127 from the MIT1002 model’s repository](https://github.com/C-CoMP-STC/GEM-mit1002/pull/127). Apparently, I accidentally forgot this reaction in #3.

**I hereby confirm that I have:**
- [X] Made my edits to the model on the XML file
- [ ] Tested my code on my own computer for running the model
- [X] Selected `develop` as a target branch
- [ ] Any removed reactions and metabolites have been moved to the corresponding deprecated identifier lists