### PR TITLE
Feat: add proline 4-hydroxylase

### DIFF
--- a/model.xml
+++ b/model.xml
@@ -21600,6 +21600,22 @@
           </rdf:RDF>
         </annotation>
       </species>
+      <species metaid="meta_M_cpd00851_c0" sboTerm="SBO:0000247" id="M_cpd00851_c0" name="trans-4-hydroxy-L-proline [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="0" fbc:chemicalFormula="C5H9NO3">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_M_cpd00851_c0">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/bigg.metabolite/4hpro_LT"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.compound/C01157"/>
+                  <rdf:li rdf:resource="https://identifiers.org/seed.compound/cpd00851"/>
+                  <rdf:li rdf:resource="https://identifiers.org/biocyc/META:4-HYDROXY-L-PROLINE"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </species>
     </listOfSpecies>
     <listOfParameters>
       <parameter sboTerm="SBO:0000626" id="cobra_default_lb" value="-1000" constant="true"/>
@@ -66697,6 +66713,34 @@
           <fbc:geneProductRef fbc:geneProduct="G_ACZ81_RS15305"/>
         </fbc:geneProductAssociation>
       </reaction>
+      <reaction metaid="meta_R_rxn00932_c0" sboTerm="SBO:0000176" id="R_rxn00932_c0" name="L-Proline,2-oxoglutarate:oxygen oxidoreductase (4-hydroxylating)" reversible="false" fast="false" fbc:lowerFluxBound="cobra_0_bound" fbc:upperFluxBound="cobra_default_ub">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_R_rxn00932_c0">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/ec-code/1.14.11.2"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.reaction/R01252"/>
+                  <rdf:li rdf:resource="https://identifiers.org/seed.reaction/rxn00932"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+        <listOfReactants>
+          <speciesReference species="M_cpd00129_c0" stoichiometry="1" constant="true"/>
+          <speciesReference species="M_cpd00024_c0" stoichiometry="1" constant="true"/>
+          <speciesReference species="M_cpd00007_c0" stoichiometry="1" constant="true"/>
+        </listOfReactants>
+        <listOfProducts>
+          <speciesReference species="M_cpd00851_c0" stoichiometry="1" constant="true"/>
+          <speciesReference species="M_cpd00036_c0" stoichiometry="1" constant="true"/>
+          <speciesReference species="M_cpd00011_c0" stoichiometry="1" constant="true"/>
+        </listOfProducts>
+        <fbc:geneProductAssociation>
+          <fbc:geneProductRef fbc:geneProduct="G_ACZ81_RS05535"/>
+        </fbc:geneProductAssociation>
+      </reaction>
     </listOfReactions>
     <fbc:listOfObjectives fbc:activeObjective="obj">
       <fbc:objective fbc:id="obj" fbc:type="maximize">
@@ -78303,6 +78347,7 @@
       <fbc:geneProduct fbc:id="G_ACZ81_RS03210" fbc:name="G_ACZ81_RS03210" fbc:label="G_ACZ81_RS03210"/>
       <fbc:geneProduct fbc:id="G_ACZ81_RS15300" fbc:name="acnD" fbc:label="G_ACZ81_RS15300"/>
       <fbc:geneProduct fbc:id="G_ACZ81_RS15305" fbc:name="prpF" fbc:label="G_ACZ81_RS15305"/>
+      <fbc:geneProduct fbc:id="G_ACZ81_RS05535" fbc:name="G_ACZ81_RS05535" fbc:label="G_ACZ81_RS05535"/>
     </fbc:listOfGeneProducts>
   </model>
 </sbml>


### PR DESCRIPTION
#### Main improvements in this PR:

This pull request:

- Adds new gene `ACZ81_RS05535`: proline 4-hydroxylase
- Adds new metabolite `cpd00851_c0`: trans-4-hydroxy-L-proline
- Adds new reaction `rxn00932_c0`: O2 [c0] + 2-Oxoglutarate [c0] + L-Proline [c0] --> CO2 [c0] + Succinate [c0] + trans-4-Hydroxy-L-proline [c0], GPR: `WP_049587685.1`

I came across this while looking for reactions that weren’t shared between the MIT1002, ATCC 27126, and HOT1A3 models, and noticed that `rxn00932_c0` only appeared in the ATCC 27126 model, but eggNOG also annotated `ACZ81_RS05535` in the HOT1A3 genome with the E.C. number for `rxn00932_c0`.

**I hereby confirm that I have:**
- [X] Made my edits to the model on the XML file
- [ ] Tested my code on my own computer for running the model
- [X] Selected `develop` as a target branch
- [ ] Any removed reactions and metabolites have been moved to the corresponding deprecated identifier lists