### PR TITLE
fix: missing metabolites in rxn01664 and rxn45861

### DIFF
--- a/model.xml
+++ b/model.xml
@@ -21616,6 +21616,23 @@
           </rdf:RDF>
         </annotation>
       </species>
+      <species metaid="meta_M_cpd00352_c0" sboTerm="SBO:0000247" id="M_cpd00352_c0" name="delta1-Piperideine-6-L-carboxylate [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-1" fbc:chemicalFormula="C6H8NO2">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_M_cpd00352_c0">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/bigg.metabolite/thp2c"/>
+                  <rdf:li rdf:resource="https://identifiers.org/biocyc/META:CPD-7682"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.compound/C00450"/>
+                  <rdf:li rdf:resource="https://identifiers.org/metanetx.chemical/MNXM748"/>
+                  <rdf:li rdf:resource="https://identifiers.org/seed.compound/cpd00352"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </species>
     </listOfSpecies>
     <listOfParameters>
       <parameter sboTerm="SBO:0000626" id="cobra_default_lb" value="-1000" constant="true"/>
@@ -65386,6 +65403,7 @@
         <listOfProducts>
           <speciesReference species="M_cpd00001_c0" stoichiometry="1" constant="true"/>
           <speciesReference species="M_cpd00067_c0" stoichiometry="2" constant="true"/>
+          <speciesReference species="M_cpd00352_c0" stoichiometry="1" constant="true"/>
         </listOfProducts>
       </reaction>
       <reaction metaid="meta_R_rxn01685_c0" sboTerm="SBO:0000176" id="R_rxn01685_c0" name="Acetoin:NAD+ oxidoreductase [c0]" reversible="false" fast="false" fbc:lowerFluxBound="cobra_default_ub" fbc:upperFluxBound="cobra_default_ub">
@@ -66601,9 +66619,11 @@
         <listOfReactants>
           <speciesReference species="M_cpd00005_c0" stoichiometry="1" constant="true"/>
           <speciesReference species="M_cpd00067_c0" stoichiometry="3" constant="true"/>
+          <speciesReference species="M_cpd00352_c0" stoichiometry="1" constant="true"/>
         </listOfReactants>
         <listOfProducts>
           <speciesReference species="M_cpd00006_c0" stoichiometry="2" constant="true"/>
+          <speciesReference species="M_cpd00323_c0" stoichiometry="1" constant="true"/>
         </listOfProducts>
         <fbc:geneProductAssociation>
           <fbc:geneProductRef fbc:geneProduct="G_ACZ81_RS14950"/>


### PR DESCRIPTION
#### Main improvements in this PR:

This pull request:

- Adds new metabolite delta1-Piperidine-6-L-carboxylate (`cpd00352_c0`) to the model
- Adds `cpd00352_c0` to `rxn01664_c0` with a coefficient of +1
- Adds `cpd00352_c0` to `rxn45861_c0` with a coefficient of -1
- Adds `cpd00323_c0` to `rxn45861_c0` with a coefficient of +1

I just noticed that I somehow managed to add `rxn01664_c0` and `rxn45861_c0` without also adding `cpd00352_c0` in #15, which left those reactions blatantly unbalanced. I also somehow managed to add pipecolate (`cpd00323_c0`) and its exchange reaction but leave it out of `rxn45861_c0`.

**I hereby confirm that I have:**
- [X] Made my edits to the model on the XML file
- [ ] Tested my code on my own computer for running the model
- [X] Selected `develop` as a target branch
- [ ] Any removed reactions and metabolites have been moved to the corresponding deprecated identifier lists