### PR TITLE
Feat: add and remove reactions recently added to or removed from MIT1002 model

### DIFF
--- a/model.xml
+++ b/model.xml
@@ -3590,25 +3590,6 @@
           </rdf:RDF>
         </annotation>
       </species>
-      <species metaid="meta_M_cpd03708_c0" sboTerm="SBO:0000247" id="M_cpd03708_c0" name="2,4-Dihydroxyhept-2-enedioate [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-2" fbc:chemicalFormula="C7H8O6">
-        <annotation>
-          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
-            <rdf:Description rdf:about="#meta_M_cpd03708_c0">
-              <bqbiol:is>
-                <rdf:Bag>
-                  <rdf:li rdf:resource="https://identifiers.org/seed.compound/cpd03708"/>
-                  <rdf:li rdf:resource="https://identifiers.org/inchi/InChI=1S/C7H10O6/c8-4(1-2-6(10)11)3-5(9)7(12)13/h3-4,8-9H,1-2H2,(H,10,11)(H,12,13)/p-2/b5-3-"/>
-                  <rdf:li rdf:resource="https://identifiers.org/inchikey/APNIDHDQYISZAE-HYXAFXHYSA-L"/>
-                  <rdf:li rdf:resource="https://identifiers.org/bigg.metabolite/24dhhed"/>
-                  <rdf:li rdf:resource="https://identifiers.org/kegg.compound/C06201"/>
-                  <rdf:li rdf:resource="https://identifiers.org/metanetx.chemical/MNXM722757"/>
-                  <rdf:li rdf:resource="https://identifiers.org/biocyc/META:CPD-15125"/>
-                </rdf:Bag>
-              </bqbiol:is>
-            </rdf:Description>
-          </rdf:RDF>
-        </annotation>
-      </species>
       <species metaid="meta_M_cpd00345_c0" sboTerm="SBO:0000247" id="M_cpd00345_c0" name="5-Methyltetrahydrofolate [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-2" fbc:chemicalFormula="C20H23N7O6">
         <annotation>
           <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
@@ -6632,22 +6613,6 @@
           </rdf:RDF>
         </annotation>
       </species>
-      <species metaid="meta_M_cpd12547_c0" sboTerm="SBO:0000247" id="M_cpd12547_c0" name="L-2-Lysophosphatidylethanolamine [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="0" fbc:chemicalFormula="C23H46NO7P">
-        <annotation>
-          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
-            <rdf:Description rdf:about="#meta_M_cpd12547_c0">
-              <bqbiol:is>
-                <rdf:Bag>
-                  <rdf:li rdf:resource="https://identifiers.org/seed.compound/cpd12547"/>
-                  <rdf:li rdf:resource="https://identifiers.org/bigg.metabolite/1agpe180"/>
-                  <rdf:li rdf:resource="https://identifiers.org/kegg.compound/C04438"/>
-                  <rdf:li rdf:resource="https://identifiers.org/metanetx.chemical/MNXM96082"/>
-                </rdf:Bag>
-              </bqbiol:is>
-            </rdf:Description>
-          </rdf:RDF>
-        </annotation>
-      </species>
       <species metaid="meta_M_cpd00071_c0" sboTerm="SBO:0000247" id="M_cpd00071_c0" name="Acetaldehyde [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="0" fbc:chemicalFormula="C2H4O">
         <annotation>
           <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
@@ -6975,34 +6940,6 @@
                   <rdf:li rdf:resource="https://identifiers.org/kegg.compound/C00108"/>
                   <rdf:li rdf:resource="https://identifiers.org/metanetx.chemical/MNXM188"/>
                   <rdf:li rdf:resource="https://identifiers.org/biocyc/META:ANTHRANILATE"/>
-                </rdf:Bag>
-              </bqbiol:is>
-            </rdf:Description>
-          </rdf:RDF>
-        </annotation>
-      </species>
-      <species metaid="meta_M_cpd15746_c0" sboTerm="SBO:0000247" id="M_cpd15746_c0" name="Palmitoyllipoteichoic acid (n=24), linked, unsubstituted [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-24" fbc:chemicalFormula="C119H232O135P24">
-        <annotation>
-          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
-            <rdf:Description rdf:about="#meta_M_cpd15746_c0">
-              <bqbiol:is>
-                <rdf:Bag>
-                  <rdf:li rdf:resource="https://identifiers.org/seed.compound/cpd15746"/>
-                  <rdf:li rdf:resource="https://identifiers.org/metanetx.chemical/MNXM5882"/>
-                </rdf:Bag>
-              </bqbiol:is>
-            </rdf:Description>
-          </rdf:RDF>
-        </annotation>
-      </species>
-      <species metaid="meta_M_cpd15764_c0" sboTerm="SBO:0000247" id="M_cpd15764_c0" name="Palmitoyllipoteichoic acid (n=24), linked, N-acetyl-D-glucosamine [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-24" fbc:chemicalFormula="C311H544N24O255P24">
-        <annotation>
-          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
-            <rdf:Description rdf:about="#meta_M_cpd15764_c0">
-              <bqbiol:is>
-                <rdf:Bag>
-                  <rdf:li rdf:resource="https://identifiers.org/seed.compound/cpd15764"/>
-                  <rdf:li rdf:resource="https://identifiers.org/metanetx.chemical/MNXM8989"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -7931,34 +7868,6 @@
                   <rdf:li rdf:resource="https://identifiers.org/kegg.compound/C00048"/>
                   <rdf:li rdf:resource="https://identifiers.org/metanetx.chemical/MNXM69"/>
                   <rdf:li rdf:resource="https://identifiers.org/biocyc/META:GLYOX"/>
-                </rdf:Bag>
-              </bqbiol:is>
-            </rdf:Description>
-          </rdf:RDF>
-        </annotation>
-      </species>
-      <species metaid="meta_M_cpd15753_c0" sboTerm="SBO:0000247" id="M_cpd15753_c0" name="Anteisopentadecanoyllipoteichoic acid (n=24), linked, unsubstituted [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-24" fbc:chemicalFormula="C117H228O135P24">
-        <annotation>
-          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
-            <rdf:Description rdf:about="#meta_M_cpd15753_c0">
-              <bqbiol:is>
-                <rdf:Bag>
-                  <rdf:li rdf:resource="https://identifiers.org/seed.compound/cpd15753"/>
-                  <rdf:li rdf:resource="https://identifiers.org/metanetx.chemical/MNXM5623"/>
-                </rdf:Bag>
-              </bqbiol:is>
-            </rdf:Description>
-          </rdf:RDF>
-        </annotation>
-      </species>
-      <species metaid="meta_M_cpd15771_c0" sboTerm="SBO:0000247" id="M_cpd15771_c0" name="Anteisopentadecanoyllipoteichoic acid (n=24), linked, N-acetyl-D-glucosamine [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-24" fbc:chemicalFormula="C309H540N24O255P24">
-        <annotation>
-          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
-            <rdf:Description rdf:about="#meta_M_cpd15771_c0">
-              <bqbiol:is>
-                <rdf:Bag>
-                  <rdf:li rdf:resource="https://identifiers.org/seed.compound/cpd15771"/>
-                  <rdf:li rdf:resource="https://identifiers.org/metanetx.chemical/MNXM8312"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -8959,21 +8868,6 @@
           </rdf:RDF>
         </annotation>
       </species>
-      <species metaid="meta_M_cpd14699_c0" sboTerm="SBO:0000247" id="M_cpd14699_c0" name="S-(3-Methylbutanoyl)-dihydrolipoamide-E [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="0" fbc:chemicalFormula="C13H25NO2S2">
-        <annotation>
-          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
-            <rdf:Description rdf:about="#meta_M_cpd14699_c0">
-              <bqbiol:is>
-                <rdf:Bag>
-                  <rdf:li rdf:resource="https://identifiers.org/seed.compound/cpd14699"/>
-                  <rdf:li rdf:resource="https://identifiers.org/kegg.compound/C15975"/>
-                  <rdf:li rdf:resource="https://identifiers.org/metanetx.chemical/MNXM163705"/>
-                </rdf:Bag>
-              </bqbiol:is>
-            </rdf:Description>
-          </rdf:RDF>
-        </annotation>
-      </species>
       <species metaid="meta_M_cpd00050_c0" sboTerm="SBO:0000247" id="M_cpd00050_c0" name="FMN [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-3" fbc:chemicalFormula="C17H18N4O9P">
         <annotation>
           <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
@@ -9951,27 +9845,6 @@
                   <rdf:li rdf:resource="https://identifiers.org/kegg.compound/C00881"/>
                   <rdf:li rdf:resource="https://identifiers.org/metanetx.chemical/MNXM704"/>
                   <rdf:li rdf:resource="https://identifiers.org/biocyc/META:DEOXYCYTIDINE"/>
-                </rdf:Bag>
-              </bqbiol:is>
-            </rdf:Description>
-          </rdf:RDF>
-        </annotation>
-      </species>
-      <species metaid="meta_M_cpd00663_c0" sboTerm="SBO:0000247" id="M_cpd00663_c0" name="Acrylyl-CoA [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-3" fbc:chemicalFormula="C24H35N7O17P3S">
-        <annotation>
-          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
-            <rdf:Description rdf:about="#meta_M_cpd00663_c0">
-              <bqbiol:is>
-                <rdf:Bag>
-                  <rdf:li rdf:resource="https://identifiers.org/seed.compound/cpd00663"/>
-                  <rdf:li rdf:resource="https://identifiers.org/inchi/InChI=1S/C24H38N7O17P3S/c1-4-15(33)52-8-7-26-14(32)5-6-27-22(36)19(35)24(2,3)10-45-51(42,43)48-50(40,41)44-9-13-18(47-49(37,38)39)17(34)23(46-13)31-12-30-16-20(25)28-11-29-21(16)31/h4,11-13,17-19,23,34-35H,1,5-10H2,2-3H3,(H,26,32)(H,27,36)(H,40,41)(H,42,43)(H2,25,28,29)(H2,37,38,39)/p-4/t13-,17-,18-,19+,23-/m1/s1"/>
-                  <rdf:li rdf:resource="https://identifiers.org/inchikey/POODSGUMUCVRTR-IEXPHMLFSA-J"/>
-                  <rdf:li rdf:resource="https://identifiers.org/bigg.metabolite/pp2coa"/>
-                  <rdf:li rdf:resource="https://identifiers.org/bigg.metabolite/prpncoa"/>
-                  <rdf:li rdf:resource="https://identifiers.org/kegg.compound/C00894"/>
-                  <rdf:li rdf:resource="https://identifiers.org/metanetx.chemical/MNXM78210"/>
-                  <rdf:li rdf:resource="https://identifiers.org/metanetx.chemical/MNXM650"/>
-                  <rdf:li rdf:resource="https://identifiers.org/biocyc/META:ACRYLYL-COA"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -11464,25 +11337,6 @@
           </rdf:RDF>
         </annotation>
       </species>
-      <species metaid="meta_M_cpd00041_e0" sboTerm="SBO:0000247" id="M_cpd00041_e0" name="L-Aspartate [e0]" compartment="e0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-1" fbc:chemicalFormula="C4H6NO4">
-        <annotation>
-          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
-            <rdf:Description rdf:about="#meta_M_cpd00041_e0">
-              <bqbiol:is>
-                <rdf:Bag>
-                  <rdf:li rdf:resource="https://identifiers.org/seed.compound/cpd00041"/>
-                  <rdf:li rdf:resource="https://identifiers.org/inchi/InChI=1S/C4H7NO4/c5-2(4(8)9)1-3(6)7/h2H,1,5H2,(H,6,7)(H,8,9)/p-1/t2-/m0/s1"/>
-                  <rdf:li rdf:resource="https://identifiers.org/inchikey/CKLJMWTZIZZHCS-REOHCLBHSA-M"/>
-                  <rdf:li rdf:resource="https://identifiers.org/bigg.metabolite/asp__L"/>
-                  <rdf:li rdf:resource="https://identifiers.org/kegg.compound/C00049"/>
-                  <rdf:li rdf:resource="https://identifiers.org/metanetx.chemical/MNXM42"/>
-                  <rdf:li rdf:resource="https://identifiers.org/biocyc/META:L-ASPARTATE"/>
-                </rdf:Bag>
-              </bqbiol:is>
-            </rdf:Description>
-          </rdf:RDF>
-        </annotation>
-      </species>
       <species metaid="meta_M_cpd08287_c0" sboTerm="SBO:0000247" id="M_cpd08287_c0" name="4--cytidine5-diphospho-2-C-methyl-D-erythritol [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-2" fbc:chemicalFormula="C14H23N3O14P2">
         <annotation>
           <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
@@ -12644,43 +12498,6 @@
           </rdf:RDF>
         </annotation>
       </species>
-      <species metaid="meta_M_cpd15520_c0" sboTerm="SBO:0000247" id="M_cpd15520_c0" name="O16 antigen undecaprenyl diphosphate [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-2" fbc:chemicalFormula="C89H145NO32P2">
-        <annotation>
-          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
-            <rdf:Description rdf:about="#meta_M_cpd15520_c0">
-              <bqbiol:is>
-                <rdf:Bag>
-                  <rdf:li rdf:resource="https://identifiers.org/seed.compound/cpd15520"/>
-                  <rdf:li rdf:resource="https://identifiers.org/inchi/InChI=1S/C89H147NO32P2/c1-52(2)26-16-27-53(3)28-17-29-54(4)30-18-31-55(5)32-19-33-56(6)34-20-35-57(7)36-21-37-58(8)38-22-39-59(9)40-23-41-60(10)42-24-43-61(11)44-25-45-62(12)46-47-112-123(106,107)122-124(108,109)121-85-70(90-64(14)93)82(74(99)69(116-85)51-110-86-78(103)75(100)72(97)67(49-92)115-86)119-89-84(114-65(15)94)83(71(96)63(13)113-89)120-88-79(104)76(101)73(98)68(117-88)50-111-87-80(105)77(102)81(118-87)66(95)48-91/h26,28,30,32,34,36,38,40,42,44,46,63,66-89,91-92,95-105H,16-25,27,29,31,33,35,37,39,41,43,45,47-51H2,1-15H3,(H,90,93)(H,106,107)(H,108,109)/p-2/b53-28+,54-30+,55-32-,56-34-,57-36-,58-38-,59-40-,60-42-,61-44-,62-46+/t63-,66+,67+,68+,69+,70+,71-,72+,73+,74+,75-,76-,77+,78+,79+,80+,81-,82+,83+,84+,85+,86-,87+,88+,89-/m0/s1"/>
-                  <rdf:li rdf:resource="https://identifiers.org/inchikey/NYDKXESIKHJNQU-QMOIQEMSSA-L"/>
-                  <rdf:li rdf:resource="https://identifiers.org/bigg.metabolite/o16aund"/>
-                  <rdf:li rdf:resource="https://identifiers.org/metanetx.chemical/MNXM65211"/>
-                  <rdf:li rdf:resource="https://identifiers.org/biocyc/META:CPD0-2279"/>
-                </rdf:Bag>
-              </bqbiol:is>
-            </rdf:Description>
-          </rdf:RDF>
-        </annotation>
-      </species>
-      <species metaid="meta_M_cpd15516_c0" sboTerm="SBO:0000247" id="M_cpd15516_c0" name="(O16 antigen)x2 undecaprenyl diphosphate [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-2" fbc:chemicalFormula="C123H200N2O57P2">
-        <annotation>
-          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
-            <rdf:Description rdf:about="#meta_M_cpd15516_c0">
-              <bqbiol:is>
-                <rdf:Bag>
-                  <rdf:li rdf:resource="https://identifiers.org/seed.compound/cpd15516"/>
-                  <rdf:li rdf:resource="https://identifiers.org/inchi/InChI=1S/C123H202N2O57P2/c1-59(2)29-19-30-60(3)31-20-32-61(4)33-21-34-62(5)35-22-36-63(6)37-23-38-64(7)39-24-40-65(8)41-25-42-66(9)43-26-44-67(10)45-27-46-68(11)47-28-48-69(12)49-50-163-183(155,156)182-184(157,158)181-115-85(125-73(16)131)108(93(143)83(171-115)58-160-117-100(150)95(145)89(139)79(54-129)169-117)177-123-113(167-75(18)133)110(87(137)71(14)165-123)179-120-102(152)97(147)91(141)81(173-120)56-162-121-111(104(154)106(175-121)77(135)52-127)180-114-84(124-72(15)130)107(92(142)82(170-114)57-159-116-99(149)94(144)88(138)78(53-128)168-116)176-122-112(166-74(17)132)109(86(136)70(13)164-122)178-119-101(151)96(146)90(140)80(172-119)55-161-118-103(153)98(148)105(174-118)76(134)51-126/h29,31,33,35,37,39,41,43,45,47,49,70-71,76-123,126-129,134-154H,19-28,30,32,34,36,38,40,42,44,46,48,50-58H2,1-18H3,(H,124,130)(H,125,131)(H,155,156)(H,157,158)/p-2/b60-31+,61-33+,62-35-,63-37-,64-39-,65-41-,66-43-,67-45-,68-47-,69-49+/t70-,71-,76+,77+,78+,79+,80+,81+,82+,83+,84+,85+,86-,87-,88+,89+,90+,91+,92+,93+,94-,95-,96-,97-,98+,99+,100+,101+,102+,103+,104-,105-,106-,107+,108+,109+,110+,111+,112+,113+,114+,115+,116-,117-,118+,119+,120+,121+,122-,123-/m0/s1"/>
-                  <rdf:li rdf:resource="https://identifiers.org/inchikey/JLHGQTKMJCQGJD-YBCKUOELSA-L"/>
-                  <rdf:li rdf:resource="https://identifiers.org/bigg.metabolite/o16a2und"/>
-                  <rdf:li rdf:resource="https://identifiers.org/metanetx.chemical/MNXM31520"/>
-                  <rdf:li rdf:resource="https://identifiers.org/metanetx.chemical/MNXM174111"/>
-                  <rdf:li rdf:resource="https://identifiers.org/biocyc/META:CPD0-2268"/>
-                </rdf:Bag>
-              </bqbiol:is>
-            </rdf:Description>
-          </rdf:RDF>
-        </annotation>
-      </species>
       <species metaid="meta_M_cpd00198_c0" sboTerm="SBO:0000247" id="M_cpd00198_c0" name="D-Xylulose5-phosphate [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-2" fbc:chemicalFormula="C5H9O8P">
         <annotation>
           <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
@@ -13135,21 +12952,6 @@
           </rdf:RDF>
         </annotation>
       </species>
-      <species metaid="meta_M_cpd14703_c0" sboTerm="SBO:0000247" id="M_cpd14703_c0" name="S-(2-Methylbutanoyl)-dihydrolipoamide-E [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="0" fbc:chemicalFormula="C13H25NO2S2">
-        <annotation>
-          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
-            <rdf:Description rdf:about="#meta_M_cpd14703_c0">
-              <bqbiol:is>
-                <rdf:Bag>
-                  <rdf:li rdf:resource="https://identifiers.org/seed.compound/cpd14703"/>
-                  <rdf:li rdf:resource="https://identifiers.org/kegg.compound/C15979"/>
-                  <rdf:li rdf:resource="https://identifiers.org/metanetx.chemical/MNXM5588"/>
-                </rdf:Bag>
-              </bqbiol:is>
-            </rdf:Description>
-          </rdf:RDF>
-        </annotation>
-      </species>
       <species metaid="meta_M_cpd00890_c0" sboTerm="SBO:0000247" id="M_cpd00890_c0" name="UDP-N-acetylmuramoyl-L-alanine [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-3" fbc:chemicalFormula="C23H33N4O20P2">
         <annotation>
           <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
@@ -13586,44 +13388,6 @@
                   <rdf:li rdf:resource="https://identifiers.org/kegg.compound/C14145"/>
                   <rdf:li rdf:resource="https://identifiers.org/metanetx.chemical/MNXM2784"/>
                   <rdf:li rdf:resource="https://identifiers.org/biocyc/META:3-HYDROXYADIPYL-COA"/>
-                </rdf:Bag>
-              </bqbiol:is>
-            </rdf:Description>
-          </rdf:RDF>
-        </annotation>
-      </species>
-      <species metaid="meta_M_cpd11574_e0" sboTerm="SBO:0000247" id="M_cpd11574_e0" name="Molybdate [e0]" compartment="e0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="0" fbc:chemicalFormula="H2MoO4">
-        <annotation>
-          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
-            <rdf:Description rdf:about="#meta_M_cpd11574_e0">
-              <bqbiol:is>
-                <rdf:Bag>
-                  <rdf:li rdf:resource="https://identifiers.org/seed.compound/cpd11574"/>
-                  <rdf:li rdf:resource="https://identifiers.org/inchi/InChI=1S/Mo.4O/q;;;2*-1"/>
-                  <rdf:li rdf:resource="https://identifiers.org/inchikey/MEFBJEMVZONFCJ-UHFFFAOYSA-N"/>
-                  <rdf:li rdf:resource="https://identifiers.org/bigg.metabolite/mobd"/>
-                  <rdf:li rdf:resource="https://identifiers.org/kegg.compound/C06232"/>
-                  <rdf:li rdf:resource="https://identifiers.org/metanetx.chemical/MNXM1026"/>
-                  <rdf:li rdf:resource="https://identifiers.org/biocyc/META:CPD-3"/>
-                </rdf:Bag>
-              </bqbiol:is>
-            </rdf:Description>
-          </rdf:RDF>
-        </annotation>
-      </species>
-      <species metaid="meta_M_cpd11574_c0" sboTerm="SBO:0000247" id="M_cpd11574_c0" name="Molybdate [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="0" fbc:chemicalFormula="H2MoO4">
-        <annotation>
-          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
-            <rdf:Description rdf:about="#meta_M_cpd11574_c0">
-              <bqbiol:is>
-                <rdf:Bag>
-                  <rdf:li rdf:resource="https://identifiers.org/seed.compound/cpd11574"/>
-                  <rdf:li rdf:resource="https://identifiers.org/inchi/InChI=1S/Mo.4O/q;;;2*-1"/>
-                  <rdf:li rdf:resource="https://identifiers.org/inchikey/MEFBJEMVZONFCJ-UHFFFAOYSA-N"/>
-                  <rdf:li rdf:resource="https://identifiers.org/bigg.metabolite/mobd"/>
-                  <rdf:li rdf:resource="https://identifiers.org/kegg.compound/C06232"/>
-                  <rdf:li rdf:resource="https://identifiers.org/metanetx.chemical/MNXM1026"/>
-                  <rdf:li rdf:resource="https://identifiers.org/biocyc/META:CPD-3"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -14509,34 +14273,6 @@
                   <rdf:li rdf:resource="https://identifiers.org/kegg.compound/C00164"/>
                   <rdf:li rdf:resource="https://identifiers.org/metanetx.chemical/MNXM154"/>
                   <rdf:li rdf:resource="https://identifiers.org/biocyc/META:3-KETOBUTYRATE"/>
-                </rdf:Bag>
-              </bqbiol:is>
-            </rdf:Description>
-          </rdf:RDF>
-        </annotation>
-      </species>
-      <species metaid="meta_M_cpd15752_c0" sboTerm="SBO:0000247" id="M_cpd15752_c0" name="Isopentadecanoyllipoteichoic acid (n=24), linked, unsubstituted [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-24" fbc:chemicalFormula="C117H228O135P24">
-        <annotation>
-          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
-            <rdf:Description rdf:about="#meta_M_cpd15752_c0">
-              <bqbiol:is>
-                <rdf:Bag>
-                  <rdf:li rdf:resource="https://identifiers.org/seed.compound/cpd15752"/>
-                  <rdf:li rdf:resource="https://identifiers.org/metanetx.chemical/MNXM5794"/>
-                </rdf:Bag>
-              </bqbiol:is>
-            </rdf:Description>
-          </rdf:RDF>
-        </annotation>
-      </species>
-      <species metaid="meta_M_cpd15770_c0" sboTerm="SBO:0000247" id="M_cpd15770_c0" name="Isopentadecanoyllipoteichoic acid (n=24), linked, N-acetyl-D-glucosamine [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-24" fbc:chemicalFormula="C309H540N24O255P24">
-        <annotation>
-          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
-            <rdf:Description rdf:about="#meta_M_cpd15770_c0">
-              <bqbiol:is>
-                <rdf:Bag>
-                  <rdf:li rdf:resource="https://identifiers.org/seed.compound/cpd15770"/>
-                  <rdf:li rdf:resource="https://identifiers.org/metanetx.chemical/MNXM8772"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -15779,43 +15515,6 @@
           </rdf:RDF>
         </annotation>
       </species>
-      <species metaid="meta_M_cpd00965_c0" sboTerm="SBO:0000247" id="M_cpd00965_c0" name="Hg [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="2" fbc:chemicalFormula="H2Hg">
-        <annotation>
-          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
-            <rdf:Description rdf:about="#meta_M_cpd00965_c0">
-              <bqbiol:is>
-                <rdf:Bag>
-                  <rdf:li rdf:resource="https://identifiers.org/seed.compound/cpd00965"/>
-                  <rdf:li rdf:resource="https://identifiers.org/inchi/InChI=1S/Hg"/>
-                  <rdf:li rdf:resource="https://identifiers.org/inchikey/QSHDDOUJBYECFT-UHFFFAOYSA-N"/>
-                  <rdf:li rdf:resource="https://identifiers.org/kegg.compound/C01319"/>
-                  <rdf:li rdf:resource="https://identifiers.org/metanetx.chemical/MNXM4041"/>
-                  <rdf:li rdf:resource="https://identifiers.org/biocyc/META:HG0"/>
-                </rdf:Bag>
-              </bqbiol:is>
-            </rdf:Description>
-          </rdf:RDF>
-        </annotation>
-      </species>
-      <species metaid="meta_M_cpd00531_c0" sboTerm="SBO:0000247" id="M_cpd00531_c0" name="Hg2+ [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="2" fbc:chemicalFormula="Hg">
-        <annotation>
-          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
-            <rdf:Description rdf:about="#meta_M_cpd00531_c0">
-              <bqbiol:is>
-                <rdf:Bag>
-                  <rdf:li rdf:resource="https://identifiers.org/seed.compound/cpd00531"/>
-                  <rdf:li rdf:resource="https://identifiers.org/inchi/InChI=1S/Hg/q+2"/>
-                  <rdf:li rdf:resource="https://identifiers.org/inchikey/BQPIGGFYSBELGY-UHFFFAOYSA-N"/>
-                  <rdf:li rdf:resource="https://identifiers.org/bigg.metabolite/hg2"/>
-                  <rdf:li rdf:resource="https://identifiers.org/kegg.compound/C00703"/>
-                  <rdf:li rdf:resource="https://identifiers.org/metanetx.chemical/MNXM1562"/>
-                  <rdf:li rdf:resource="https://identifiers.org/biocyc/META:HG+2"/>
-                </rdf:Bag>
-              </bqbiol:is>
-            </rdf:Description>
-          </rdf:RDF>
-        </annotation>
-      </species>
       <species metaid="meta_M_cpd15558_c0" sboTerm="SBO:0000247" id="M_cpd15558_c0" name="phosphatidylserine dioctadec-11-enoyl [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-2" fbc:chemicalFormula="C42H76NO10P">
         <annotation>
           <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
@@ -15954,42 +15653,6 @@
                   <rdf:li rdf:resource="https://identifiers.org/kegg.compound/C06025"/>
                   <rdf:li rdf:resource="https://identifiers.org/metanetx.chemical/MNXM824"/>
                   <rdf:li rdf:resource="https://identifiers.org/biocyc/META:KDO2-LIPID-IVA"/>
-                </rdf:Bag>
-              </bqbiol:is>
-            </rdf:Description>
-          </rdf:RDF>
-        </annotation>
-      </species>
-      <species metaid="meta_M_cpd01012_c0" sboTerm="SBO:0000247" id="M_cpd01012_c0" name="Cd2+ [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="2" fbc:chemicalFormula="Cd">
-        <annotation>
-          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
-            <rdf:Description rdf:about="#meta_M_cpd01012_c0">
-              <bqbiol:is>
-                <rdf:Bag>
-                  <rdf:li rdf:resource="https://identifiers.org/seed.compound/cpd01012"/>
-                  <rdf:li rdf:resource="https://identifiers.org/inchi/InChI=1S/Cd/q+2"/>
-                  <rdf:li rdf:resource="https://identifiers.org/inchikey/WLZRMCYVCSSEQC-UHFFFAOYSA-N"/>
-                  <rdf:li rdf:resource="https://identifiers.org/bigg.metabolite/cd2"/>
-                  <rdf:li rdf:resource="https://identifiers.org/metanetx.chemical/MNXM4505"/>
-                  <rdf:li rdf:resource="https://identifiers.org/biocyc/META:CD+2"/>
-                </rdf:Bag>
-              </bqbiol:is>
-            </rdf:Description>
-          </rdf:RDF>
-        </annotation>
-      </species>
-      <species metaid="meta_M_cpd01012_e0" sboTerm="SBO:0000247" id="M_cpd01012_e0" name="Cd2+ [e0]" compartment="e0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="2" fbc:chemicalFormula="Cd">
-        <annotation>
-          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
-            <rdf:Description rdf:about="#meta_M_cpd01012_e0">
-              <bqbiol:is>
-                <rdf:Bag>
-                  <rdf:li rdf:resource="https://identifiers.org/seed.compound/cpd01012"/>
-                  <rdf:li rdf:resource="https://identifiers.org/inchi/InChI=1S/Cd/q+2"/>
-                  <rdf:li rdf:resource="https://identifiers.org/inchikey/WLZRMCYVCSSEQC-UHFFFAOYSA-N"/>
-                  <rdf:li rdf:resource="https://identifiers.org/bigg.metabolite/cd2"/>
-                  <rdf:li rdf:resource="https://identifiers.org/metanetx.chemical/MNXM4505"/>
-                  <rdf:li rdf:resource="https://identifiers.org/biocyc/META:CD+2"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -16648,34 +16311,6 @@
           </rdf:RDF>
         </annotation>
       </species>
-      <species metaid="meta_M_cpd15748_c0" sboTerm="SBO:0000247" id="M_cpd15748_c0" name="Stearoyllipoteichoic acid (n=24), linked, unsubstituted [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-24" fbc:chemicalFormula="C123H240O135P24">
-        <annotation>
-          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
-            <rdf:Description rdf:about="#meta_M_cpd15748_c0">
-              <bqbiol:is>
-                <rdf:Bag>
-                  <rdf:li rdf:resource="https://identifiers.org/seed.compound/cpd15748"/>
-                  <rdf:li rdf:resource="https://identifiers.org/metanetx.chemical/MNXM5933"/>
-                </rdf:Bag>
-              </bqbiol:is>
-            </rdf:Description>
-          </rdf:RDF>
-        </annotation>
-      </species>
-      <species metaid="meta_M_cpd15766_c0" sboTerm="SBO:0000247" id="M_cpd15766_c0" name="Stearoyllipoteichoic acid (n=24), linked, N-acetyl-D-glucosamine [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-24" fbc:chemicalFormula="C315H552N24O255P24">
-        <annotation>
-          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
-            <rdf:Description rdf:about="#meta_M_cpd15766_c0">
-              <bqbiol:is>
-                <rdf:Bag>
-                  <rdf:li rdf:resource="https://identifiers.org/seed.compound/cpd15766"/>
-                  <rdf:li rdf:resource="https://identifiers.org/metanetx.chemical/MNXM9122"/>
-                </rdf:Bag>
-              </bqbiol:is>
-            </rdf:Description>
-          </rdf:RDF>
-        </annotation>
-      </species>
       <species metaid="meta_M_cpd11436_c0" sboTerm="SBO:0000247" id="M_cpd11436_c0" name="fa3 [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-1" fbc:chemicalFormula="C15H29O2">
         <annotation>
           <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
@@ -16982,34 +16617,6 @@
                   <rdf:li rdf:resource="https://identifiers.org/kegg.compound/C00257"/>
                   <rdf:li rdf:resource="https://identifiers.org/metanetx.chemical/MNXM341"/>
                   <rdf:li rdf:resource="https://identifiers.org/biocyc/META:GLUCONATE"/>
-                </rdf:Bag>
-              </bqbiol:is>
-            </rdf:Description>
-          </rdf:RDF>
-        </annotation>
-      </species>
-      <species metaid="meta_M_cpd15754_c0" sboTerm="SBO:0000247" id="M_cpd15754_c0" name="Isohexadecanoyllipoteichoic acid (n=24), linked, unsubstituted [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-24" fbc:chemicalFormula="C119H232O135P24">
-        <annotation>
-          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
-            <rdf:Description rdf:about="#meta_M_cpd15754_c0">
-              <bqbiol:is>
-                <rdf:Bag>
-                  <rdf:li rdf:resource="https://identifiers.org/seed.compound/cpd15754"/>
-                  <rdf:li rdf:resource="https://identifiers.org/metanetx.chemical/MNXM5793"/>
-                </rdf:Bag>
-              </bqbiol:is>
-            </rdf:Description>
-          </rdf:RDF>
-        </annotation>
-      </species>
-      <species metaid="meta_M_cpd15772_c0" sboTerm="SBO:0000247" id="M_cpd15772_c0" name="Isohexadecanoyllipoteichoic acid (n=24), linked, N-acetyl-D-glucosamine [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-24" fbc:chemicalFormula="C311H544N24O255P24">
-        <annotation>
-          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
-            <rdf:Description rdf:about="#meta_M_cpd15772_c0">
-              <bqbiol:is>
-                <rdf:Bag>
-                  <rdf:li rdf:resource="https://identifiers.org/seed.compound/cpd15772"/>
-                  <rdf:li rdf:resource="https://identifiers.org/metanetx.chemical/MNXM8765"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -18144,44 +17751,6 @@
           </rdf:RDF>
         </annotation>
       </species>
-      <species metaid="meta_M_cpd01747_c0" sboTerm="SBO:0000247" id="M_cpd01747_c0" name="Indole-3-acetamide [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="0" fbc:chemicalFormula="C10H10N2O">
-        <annotation>
-          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
-            <rdf:Description rdf:about="#meta_M_cpd01747_c0">
-              <bqbiol:is>
-                <rdf:Bag>
-                  <rdf:li rdf:resource="https://identifiers.org/seed.compound/cpd01747"/>
-                  <rdf:li rdf:resource="https://identifiers.org/inchi/InChI=1S/C10H10N2O/c11-10(13)5-7-6-12-9-4-2-1-3-8(7)9/h1-4,6,12H,5H2,(H2,11,13)"/>
-                  <rdf:li rdf:resource="https://identifiers.org/inchikey/ZOAMBXDOGPRZLP-UHFFFAOYSA-N"/>
-                  <rdf:li rdf:resource="https://identifiers.org/bigg.metabolite/iad"/>
-                  <rdf:li rdf:resource="https://identifiers.org/kegg.compound/C02693"/>
-                  <rdf:li rdf:resource="https://identifiers.org/metanetx.chemical/MNXM2239"/>
-                  <rdf:li rdf:resource="https://identifiers.org/biocyc/META:CPD-237"/>
-                </rdf:Bag>
-              </bqbiol:is>
-            </rdf:Description>
-          </rdf:RDF>
-        </annotation>
-      </species>
-      <species metaid="meta_M_cpd00703_c0" sboTerm="SBO:0000247" id="M_cpd00703_c0" name="Indoleacetate [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-1" fbc:chemicalFormula="C10H8NO2">
-        <annotation>
-          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
-            <rdf:Description rdf:about="#meta_M_cpd00703_c0">
-              <bqbiol:is>
-                <rdf:Bag>
-                  <rdf:li rdf:resource="https://identifiers.org/seed.compound/cpd00703"/>
-                  <rdf:li rdf:resource="https://identifiers.org/inchi/InChI=1S/C10H9NO2/c12-10(13)5-7-6-11-9-4-2-1-3-8(7)9/h1-4,6,11H,5H2,(H,12,13)/p-1"/>
-                  <rdf:li rdf:resource="https://identifiers.org/inchikey/SEOVTRFCIGRIMH-UHFFFAOYSA-M"/>
-                  <rdf:li rdf:resource="https://identifiers.org/bigg.metabolite/ind3ac"/>
-                  <rdf:li rdf:resource="https://identifiers.org/kegg.compound/C00954"/>
-                  <rdf:li rdf:resource="https://identifiers.org/metanetx.chemical/MNXM383"/>
-                  <rdf:li rdf:resource="https://identifiers.org/biocyc/META:INDOLE_ACETATE_AUXIN"/>
-                </rdf:Bag>
-              </bqbiol:is>
-            </rdf:Description>
-          </rdf:RDF>
-        </annotation>
-      </species>
       <species metaid="meta_M_cpd03195_c0" sboTerm="SBO:0000247" id="M_cpd03195_c0" name="Melibiitol [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="0" fbc:chemicalFormula="C12H24O11">
         <annotation>
           <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
@@ -18266,34 +17835,6 @@
                   <rdf:li rdf:resource="https://identifiers.org/seed.compound/cpd15541"/>
                   <rdf:li rdf:resource="https://identifiers.org/bigg.metabolite/pg181"/>
                   <rdf:li rdf:resource="https://identifiers.org/metanetx.chemical/MNXM162552"/>
-                </rdf:Bag>
-              </bqbiol:is>
-            </rdf:Description>
-          </rdf:RDF>
-        </annotation>
-      </species>
-      <species metaid="meta_M_cpd15747_c0" sboTerm="SBO:0000247" id="M_cpd15747_c0" name="Myristoyllipoteichoic acid (n=24), linked, unsubstituted [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-24" fbc:chemicalFormula="C115H224O135P24">
-        <annotation>
-          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
-            <rdf:Description rdf:about="#meta_M_cpd15747_c0">
-              <bqbiol:is>
-                <rdf:Bag>
-                  <rdf:li rdf:resource="https://identifiers.org/seed.compound/cpd15747"/>
-                  <rdf:li rdf:resource="https://identifiers.org/metanetx.chemical/MNXM5827"/>
-                </rdf:Bag>
-              </bqbiol:is>
-            </rdf:Description>
-          </rdf:RDF>
-        </annotation>
-      </species>
-      <species metaid="meta_M_cpd15765_c0" sboTerm="SBO:0000247" id="M_cpd15765_c0" name="Myristoyllipoteichoic acid (n=24), linked, N-acetyl-D-glucosamine [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-24" fbc:chemicalFormula="C307H536N24O255P24">
-        <annotation>
-          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
-            <rdf:Description rdf:about="#meta_M_cpd15765_c0">
-              <bqbiol:is>
-                <rdf:Bag>
-                  <rdf:li rdf:resource="https://identifiers.org/seed.compound/cpd15765"/>
-                  <rdf:li rdf:resource="https://identifiers.org/metanetx.chemical/MNXM8894"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -18586,34 +18127,6 @@
           </rdf:RDF>
         </annotation>
       </species>
-      <species metaid="meta_M_cpd15751_c0" sboTerm="SBO:0000247" id="M_cpd15751_c0" name="Isotetradecanoyllipoteichoic acid (n=24), linked, unsubstituted [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-24" fbc:chemicalFormula="C115H224O135P24">
-        <annotation>
-          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
-            <rdf:Description rdf:about="#meta_M_cpd15751_c0">
-              <bqbiol:is>
-                <rdf:Bag>
-                  <rdf:li rdf:resource="https://identifiers.org/seed.compound/cpd15751"/>
-                  <rdf:li rdf:resource="https://identifiers.org/metanetx.chemical/MNXM5797"/>
-                </rdf:Bag>
-              </bqbiol:is>
-            </rdf:Description>
-          </rdf:RDF>
-        </annotation>
-      </species>
-      <species metaid="meta_M_cpd15769_c0" sboTerm="SBO:0000247" id="M_cpd15769_c0" name="Isotetradecanoyllipoteichoic acid (n=24), linked, N-acetyl-D-glucosamine [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-24" fbc:chemicalFormula="C307H536N24O255P24">
-        <annotation>
-          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
-            <rdf:Description rdf:about="#meta_M_cpd15769_c0">
-              <bqbiol:is>
-                <rdf:Bag>
-                  <rdf:li rdf:resource="https://identifiers.org/seed.compound/cpd15769"/>
-                  <rdf:li rdf:resource="https://identifiers.org/metanetx.chemical/MNXM8777"/>
-                </rdf:Bag>
-              </bqbiol:is>
-            </rdf:Description>
-          </rdf:RDF>
-        </annotation>
-      </species>
       <species metaid="meta_M_cpd15347_c0" sboTerm="SBO:0000247" id="M_cpd15347_c0" name="2-(9Z)-hexadecenoyl-sn-glycero-3-phosphoglycerol [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-1" fbc:chemicalFormula="C22H42O9P">
         <annotation>
           <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
@@ -18881,41 +18394,6 @@
           </rdf:RDF>
         </annotation>
       </species>
-      <species metaid="meta_M_cpd36025_c0" sboTerm="SBO:0000247" id="M_cpd36025_c0" name="(8S)-3&apos;,8-cyclo-7,8-dihydroguanosine 5&apos;-triphosphate [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-4" fbc:chemicalFormula="C10H12N5O14P3">
-        <annotation>
-          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
-            <rdf:Description rdf:about="#meta_M_cpd36025_c0">
-              <bqbiol:is>
-                <rdf:Bag>
-                  <rdf:li rdf:resource="https://identifiers.org/seed.compound/cpd36025"/>
-                  <rdf:li rdf:resource="https://identifiers.org/inchi/InChI=1S/C10H16N5O14P3/c11-9-13-5-3(6(17)14-9)12-8-10(18)2(27-7(4(10)16)15(5)8)1-26-31(22,23)29-32(24,25)28-30(19,20)21/h2,4,7-8,12,16,18H,1H2,(H,22,23)(H,24,25)(H2,19,20,21)(H3,11,13,14,17)/p-4/t2?,4?,7?,8-,10?/m0/s1"/>
-                  <rdf:li rdf:resource="https://identifiers.org/inchikey/HRBCPXBJAWPPIC-GZBYGQQWSA-J"/>
-                  <rdf:li rdf:resource="https://identifiers.org/metanetx.chemical/MNXM162448"/>
-                  <rdf:li rdf:resource="https://identifiers.org/biocyc/META:CPD-19179"/>
-                </rdf:Bag>
-              </bqbiol:is>
-            </rdf:Description>
-          </rdf:RDF>
-        </annotation>
-      </species>
-      <species metaid="meta_M_cpd19505_c0" sboTerm="SBO:0000247" id="M_cpd19505_c0" name="Precursor Z [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-1" fbc:chemicalFormula="C10H13N5O8P">
-        <annotation>
-          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
-            <rdf:Description rdf:about="#meta_M_cpd19505_c0">
-              <bqbiol:is>
-                <rdf:Bag>
-                  <rdf:li rdf:resource="https://identifiers.org/seed.compound/cpd19505"/>
-                  <rdf:li rdf:resource="https://identifiers.org/inchi/InChI=1S/C10H14N5O8P/c11-9-14-6-3(7(16)15-9)12-4-8(13-6)22-2-1-21-24(19,20)23-5(2)10(4,17)18/h2,4-5,8,12,17-18H,1H2,(H,19,20)(H4,11,13,14,15,16)/p-1/t2-,4-,5+,8-/m1/s1"/>
-                  <rdf:li rdf:resource="https://identifiers.org/inchikey/CZAKJJUNKNPTTO-AJFJRRQVSA-M"/>
-                  <rdf:li rdf:resource="https://identifiers.org/kegg.compound/C18239"/>
-                  <rdf:li rdf:resource="https://identifiers.org/metanetx.chemical/MNXM1385"/>
-                  <rdf:li rdf:resource="https://identifiers.org/biocyc/META:PRECURSOR-Z"/>
-                </rdf:Bag>
-              </bqbiol:is>
-            </rdf:Description>
-          </rdf:RDF>
-        </annotation>
-      </species>
       <species metaid="meta_M_cpd14545_c0" sboTerm="SBO:0000247" id="M_cpd14545_c0" name="Iminoglycine [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-1" fbc:chemicalFormula="C2H2NO2">
         <annotation>
           <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
@@ -18953,26 +18431,6 @@
           </rdf:RDF>
         </annotation>
       </species>
-      <species metaid="meta_M_cpd28253_c0" sboTerm="SBO:0000247" id="M_cpd28253_c0" name="Thi-S [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="0" fbc:chemicalFormula="C4H7N2O3R">
-        <annotation>
-          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
-            <rdf:Description rdf:about="#meta_M_cpd28253_c0">
-              <bqbiol:is>
-                <rdf:Bag>
-                  <rdf:li rdf:resource="https://identifiers.org/seed.compound/cpd28253"/>
-                  <rdf:li rdf:resource="https://identifiers.org/metanetx.chemical/MNXM147972"/>
-                  <rdf:li rdf:resource="https://identifiers.org/metanetx.chemical/MNXM13028"/>
-                  <rdf:li rdf:resource="https://identifiers.org/biocyc/META:Thi-S"/>
-                  <rdf:li rdf:resource="https://identifiers.org/biocyc/META:MPT-Synthase-small-subunits"/>
-                  <rdf:li rdf:resource="https://identifiers.org/biocyc/META:CysO-Sulfur-carrier-proteins"/>
-                  <rdf:li rdf:resource="https://identifiers.org/biocyc/META:URM1"/>
-                  <rdf:li rdf:resource="https://identifiers.org/biocyc/META:TtuB-Sulfur-carrier-proteins"/>
-                </rdf:Bag>
-              </bqbiol:is>
-            </rdf:Description>
-          </rdf:RDF>
-        </annotation>
-      </species>
       <species metaid="meta_M_cpd12489_c0" sboTerm="SBO:0000247" id="M_cpd12489_c0" name="(3Z)-Decenoyl-ACP [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-2" fbc:chemicalFormula="C21H37N2O8PRS">
         <annotation>
           <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
@@ -18982,43 +18440,6 @@
                   <rdf:li rdf:resource="https://identifiers.org/seed.compound/cpd12489"/>
                   <rdf:li rdf:resource="https://identifiers.org/kegg.compound/C04180"/>
                   <rdf:li rdf:resource="https://identifiers.org/metanetx.chemical/MNXM5086"/>
-                </rdf:Bag>
-              </bqbiol:is>
-            </rdf:Description>
-          </rdf:RDF>
-        </annotation>
-      </species>
-      <species metaid="meta_M_cpd19503_c0" sboTerm="SBO:0000247" id="M_cpd19503_c0" name="Molybdoenzyme molybdenum cofactor [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-2" fbc:chemicalFormula="C10H10MoN5O8PS2">
-        <annotation>
-          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
-            <rdf:Description rdf:about="#meta_M_cpd19503_c0">
-              <bqbiol:is>
-                <rdf:Bag>
-                  <rdf:li rdf:resource="https://identifiers.org/seed.compound/cpd19503"/>
-                  <rdf:li rdf:resource="https://identifiers.org/inchi/InChI=1S/C10H14N5O6PS2.Mo.2O/c11-10-14-7-4(8(16)15-10)12-3-6(24)5(23)2(21-9(3)13-7)1-20-22(17,18)19;;;/h2-3,9,12,23-24H,1H2,(H2,17,18,19)(H4,11,13,14,15,16);;;/q;+2;;/p-4/t2-,3+,9-;;;/m1.../s1"/>
-                  <rdf:li rdf:resource="https://identifiers.org/inchikey/HDAJUGGARUFROU-JSUDGWJLSA-J"/>
-                  <rdf:li rdf:resource="https://identifiers.org/kegg.compound/C18237"/>
-                  <rdf:li rdf:resource="https://identifiers.org/metanetx.chemical/MNXM2838"/>
-                  <rdf:li rdf:resource="https://identifiers.org/biocyc/META:CPD-8123"/>
-                </rdf:Bag>
-              </bqbiol:is>
-            </rdf:Description>
-          </rdf:RDF>
-        </annotation>
-      </species>
-      <species metaid="meta_M_cpd21288_c0" sboTerm="SBO:0000247" id="M_cpd21288_c0" name="Mast cell degranulating peptide [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-2" fbc:chemicalFormula="C19H22MoN8O15P2S2">
-        <annotation>
-          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
-            <rdf:Description rdf:about="#meta_M_cpd21288_c0">
-              <bqbiol:is>
-                <rdf:Bag>
-                  <rdf:li rdf:resource="https://identifiers.org/seed.compound/cpd21288"/>
-                  <rdf:li rdf:resource="https://identifiers.org/inchi/InChI=1S/C19H26N8O13P2S2.Mo.2O/c20-7-1-2-27(19(31)22-7)17-11(29)10(28)5(39-17)3-36-41(32,33)40-42(34,35)37-4-6-12(43)13(44)8-16(38-6)24-14-9(23-8)15(30)26-18(21)25-14;;;/h1-2,5-6,8,10-11,16-17,23,28-29,43-44H,3-4H2,(H,32,33)(H,34,35)(H2,20,22,31)(H4,21,24,25,26,30);;;/q;+2;;/p-4/t5-,6-,8+,10-,11-,16-,17-;;;/m1.../s1"/>
-                  <rdf:li rdf:resource="https://identifiers.org/inchikey/KGCKMLSJAXDKBP-RRNIHQQDSA-J"/>
-                  <rdf:li rdf:resource="https://identifiers.org/kegg.compound/C20049"/>
-                  <rdf:li rdf:resource="https://identifiers.org/metanetx.chemical/MNXM61195"/>
-                  <rdf:li rdf:resource="https://identifiers.org/metanetx.chemical/MNXM8479"/>
-                  <rdf:li rdf:resource="https://identifiers.org/biocyc/META:CPD0-1882"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -19145,24 +18566,6 @@
           </rdf:RDF>
         </annotation>
       </species>
-      <species metaid="meta_M_cpd11209_c0" sboTerm="SBO:0000247" id="M_cpd11209_c0" name="N-Acetyl-L-citrulline [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-1" fbc:chemicalFormula="C8H14N3O4">
-        <annotation>
-          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
-            <rdf:Description rdf:about="#meta_M_cpd11209_c0">
-              <bqbiol:is>
-                <rdf:Bag>
-                  <rdf:li rdf:resource="https://identifiers.org/seed.compound/cpd11209"/>
-                  <rdf:li rdf:resource="https://identifiers.org/inchi/InChI=1S/C8H15N3O4/c1-5(12)11-6(7(13)14)3-2-4-10-8(9)15/h6H,2-4H2,1H3,(H,11,12)(H,13,14)(H3,9,10,15)/p-1/t6-/m0/s1"/>
-                  <rdf:li rdf:resource="https://identifiers.org/inchikey/WMQMIOYQXNRROC-LURJTMIESA-M"/>
-                  <rdf:li rdf:resource="https://identifiers.org/kegg.compound/C15532"/>
-                  <rdf:li rdf:resource="https://identifiers.org/metanetx.chemical/MNXM3314"/>
-                  <rdf:li rdf:resource="https://identifiers.org/biocyc/META:CPD-7224"/>
-                </rdf:Bag>
-              </bqbiol:is>
-            </rdf:Description>
-          </rdf:RDF>
-        </annotation>
-      </species>
       <species metaid="meta_M_cpd19030_c0" sboTerm="SBO:0000247" id="M_cpd19030_c0" name="(R)-2,3-Dihydroxy-3-methylbutanoate [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-1" fbc:chemicalFormula="C5H9O4">
         <annotation>
           <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
@@ -19195,24 +18598,6 @@
                   <rdf:li rdf:resource="https://identifiers.org/kegg.compound/C15672"/>
                   <rdf:li rdf:resource="https://identifiers.org/metanetx.chemical/MNXM1278"/>
                   <rdf:li rdf:resource="https://identifiers.org/biocyc/META:HEME_O"/>
-                </rdf:Bag>
-              </bqbiol:is>
-            </rdf:Description>
-          </rdf:RDF>
-        </annotation>
-      </species>
-      <species metaid="meta_M_cpd11312_c0" sboTerm="SBO:0000247" id="M_cpd11312_c0" name="hemeA [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-2" fbc:chemicalFormula="C49H54FeN4O6">
-        <annotation>
-          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
-            <rdf:Description rdf:about="#meta_M_cpd11312_c0">
-              <bqbiol:is>
-                <rdf:Bag>
-                  <rdf:li rdf:resource="https://identifiers.org/seed.compound/cpd11312"/>
-                  <rdf:li rdf:resource="https://identifiers.org/inchi/InChI=1S/C49H58N4O6.Fe/c1-9-34-31(6)39-25-45-49(46(55)18-12-17-30(5)16-11-15-29(4)14-10-13-28(2)3)33(8)40(52-45)24-44-37(27-54)36(20-22-48(58)59)43(53-44)26-42-35(19-21-47(56)57)32(7)38(51-42)23-41(34)50-39;/h9,13,15,17,23-27,46,55H,1,10-12,14,16,18-22H2,2-8H3,(H4,50,51,52,53,54,56,57,58,59);/q;+2/p-4/b29-15+,30-17+,38-23-,39-25-,40-24-,41-23-,42-26-,43-26-,44-24-,45-25-;"/>
-                  <rdf:li rdf:resource="https://identifiers.org/inchikey/ZGGYGTCPXNDTRV-ONCSLILDSA-J"/>
-                  <rdf:li rdf:resource="https://identifiers.org/bigg.metabolite/hemeA"/>
-                  <rdf:li rdf:resource="https://identifiers.org/kegg.compound/C15670"/>
-                  <rdf:li rdf:resource="https://identifiers.org/metanetx.chemical/MNXM53309"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -19400,69 +18785,6 @@
           </rdf:RDF>
         </annotation>
       </species>
-      <species metaid="meta_M_cpd28260_c0" sboTerm="SBO:0000247" id="M_cpd28260_c0" name="Thiocarboxylated-MPT-synthases [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="0" fbc:chemicalFormula="C4H7N2O2RS">
-        <annotation>
-          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
-            <rdf:Description rdf:about="#meta_M_cpd28260_c0">
-              <bqbiol:is>
-                <rdf:Bag>
-                  <rdf:li rdf:resource="https://identifiers.org/seed.compound/cpd28260"/>
-                  <rdf:li rdf:resource="https://identifiers.org/metanetx.chemical/MNXM13032"/>
-                  <rdf:li rdf:resource="https://identifiers.org/biocyc/META:Thiocarboxylated-MPT-synthases"/>
-                </rdf:Bag>
-              </bqbiol:is>
-            </rdf:Description>
-          </rdf:RDF>
-        </annotation>
-      </species>
-      <species metaid="meta_M_cpd03520_c0" sboTerm="SBO:0000247" id="M_cpd03520_c0" name="Molybdopterin [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-3" fbc:chemicalFormula="C10H11N5O6PS2">
-        <annotation>
-          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
-            <rdf:Description rdf:about="#meta_M_cpd03520_c0">
-              <bqbiol:is>
-                <rdf:Bag>
-                  <rdf:li rdf:resource="https://identifiers.org/seed.compound/cpd03520"/>
-                  <rdf:li rdf:resource="https://identifiers.org/inchi/InChI=1S/C10H14N5O6PS2/c11-10-14-7-4(8(16)15-10)12-3-6(24)5(23)2(21-9(3)13-7)1-20-22(17,18)19/h2-3,9,12,23-24H,1H2,(H2,17,18,19)(H4,11,13,14,15,16)/p-3/t2-,3+,9-/m1/s1"/>
-                  <rdf:li rdf:resource="https://identifiers.org/inchikey/HPEUEJRPDGMIMY-IFQPEPLCSA-K"/>
-                  <rdf:li rdf:resource="https://identifiers.org/kegg.compound/C05924"/>
-                  <rdf:li rdf:resource="https://identifiers.org/metanetx.chemical/MNXM1193"/>
-                  <rdf:li rdf:resource="https://identifiers.org/biocyc/META:CPD-4"/>
-                </rdf:Bag>
-              </bqbiol:is>
-            </rdf:Description>
-          </rdf:RDF>
-        </annotation>
-      </species>
-      <species metaid="meta_M_cpd27484_c0" sboTerm="SBO:0000247" id="M_cpd27484_c0" name="MPT-Synthases [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="0" fbc:chemicalFormula="R">
-        <annotation>
-          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
-            <rdf:Description rdf:about="#meta_M_cpd27484_c0">
-              <bqbiol:is>
-                <rdf:Bag>
-                  <rdf:li rdf:resource="https://identifiers.org/seed.compound/cpd27484"/>
-                  <rdf:li rdf:resource="https://identifiers.org/metanetx.chemical/MNXM12289"/>
-                  <rdf:li rdf:resource="https://identifiers.org/biocyc/META:MPT-Synthases"/>
-                </rdf:Bag>
-              </bqbiol:is>
-            </rdf:Description>
-          </rdf:RDF>
-        </annotation>
-      </species>
-      <species metaid="meta_M_cpd26672_c0" sboTerm="SBO:0000247" id="M_cpd26672_c0" name="Carboxyadenylated-MPT-synthases [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="0" fbc:chemicalFormula="C14H19N7O9PR">
-        <annotation>
-          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
-            <rdf:Description rdf:about="#meta_M_cpd26672_c0">
-              <bqbiol:is>
-                <rdf:Bag>
-                  <rdf:li rdf:resource="https://identifiers.org/seed.compound/cpd26672"/>
-                  <rdf:li rdf:resource="https://identifiers.org/metanetx.chemical/MNXM10882"/>
-                  <rdf:li rdf:resource="https://identifiers.org/biocyc/META:Carboxyadenylated-MPT-synthases"/>
-                </rdf:Bag>
-              </bqbiol:is>
-            </rdf:Description>
-          </rdf:RDF>
-        </annotation>
-      </species>
       <species metaid="meta_M_cpd27021_c0" sboTerm="SBO:0000247" id="M_cpd27021_c0" name="(2E)-Enoylpimeloyl-ACP-methyl-ester [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="0" fbc:chemicalFormula="C22H36N3O11PR2S">
         <annotation>
           <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
@@ -19491,58 +18813,6 @@
                   <rdf:li rdf:resource="https://identifiers.org/kegg.compound/C20258"/>
                   <rdf:li rdf:resource="https://identifiers.org/metanetx.chemical/MNXM30985"/>
                   <rdf:li rdf:resource="https://identifiers.org/biocyc/META:CPD-14443"/>
-                </rdf:Bag>
-              </bqbiol:is>
-            </rdf:Description>
-          </rdf:RDF>
-        </annotation>
-      </species>
-      <species metaid="meta_M_cpd21090_c0" sboTerm="SBO:0000247" id="M_cpd21090_c0" name="Adenylated molybdopterin [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-3" fbc:chemicalFormula="C20H23N10O12P2S2">
-        <annotation>
-          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
-            <rdf:Description rdf:about="#meta_M_cpd21090_c0">
-              <bqbiol:is>
-                <rdf:Bag>
-                  <rdf:li rdf:resource="https://identifiers.org/seed.compound/cpd21090"/>
-                  <rdf:li rdf:resource="https://identifiers.org/inchi/InChI=1S/C20H26N10O12P2S2/c21-14-8-16(24-3-23-14)30(4-25-8)19-11(32)10(31)5(41-19)1-38-43(34,35)42-44(36,37)39-2-6-12(45)13(46)7-18(40-6)27-15-9(26-7)17(33)29-20(22)28-15/h3-7,10-11,18-19,26,31-32,45-46H,1-2H2,(H,34,35)(H,36,37)(H2,21,23,24)(H4,22,27,28,29,33)/p-3/t5-,6-,7+,10-,11-,18-,19-/m1/s1"/>
-                  <rdf:li rdf:resource="https://identifiers.org/inchikey/XJXFAXLUOKQPAQ-YPRLVJTJSA-K"/>
-                  <rdf:li rdf:resource="https://identifiers.org/kegg.compound/C19848"/>
-                  <rdf:li rdf:resource="https://identifiers.org/metanetx.chemical/MNXM3054"/>
-                  <rdf:li rdf:resource="https://identifiers.org/biocyc/META:CPD-8122"/>
-                </rdf:Bag>
-              </bqbiol:is>
-            </rdf:Description>
-          </rdf:RDF>
-        </annotation>
-      </species>
-      <species metaid="meta_M_cpd33647_c0" sboTerm="SBO:0000247" id="M_cpd33647_c0" name="bis(molybdenum cofactor) [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-4" fbc:chemicalFormula="C20H20MoN10O13P2S4">
-        <annotation>
-          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
-            <rdf:Description rdf:about="#meta_M_cpd33647_c0">
-              <bqbiol:is>
-                <rdf:Bag>
-                  <rdf:li rdf:resource="https://identifiers.org/seed.compound/cpd33647"/>
-                  <rdf:li rdf:resource="https://identifiers.org/inchi/InChI=1S/2C10H14N5O6PS2.Mo.O/c2*11-10-14-7-4(8(16)15-10)12-3-6(24)5(23)2(21-9(3)13-7)1-20-22(17,18)19;;/h2*2-3,9,12,23-24H,1H2,(H2,17,18,19)(H4,11,13,14,15,16);;/q;;+4;/p-8/t2*2-,3+,9-;;/m11../s1"/>
-                  <rdf:li rdf:resource="https://identifiers.org/inchikey/IHRHKHANGAHFPM-BURDSJQCSA-F"/>
-                  <rdf:li rdf:resource="https://identifiers.org/metanetx.chemical/MNXM147053"/>
-                  <rdf:li rdf:resource="https://identifiers.org/biocyc/META:CPD-15874"/>
-                </rdf:Bag>
-              </bqbiol:is>
-            </rdf:Description>
-          </rdf:RDF>
-        </annotation>
-      </species>
-      <species metaid="meta_M_cpd35194_c0" sboTerm="SBO:0000247" id="M_cpd35194_c0" name="Mo(Dtpp-mGDP)2 [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-4" fbc:chemicalFormula="C40H44MoN20O27P4S4">
-        <annotation>
-          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
-            <rdf:Description rdf:about="#meta_M_cpd35194_c0">
-              <bqbiol:is>
-                <rdf:Bag>
-                  <rdf:li rdf:resource="https://identifiers.org/seed.compound/cpd35194"/>
-                  <rdf:li rdf:resource="https://identifiers.org/inchi/InChI=1S/2C20H26N10O13P2S2.Mo.O/c2*21-19-26-13-7(15(33)28-19)24-6-12(47)11(46)5(41-17(6)25-13)2-40-45(37,38)43-44(35,36)39-1-4-9(31)10(32)18(42-4)30-3-23-8-14(30)27-20(22)29-16(8)34;;/h2*3-6,9-10,17-18,24,31-32,46-47H,1-2H2,(H,35,36)(H,37,38)(H3,22,27,29,34)(H4,21,25,26,28,33);;/q;;+4;/p-8/t2*4-,5-,6+,9-,10-,17-,18-;;/m11../s1"/>
-                  <rdf:li rdf:resource="https://identifiers.org/inchikey/SPLYCLQDZVSNSU-HWCCSRDCSA-F"/>
-                  <rdf:li rdf:resource="https://identifiers.org/metanetx.chemical/MNXM62267"/>
-                  <rdf:li rdf:resource="https://identifiers.org/biocyc/META:CPD-15873"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -19704,42 +18974,6 @@
                   <rdf:li rdf:resource="https://identifiers.org/kegg.compound/C02350"/>
                   <rdf:li rdf:resource="https://identifiers.org/metanetx.chemical/MNXM91795"/>
                   <rdf:li rdf:resource="https://identifiers.org/biocyc/META:S-ALLANTOIN"/>
-                </rdf:Bag>
-              </bqbiol:is>
-            </rdf:Description>
-          </rdf:RDF>
-        </annotation>
-      </species>
-      <species metaid="meta_M_cpd21167_c0" sboTerm="SBO:0000247" id="M_cpd21167_c0" name="MGD [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-2" fbc:chemicalFormula="C20H22MoN10O15P2S2">
-        <annotation>
-          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
-            <rdf:Description rdf:about="#meta_M_cpd21167_c0">
-              <bqbiol:is>
-                <rdf:Bag>
-                  <rdf:li rdf:resource="https://identifiers.org/seed.compound/cpd21167"/>
-                  <rdf:li rdf:resource="https://identifiers.org/inchi/InChI=1S/C20H26N10O13P2S2.Mo.2O/c21-19-26-13-7(15(33)28-19)24-6-12(47)11(46)5(41-17(6)25-13)2-40-45(37,38)43-44(35,36)39-1-4-9(31)10(32)18(42-4)30-3-23-8-14(30)27-20(22)29-16(8)34;;;/h3-6,9-10,17-18,24,31-32,46-47H,1-2H2,(H,35,36)(H,37,38)(H3,22,27,29,34)(H4,21,25,26,28,33);;;/q;+2;;/p-4/t4-,5-,6+,9-,10-,17-,18?;;;/m1.../s1"/>
-                  <rdf:li rdf:resource="https://identifiers.org/inchikey/RQPREYSMTBNTJA-USTSGIOXSA-J"/>
-                  <rdf:li rdf:resource="https://identifiers.org/metanetx.chemical/MNXM11740"/>
-                  <rdf:li rdf:resource="https://identifiers.org/metanetx.chemical/MNXM62333"/>
-                  <rdf:li rdf:resource="https://identifiers.org/biocyc/META:CPD-582"/>
-                </rdf:Bag>
-              </bqbiol:is>
-            </rdf:Description>
-          </rdf:RDF>
-        </annotation>
-      </species>
-      <species metaid="meta_M_cpd01029_c0" sboTerm="SBO:0000247" id="M_cpd01029_c0" name="Base Q [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="1" fbc:chemicalFormula="C12H16N5O3">
-        <annotation>
-          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
-            <rdf:Description rdf:about="#meta_M_cpd01029_c0">
-              <bqbiol:is>
-                <rdf:Bag>
-                  <rdf:li rdf:resource="https://identifiers.org/seed.compound/cpd01029"/>
-                  <rdf:li rdf:resource="https://identifiers.org/inchi/InChI=1S/C12H15N5O3/c13-12-16-10-8(11(20)17-12)5(4-15-10)3-14-6-1-2-7(18)9(6)19/h1-2,4,6-7,9,14,18-19H,3H2,(H4,13,15,16,17,20)/p+1/t6-,7-,9+/m0/s1"/>
-                  <rdf:li rdf:resource="https://identifiers.org/inchikey/WYROLENTHWJFLR-ACLDMZEESA-O"/>
-                  <rdf:li rdf:resource="https://identifiers.org/kegg.compound/C01449"/>
-                  <rdf:li rdf:resource="https://identifiers.org/metanetx.chemical/MNXM21435"/>
-                  <rdf:li rdf:resource="https://identifiers.org/biocyc/META:QUEUINE"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -20586,44 +19820,6 @@
                   <rdf:li rdf:resource="https://identifiers.org/kegg.compound/C00431"/>
                   <rdf:li rdf:resource="https://identifiers.org/metanetx.chemical/MNXM792"/>
                   <rdf:li rdf:resource="https://identifiers.org/biocyc/META:5-AMINOPENTANOATE"/>
-                </rdf:Bag>
-              </bqbiol:is>
-            </rdf:Description>
-          </rdf:RDF>
-        </annotation>
-      </species>
-      <species metaid="meta_M_cpd03453_e0" sboTerm="SBO:0000247" id="M_cpd03453_e0" name="Enterobactin [e0]" compartment="e0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="0" fbc:chemicalFormula="C30H27N3O15">
-        <annotation>
-          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
-            <rdf:Description rdf:about="#meta_M_cpd03453_e0">
-              <bqbiol:is>
-                <rdf:Bag>
-                  <rdf:li rdf:resource="https://identifiers.org/seed.compound/cpd03453"/>
-                  <rdf:li rdf:resource="https://identifiers.org/inchi/InChI=1S/C30H27N3O15/c34-19-7-1-4-13(22(19)37)25(40)31-16-10-46-29(44)18(33-27(42)15-6-3-9-21(36)24(15)39)12-48-30(45)17(11-47-28(16)43)32-26(41)14-5-2-8-20(35)23(14)38/h1-9,16-18,34-39H,10-12H2,(H,31,40)(H,32,41)(H,33,42)/t16-,17-,18-/m0/s1"/>
-                  <rdf:li rdf:resource="https://identifiers.org/inchikey/SERBHKJMVBATSJ-BZSNNMDCSA-N"/>
-                  <rdf:li rdf:resource="https://identifiers.org/bigg.metabolite/enter"/>
-                  <rdf:li rdf:resource="https://identifiers.org/kegg.compound/C05821"/>
-                  <rdf:li rdf:resource="https://identifiers.org/metanetx.chemical/MNXM883"/>
-                  <rdf:li rdf:resource="https://identifiers.org/biocyc/META:ENTEROBACTIN"/>
-                </rdf:Bag>
-              </bqbiol:is>
-            </rdf:Description>
-          </rdf:RDF>
-        </annotation>
-      </species>
-      <species metaid="meta_M_cpd03726_e0" sboTerm="SBO:0000247" id="M_cpd03726_e0" name="Fe-enterochlin [e0]" compartment="e0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="0" fbc:chemicalFormula="C30H27FeN3O15">
-        <annotation>
-          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
-            <rdf:Description rdf:about="#meta_M_cpd03726_e0">
-              <bqbiol:is>
-                <rdf:Bag>
-                  <rdf:li rdf:resource="https://identifiers.org/seed.compound/cpd03726"/>
-                  <rdf:li rdf:resource="https://identifiers.org/inchi/InChI=1S/C30H27N3O15.Fe/c34-19-7-1-4-13(22(19)37)25(40)31-16-10-46-29(44)18(33-27(42)15-6-3-9-21(36)24(15)39)12-48-30(45)17(11-47-28(16)43)32-26(41)14-5-2-8-20(35)23(14)38;/h1-9,16-18,34-39H,10-12H2,(H,31,40)(H,32,41)(H,33,42);/q;+3/t16-,17-,18-;/m0./s1"/>
-                  <rdf:li rdf:resource="https://identifiers.org/inchikey/NGILTSZTOFYVBF-UVJOBNTFSA-N"/>
-                  <rdf:li rdf:resource="https://identifiers.org/bigg.metabolite/feenter"/>
-                  <rdf:li rdf:resource="https://identifiers.org/kegg.compound/C06230"/>
-                  <rdf:li rdf:resource="https://identifiers.org/metanetx.chemical/MNXM90263"/>
-                  <rdf:li rdf:resource="https://identifiers.org/metanetx.chemical/MNXM7354"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -21647,6 +20843,275 @@
                   <rdf:li rdf:resource="https://identifiers.org/kegg.compound/C00128"/>
                   <rdf:li rdf:resource="https://identifiers.org/metanetx.chemical/MNXM141"/>
                   <rdf:li rdf:resource="https://identifiers.org/seed.compound/cpd00112"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </species>
+      <species metaid="meta_M_cpd00992_c0" sboTerm="SBO:0000247" id="M_cpd00992_c0" name="1,2-Ethanediol [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="0" fbc:chemicalFormula="C2H6O2">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_M_cpd00992_c0">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/seed.compound/cpd00992"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.compound/C01380"/>
+                  <rdf:li rdf:resource="https://identifiers.org/biocyc/META:GLYCOL"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </species>
+      <species metaid="meta_M_cpd00992_e0" sboTerm="SBO:0000247" id="M_cpd00992_e0" name="1,2-Ethanediol [e0]" compartment="e0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="0" fbc:chemicalFormula="C2H6O2">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_M_cpd00992_e0">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/seed.compound/cpd00992"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.compound/C01380"/>
+                  <rdf:li rdf:resource="https://identifiers.org/biocyc/META:GLYCOL"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </species>
+      <species metaid="meta_M_cpd00054_e0" sboTerm="SBO:0000247" id="M_cpd00054_e0" name="L-Serine [e0]" compartment="e0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="0" fbc:chemicalFormula="C3H7NO3">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_M_cpd00054_e0">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/bigg.metabolite/ser__L"/>
+                  <rdf:li rdf:resource="https://identifiers.org/biocyc/META:SER"/>
+                  <rdf:li rdf:resource="https://identifiers.org/inchi/InChI=1S/C3H7NO3/c4-2(1-5)3(6)7/h2,5H,1,4H2,(H,6,7)/t2-/m0/s1"/>
+                  <rdf:li rdf:resource="https://identifiers.org/inchikey/MTCFGRXMJLQNBG-REOHCLBHSA-N"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.compound/C00065"/>
+                  <rdf:li rdf:resource="https://identifiers.org/metanetx.chemical/MNXM53"/>
+                  <rdf:li rdf:resource="https://identifiers.org/seed.compound/cpd00054"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </species>
+      <species metaid="meta_M_cpd00085_e0" sboTerm="SBO:0000247" id="M_cpd00085_e0" name="beta-Alanine [e0]" compartment="e0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="0" fbc:chemicalFormula="C3H7NO2">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_M_cpd00085_e0">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/bigg.metabolite/ala_B"/>
+                  <rdf:li rdf:resource="https://identifiers.org/biocyc/META:B-ALANINE"/>
+                  <rdf:li rdf:resource="https://identifiers.org/inchi/InChI=1S/C3H7NO2/c4-2-1-3(5)6/h1-2,4H2,(H,5,6)"/>
+                  <rdf:li rdf:resource="https://identifiers.org/inchikey/UCMIRNVEIXFBKS-UHFFFAOYSA-N"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.compound/C00099"/>
+                  <rdf:li rdf:resource="https://identifiers.org/metanetx.chemical/MNXM144"/>
+                  <rdf:li rdf:resource="https://identifiers.org/seed.compound/cpd00085"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </species>
+      <species metaid="meta_M_cpd00132_e0" sboTerm="SBO:0000247" id="M_cpd00132_e0" name="L-Asparagine [e0]" compartment="e0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="0" fbc:chemicalFormula="C4H8N2O3">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_M_cpd00132_e0">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/bigg.metabolite/asn__L"/>
+                  <rdf:li rdf:resource="https://identifiers.org/biocyc/META:ASN"/>
+                  <rdf:li rdf:resource="https://identifiers.org/inchi/InChI=1S/C4H8N2O3/c5-2(4(8)9)1-3(6)7/h2H,1,5H2,(H2,6,7)(H,8,9)/t2-/m0/s1"/>
+                  <rdf:li rdf:resource="https://identifiers.org/inchikey/DCXYFEDJOCDNAF-REOHCLBHSA-N"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.compound/C00152"/>
+                  <rdf:li rdf:resource="https://identifiers.org/metanetx.chemical/MNXM147"/>
+                  <rdf:li rdf:resource="https://identifiers.org/seed.compound/cpd00132"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </species>
+      <species metaid="meta_M_cpd30760_e0" sboTerm="SBO:0000247" id="M_cpd30760_e0" name="Cu+ [e0]" compartment="e0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="1" fbc:chemicalFormula="Cu">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_M_cpd30760_e0">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/seed.compound/cpd30760"/>
+                  <rdf:li rdf:resource="https://identifiers.org/bigg.metabolite/cu"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.compound/C22423"/>
+                  <rdf:li rdf:resource="https://identifiers.org/biocyc/META:CU+"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </species>
+      <species metaid="meta_M_cpd24604_c0" sboTerm="SBO:0000247" id="M_cpd24604_c0" name="2Fe2S iron-sulfur cluster [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="2" fbc:chemicalFormula="Fe2S2">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_M_cpd24604_c0">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/seed.compound/cpd24604"/>
+                  <rdf:li rdf:resource="https://identifiers.org/bigg.metabolite/2fe2s"/>
+                  <rdf:li rdf:resource="https://identifiers.org/biocyc/META:CPD-6"/>
+                  <rdf:li rdf:resource="https://identifiers.org/metanetx.chemical/MNXM1107419"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </species>
+      <species metaid="meta_M_cpd00334_c0" sboTerm="SBO:0000247" id="M_cpd00334_c0" name="L-Lactaldehyde [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="0" fbc:chemicalFormula="C3H6O2">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_M_cpd00334_c0">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/bigg.metabolite/lald__L"/>
+                  <rdf:li rdf:resource="https://identifiers.org/biocyc/META:LACTALD"/>
+                  <rdf:li rdf:resource="https://identifiers.org/inchi/InChI=1S/C3H6O2/c1-3(5)2-4/h2-3,5H,1H3/t3-/m0/s1"/>
+                  <rdf:li rdf:resource="https://identifiers.org/inchikey/BSABBBMNWQWLLU-VKHMYHEASA-N"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.compound/C00424"/>
+                  <rdf:li rdf:resource="https://identifiers.org/metanetx.chemical/MNXM2387"/>
+                  <rdf:li rdf:resource="https://identifiers.org/seed.compound/cpd00334"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </species>
+      <species metaid="meta_M_cpd00259_c0" sboTerm="SBO:0000247" id="M_cpd00259_c0" name="D-Lyxulose [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="0" fbc:chemicalFormula="C5H10O5">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_M_cpd00259_c0">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/seed.compound/cpd00259"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </species>
+      <species metaid="meta_M_cpd00413_c0" sboTerm="SBO:0000247" id="M_cpd00413_c0" name="Glutaryl-CoA [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-5" fbc:chemicalFormula="C26H37N7O19P3S">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_M_cpd00413_c0">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/seed.compound/cpd00413"/>
+                  <rdf:li rdf:resource="https://identifiers.org/bigg.metabolite/glutcoa"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.compound/C00527"/>
+                  <rdf:li rdf:resource="https://identifiers.org/biocyc/META:GLUTARYL-COA"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </species>
+      <species metaid="meta_M_cpd00705_c0" sboTerm="SBO:0000247" id="M_cpd00705_c0" name="L-2-Aminoadipate [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-1" fbc:chemicalFormula="C6H10NO4">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_M_cpd00705_c0">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/seed.compound/cpd00705"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </species>
+      <species metaid="meta_M_cpd03045_c0" sboTerm="SBO:0000247" id="M_cpd03045_c0" name="S-(3-methylbutanoyl)-dihydrolipoamide [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="0" fbc:chemicalFormula="C13H24NO2RS2">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_M_cpd03045_c0">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.compound/C15979"/>
+                  <rdf:li rdf:resource="https://identifiers.org/metanetx.chemical/MNXM5588"/>
+                  <rdf:li rdf:resource="https://identifiers.org/seed.compound/cpd03045"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </species>
+      <species metaid="meta_M_cpd03046_c0" sboTerm="SBO:0000247" id="M_cpd03046_c0" name="S-(3-methylbutanoyl)-dihydrolipoamide [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="0" fbc:chemicalFormula="C13H24NO2RS2">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_M_cpd03046_c0">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.compound/C15975"/>
+                  <rdf:li rdf:resource="https://identifiers.org/metanetx.chemical/MNXM163705"/>
+                  <rdf:li rdf:resource="https://identifiers.org/seed.compound/cpd03046"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </species>
+      <species metaid="meta_M_cpd00269_c0" sboTerm="SBO:0000247" id="M_cpd00269_c0" name="2-Oxoadipate [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-2" fbc:chemicalFormula="C6H6O5">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_M_cpd00269_c0">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/seed.compound/cpd00269"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </species>
+      <species metaid="meta_M_cpd16479_c0" sboTerm="SBO:0000247" id="M_cpd16479_c0" name="S-Glutaryldihydrolipoamide [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-1" fbc:chemicalFormula="C13H21NO4RS2">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_M_cpd16479_c0">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/seed.compound/cpd16497"/>
+                  <rdf:li rdf:resource="https://identifiers.org/bigg.metabolite/S_gtrdhdlp"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.compound/C06157"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </species>
+      <species metaid="meta_M_cpd30760_c0" sboTerm="SBO:0000247" id="M_cpd30760_c0" name="Cu+ [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="1" fbc:chemicalFormula="Cu">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_M_cpd30760_c0">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/seed.compound/cpd30760"/>
+                  <rdf:li rdf:resource="https://identifiers.org/bigg.metabolite/cu"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.compound/C22423"/>
+                  <rdf:li rdf:resource="https://identifiers.org/biocyc/META:CU+"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </species>
+      <species metaid="meta_M_cpd19185_c0" sboTerm="SBO:0000247" id="M_cpd19185_c0" name="7-Aminomethyl-7-carbaguanine [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="1" fbc:chemicalFormula="C7H10N5O">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_M_cpd19185_c0">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/seed.compound/cpd19185"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.compound/C16675"/>
+                  <rdf:li rdf:resource="https://identifiers.org/biocyc/META:7-AMINOMETHYL-7-DEAZAGUANINE"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -24384,37 +23849,6 @@
           </fbc:or>
         </fbc:geneProductAssociation>
       </reaction>
-      <reaction metaid="meta_R_rxn01203_c0" sboTerm="SBO:0000176" id="R_rxn01203_c0" name="R01647 [c0]" reversible="false" fast="false" fbc:lowerFluxBound="cobra_0_bound" fbc:upperFluxBound="cobra_default_ub">
-        <annotation>
-          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
-            <rdf:Description rdf:about="#meta_R_rxn01203_c0">
-              <bqbiol:is>
-                <rdf:Bag>
-                  <rdf:li rdf:resource="https://identifiers.org/seed.reaction/rxn01203"/>
-                  <rdf:li rdf:resource="https://identifiers.org/bigg.reaction/DHEDAA"/>
-                  <rdf:li rdf:resource="https://identifiers.org/bigg.reaction/R01647"/>
-                  <rdf:li rdf:resource="https://identifiers.org/kegg.reaction/R01647"/>
-                  <rdf:li rdf:resource="https://identifiers.org/rhea/25791"/>
-                  <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR138233"/>
-                  <rdf:li rdf:resource="https://identifiers.org/biocyc/META:RXN-14146"/>
-                  <rdf:li rdf:resource="https://identifiers.org/ec-code/4.1.2.-"/>
-                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K02510"/>
-                </rdf:Bag>
-              </bqbiol:is>
-            </rdf:Description>
-          </rdf:RDF>
-        </annotation>
-        <listOfReactants>
-          <speciesReference species="M_cpd03708_c0" stoichiometry="1" constant="true"/>
-        </listOfReactants>
-        <listOfProducts>
-          <speciesReference species="M_cpd00020_c0" stoichiometry="1" constant="true"/>
-          <speciesReference species="M_cpd00199_c0" stoichiometry="1" constant="true"/>
-        </listOfProducts>
-        <fbc:geneProductAssociation>
-          <fbc:geneProductRef fbc:geneProduct="G_ACZ81_RS01880"/>
-        </fbc:geneProductAssociation>
-      </reaction>
       <reaction metaid="meta_R_rxn00910_c0" sboTerm="SBO:0000176" id="R_rxn00910_c0" name="5-methyltetrahydrofolate:NADP+ oxidoreductase [c0]" reversible="true" fast="false" fbc:lowerFluxBound="cobra_default_lb" fbc:upperFluxBound="cobra_default_ub">
         <annotation>
           <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
@@ -26278,37 +25712,6 @@
           <fbc:geneProductRef fbc:geneProduct="G_ACZ81_RS05870"/>
         </fbc:geneProductAssociation>
       </reaction>
-      <reaction metaid="meta_R_rxn08275_c0" sboTerm="SBO:0000655" id="R_rxn08275_c0" name="copper transport out via proton antiport [c0]" reversible="false" fast="false" fbc:lowerFluxBound="cobra_0_bound" fbc:upperFluxBound="cobra_default_ub">
-        <annotation>
-          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
-            <rdf:Description rdf:about="#meta_R_rxn08275_c0">
-              <bqbiol:is>
-                <rdf:Bag>
-                  <rdf:li rdf:resource="https://identifiers.org/seed.reaction/rxn08275"/>
-                  <rdf:li rdf:resource="https://identifiers.org/bigg.reaction/CUt3"/>
-                  <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR135764"/>
-                </rdf:Bag>
-              </bqbiol:is>
-            </rdf:Description>
-          </rdf:RDF>
-        </annotation>
-        <listOfReactants>
-          <speciesReference species="M_cpd00058_c0" stoichiometry="1" constant="true"/>
-          <speciesReference species="M_cpd00067_e0" stoichiometry="1" constant="true"/>
-        </listOfReactants>
-        <listOfProducts>
-          <speciesReference species="M_cpd00058_e0" stoichiometry="1" constant="true"/>
-          <speciesReference species="M_cpd00067_c0" stoichiometry="1" constant="true"/>
-        </listOfProducts>
-        <fbc:geneProductAssociation>
-          <fbc:and>
-            <fbc:geneProductRef fbc:geneProduct="G_ACZ81_RS14830"/>
-            <fbc:geneProductRef fbc:geneProduct="G_ACZ81_RS14840"/>
-            <fbc:geneProductRef fbc:geneProduct="G_ACZ81_RS20365"/>
-            <fbc:geneProductRef fbc:geneProduct="G_ACZ81_RS14835"/>
-          </fbc:and>
-        </fbc:geneProductAssociation>
-      </reaction>
       <reaction metaid="meta_R_rxn04384_c0" sboTerm="SBO:0000176" id="R_rxn04384_c0" name="adenosylcobyric acid:(R)-1-aminopropan-2-yl phosphate ligase [c0]" reversible="false" fast="false" fbc:lowerFluxBound="cobra_0_bound" fbc:upperFluxBound="cobra_default_ub">
         <annotation>
           <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
@@ -27394,35 +26797,6 @@
           <fbc:geneProductRef fbc:geneProduct="G_ACZ81_RS16715"/>
         </fbc:geneProductAssociation>
       </reaction>
-      <reaction metaid="meta_R_rxn10481_c0" sboTerm="SBO:0000655" id="R_rxn10481_c0" name="Copper transport via ABC system [c0]" reversible="false" fast="false" fbc:lowerFluxBound="cobra_0_bound" fbc:upperFluxBound="cobra_default_ub">
-        <annotation>
-          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
-            <rdf:Description rdf:about="#meta_R_rxn10481_c0">
-              <bqbiol:is>
-                <rdf:Bag>
-                  <rdf:li rdf:resource="https://identifiers.org/seed.reaction/rxn10481"/>
-                  <rdf:li rdf:resource="https://identifiers.org/bigg.reaction/Cuabc"/>
-                  <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR96952"/>
-                </rdf:Bag>
-              </bqbiol:is>
-            </rdf:Description>
-          </rdf:RDF>
-        </annotation>
-        <listOfReactants>
-          <speciesReference species="M_cpd00001_c0" stoichiometry="1" constant="true"/>
-          <speciesReference species="M_cpd00002_c0" stoichiometry="1" constant="true"/>
-          <speciesReference species="M_cpd00058_e0" stoichiometry="1" constant="true"/>
-        </listOfReactants>
-        <listOfProducts>
-          <speciesReference species="M_cpd00008_c0" stoichiometry="1" constant="true"/>
-          <speciesReference species="M_cpd00009_c0" stoichiometry="1" constant="true"/>
-          <speciesReference species="M_cpd00058_c0" stoichiometry="1" constant="true"/>
-          <speciesReference species="M_cpd00067_c0" stoichiometry="1" constant="true"/>
-        </listOfProducts>
-        <fbc:geneProductAssociation>
-          <fbc:geneProductRef fbc:geneProduct="G_ACZ81_RS10400"/>
-        </fbc:geneProductAssociation>
-      </reaction>
       <reaction metaid="meta_R_rxn03535_c0" sboTerm="SBO:0000176" id="R_rxn03535_c0" name="ATP:cob(I)yrinic acid-a,c-diamide Cobeta-adenosyltransferase [c0]" reversible="false" fast="false" fbc:lowerFluxBound="cobra_0_bound" fbc:upperFluxBound="cobra_default_ub">
         <annotation>
           <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
@@ -27885,40 +27259,6 @@
         </listOfProducts>
         <fbc:geneProductAssociation>
           <fbc:geneProductRef fbc:geneProduct="G_ACZ81_RS17435"/>
-        </fbc:geneProductAssociation>
-      </reaction>
-      <reaction metaid="meta_R_rxn08809_c0" sboTerm="SBO:0000176" id="R_rxn08809_c0" name="Lysophospholipase L1 (2-acylglycerophosphoethanolamine, n-C18:1) (periplasm) [c0]" reversible="true" fast="false" fbc:lowerFluxBound="cobra_default_lb" fbc:upperFluxBound="cobra_default_ub">
-        <annotation>
-          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
-            <rdf:Description rdf:about="#meta_R_rxn08809_c0">
-              <bqbiol:is>
-                <rdf:Bag>
-                  <rdf:li rdf:resource="https://identifiers.org/seed.reaction/rxn08809"/>
-                  <rdf:li rdf:resource="https://identifiers.org/bigg.reaction/LPLIPAL1E181pp"/>
-                  <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR142316"/>
-                  <rdf:li rdf:resource="https://identifiers.org/ec-code/3.1.1.5"/>
-                </rdf:Bag>
-              </bqbiol:is>
-            </rdf:Description>
-          </rdf:RDF>
-        </annotation>
-        <listOfReactants>
-          <speciesReference species="M_cpd00001_c0" stoichiometry="1" constant="true"/>
-          <speciesReference species="M_cpd12547_c0" stoichiometry="1" constant="true"/>
-        </listOfReactants>
-        <listOfProducts>
-          <speciesReference species="M_cpd00067_c0" stoichiometry="1" constant="true"/>
-          <speciesReference species="M_cpd00908_c0" stoichiometry="1" constant="true"/>
-          <speciesReference species="M_cpd15269_c0" stoichiometry="1" constant="true"/>
-        </listOfProducts>
-        <fbc:geneProductAssociation>
-          <fbc:or>
-            <fbc:and>
-              <fbc:geneProductRef fbc:geneProduct="G_ACZ81_RS14850"/>
-              <fbc:geneProductRef fbc:geneProduct="G_ACZ81_RS06225"/>
-            </fbc:and>
-            <fbc:geneProductRef fbc:geneProduct="G_ACZ81_RS02100"/>
-          </fbc:or>
         </fbc:geneProductAssociation>
       </reaction>
       <reaction metaid="meta_R_rxn00460_c0" sboTerm="SBO:0000176" id="R_rxn00460_c0" name="UTP:pyruvate 2-O-phosphotransferase [c0]" reversible="false" fast="false" fbc:lowerFluxBound="cobra_0_bound" fbc:upperFluxBound="cobra_default_ub">
@@ -28458,32 +27798,6 @@
             <fbc:geneProductRef fbc:geneProduct="G_ACZ81_RS06915"/>
             <fbc:geneProductRef fbc:geneProduct="G_ACZ81_RS06910"/>
           </fbc:and>
-        </fbc:geneProductAssociation>
-      </reaction>
-      <reaction metaid="meta_R_rxn10307_c0" sboTerm="SBO:0000176" id="R_rxn10307_c0" name="palmitoyl-lipoteichoic acid synthesis (n=24), linked, N-acetylglucosamine substituted [c0]" reversible="true" fast="false" fbc:lowerFluxBound="cobra_default_lb" fbc:upperFluxBound="cobra_default_ub">
-        <annotation>
-          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
-            <rdf:Description rdf:about="#meta_R_rxn10307_c0">
-              <bqbiol:is>
-                <rdf:Bag>
-                  <rdf:li rdf:resource="https://identifiers.org/seed.reaction/rxn10307"/>
-                  <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR136303"/>
-                  <rdf:li rdf:resource="https://identifiers.org/ec-code/2.7.8.-"/>
-                </rdf:Bag>
-              </bqbiol:is>
-            </rdf:Description>
-          </rdf:RDF>
-        </annotation>
-        <listOfReactants>
-          <speciesReference species="M_cpd00037_c0" stoichiometry="24" constant="true"/>
-          <speciesReference species="M_cpd15746_c0" stoichiometry="1" constant="true"/>
-        </listOfReactants>
-        <listOfProducts>
-          <speciesReference species="M_cpd00014_c0" stoichiometry="24" constant="true"/>
-          <speciesReference species="M_cpd15764_c0" stoichiometry="1" constant="true"/>
-        </listOfProducts>
-        <fbc:geneProductAssociation>
-          <fbc:geneProductRef fbc:geneProduct="G_ACZ81_RS04710"/>
         </fbc:geneProductAssociation>
       </reaction>
       <reaction metaid="meta_R_rxn12638_c0" sboTerm="SBO:0000176" id="R_rxn12638_c0" name="methionyl aminopeptidase [c0]" reversible="false" fast="false" fbc:lowerFluxBound="cobra_0_bound" fbc:upperFluxBound="cobra_default_ub">
@@ -29731,32 +29045,6 @@
             <fbc:geneProductRef fbc:geneProduct="G_ACZ81_RS07885"/>
             <fbc:geneProductRef fbc:geneProduct="G_ACZ81_RS10180"/>
           </fbc:and>
-        </fbc:geneProductAssociation>
-      </reaction>
-      <reaction metaid="meta_R_rxn10314_c0" sboTerm="SBO:0000176" id="R_rxn10314_c0" name="anteisopentadecanoyl-lipoteichoic acid synthesis (n=24), linked, N-acetylglucosamine substituted [c0]" reversible="true" fast="false" fbc:lowerFluxBound="cobra_default_lb" fbc:upperFluxBound="cobra_default_ub">
-        <annotation>
-          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
-            <rdf:Description rdf:about="#meta_R_rxn10314_c0">
-              <bqbiol:is>
-                <rdf:Bag>
-                  <rdf:li rdf:resource="https://identifiers.org/seed.reaction/rxn10314"/>
-                  <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR136310"/>
-                  <rdf:li rdf:resource="https://identifiers.org/ec-code/2.7.8.-"/>
-                </rdf:Bag>
-              </bqbiol:is>
-            </rdf:Description>
-          </rdf:RDF>
-        </annotation>
-        <listOfReactants>
-          <speciesReference species="M_cpd00037_c0" stoichiometry="24" constant="true"/>
-          <speciesReference species="M_cpd15753_c0" stoichiometry="1" constant="true"/>
-        </listOfReactants>
-        <listOfProducts>
-          <speciesReference species="M_cpd00014_c0" stoichiometry="24" constant="true"/>
-          <speciesReference species="M_cpd15771_c0" stoichiometry="1" constant="true"/>
-        </listOfProducts>
-        <fbc:geneProductAssociation>
-          <fbc:geneProductRef fbc:geneProduct="G_ACZ81_RS04710"/>
         </fbc:geneProductAssociation>
       </reaction>
       <reaction metaid="meta_R_rxn09111_c0" sboTerm="SBO:0000176" id="R_rxn09111_c0" name="Phosphatidylglycerol synthase (n-C16:0) [c0]" reversible="true" fast="false" fbc:lowerFluxBound="cobra_default_lb" fbc:upperFluxBound="cobra_default_ub">
@@ -31211,40 +30499,6 @@
         </listOfProducts>
         <fbc:geneProductAssociation>
           <fbc:geneProductRef fbc:geneProduct="G_ACZ81_RS15290"/>
-        </fbc:geneProductAssociation>
-      </reaction>
-      <reaction metaid="meta_R_rxn07433_c0" sboTerm="SBO:0000176" id="R_rxn07433_c0" name="R07602 [c0]" reversible="true" fast="false" fbc:lowerFluxBound="cobra_default_lb" fbc:upperFluxBound="cobra_default_ub">
-        <annotation>
-          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
-            <rdf:Description rdf:about="#meta_R_rxn07433_c0">
-              <bqbiol:is>
-                <rdf:Bag>
-                  <rdf:li rdf:resource="https://identifiers.org/seed.reaction/rxn07433"/>
-                  <rdf:li rdf:resource="https://identifiers.org/kegg.reaction/R07602"/>
-                  <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR142262"/>
-                  <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR111209"/>
-                  <rdf:li rdf:resource="https://identifiers.org/ec-code/1.2.4.4"/>
-                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K11381"/>
-                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K00166"/>
-                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K00167"/>
-                </rdf:Bag>
-              </bqbiol:is>
-            </rdf:Description>
-          </rdf:RDF>
-        </annotation>
-        <listOfReactants>
-          <speciesReference species="M_cpd14698_c0" stoichiometry="1" constant="true"/>
-          <speciesReference species="M_cpd14954_c0" stoichiometry="1" constant="true"/>
-        </listOfReactants>
-        <listOfProducts>
-          <speciesReference species="M_cpd00056_c0" stoichiometry="1" constant="true"/>
-          <speciesReference species="M_cpd14699_c0" stoichiometry="1" constant="true"/>
-        </listOfProducts>
-        <fbc:geneProductAssociation>
-          <fbc:and>
-            <fbc:geneProductRef fbc:geneProduct="G_ACZ81_RS10150"/>
-            <fbc:geneProductRef fbc:geneProduct="G_ACZ81_RS10145"/>
-          </fbc:and>
         </fbc:geneProductAssociation>
       </reaction>
       <reaction metaid="meta_R_rxn01269_c0" sboTerm="SBO:0000176" id="R_rxn01269_c0" name="Prephenate:NADP+ oxidoreductase(decarboxylating) [c0]" reversible="false" fast="false" fbc:lowerFluxBound="cobra_0_bound" fbc:upperFluxBound="cobra_default_ub">
@@ -32886,40 +32140,6 @@
         </listOfProducts>
         <fbc:geneProductAssociation>
           <fbc:geneProductRef fbc:geneProduct="G_ACZ81_RS16765"/>
-        </fbc:geneProductAssociation>
-      </reaction>
-      <reaction metaid="meta_R_rxn00668_c0" sboTerm="SBO:0000176" id="R_rxn00668_c0" name="propanoyl-CoA:NADP+ 2-oxidoreductase [c0]" reversible="true" fast="false" fbc:lowerFluxBound="cobra_default_lb" fbc:upperFluxBound="cobra_default_ub">
-        <annotation>
-          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
-            <rdf:Description rdf:about="#meta_R_rxn00668_c0">
-              <bqbiol:is>
-                <rdf:Bag>
-                  <rdf:li rdf:resource="https://identifiers.org/seed.reaction/rxn00668"/>
-                  <rdf:li rdf:resource="https://identifiers.org/kegg.reaction/R00919"/>
-                  <rdf:li rdf:resource="https://identifiers.org/rhea/26456"/>
-                  <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR102415"/>
-                  <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR139008"/>
-                  <rdf:li rdf:resource="https://identifiers.org/biocyc/META:RXN-9087"/>
-                  <rdf:li rdf:resource="https://identifiers.org/ec-code/1.3.1.-"/>
-                  <rdf:li rdf:resource="https://identifiers.org/ec-code/1.3.1.84"/>
-                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K19745"/>
-                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K14469"/>
-                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K15020"/>
-                </rdf:Bag>
-              </bqbiol:is>
-            </rdf:Description>
-          </rdf:RDF>
-        </annotation>
-        <listOfReactants>
-          <speciesReference species="M_cpd00005_c0" stoichiometry="1" constant="true"/>
-          <speciesReference species="M_cpd00663_c0" stoichiometry="1" constant="true"/>
-        </listOfReactants>
-        <listOfProducts>
-          <speciesReference species="M_cpd00006_c0" stoichiometry="1" constant="true"/>
-          <speciesReference species="M_cpd00086_c0" stoichiometry="1" constant="true"/>
-        </listOfProducts>
-        <fbc:geneProductAssociation>
-          <fbc:geneProductRef fbc:geneProduct="G_ACZ81_RS12215"/>
         </fbc:geneProductAssociation>
       </reaction>
       <reaction metaid="meta_R_rxn02314_c0" sboTerm="SBO:0000176" id="R_rxn02314_c0" name="ATP:D-tagatose-6-phosphate 1-phosphotransferase [c0]" reversible="true" fast="false" fbc:lowerFluxBound="cobra_default_lb" fbc:upperFluxBound="cobra_default_ub">
@@ -35575,45 +34795,6 @@
           <fbc:geneProductRef fbc:geneProduct="G_ACZ81_RS03955"/>
         </fbc:geneProductAssociation>
       </reaction>
-      <reaction metaid="meta_R_rxn05217_c0" sboTerm="SBO:0000655" id="R_rxn05217_c0" name="TRANS-RXNBWI-115637.ce.maizeexp.L-ASPARTATE_L-ASPARTATE [c0]" reversible="true" fast="false" fbc:lowerFluxBound="cobra_default_lb" fbc:upperFluxBound="cobra_default_ub">
-        <annotation>
-          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
-            <rdf:Description rdf:about="#meta_R_rxn05217_c0">
-              <bqbiol:is>
-                <rdf:Bag>
-                  <rdf:li rdf:resource="https://identifiers.org/seed.reaction/rxn05217"/>
-                  <rdf:li rdf:resource="https://identifiers.org/bigg.reaction/ASPt2pp"/>
-                  <rdf:li rdf:resource="https://identifiers.org/bigg.reaction/ASPt2"/>
-                  <rdf:li rdf:resource="https://identifiers.org/bigg.reaction/ASPt6"/>
-                  <rdf:li rdf:resource="https://identifiers.org/bigg.reaction/ASPt7"/>
-                  <rdf:li rdf:resource="https://identifiers.org/bigg.reaction/ASPt2r"/>
-                  <rdf:li rdf:resource="https://identifiers.org/bigg.reaction/GAP1_5"/>
-                  <rdf:li rdf:resource="https://identifiers.org/bigg.reaction/AGP3_2"/>
-                  <rdf:li rdf:resource="https://identifiers.org/bigg.reaction/ASPt2m"/>
-                  <rdf:li rdf:resource="https://identifiers.org/bigg.reaction/ASPt2n"/>
-                  <rdf:li rdf:resource="https://identifiers.org/bigg.reaction/AGC1_2"/>
-                  <rdf:li rdf:resource="https://identifiers.org/bigg.reaction/DIP5_4"/>
-                  <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR96106"/>
-                </rdf:Bag>
-              </bqbiol:is>
-            </rdf:Description>
-          </rdf:RDF>
-        </annotation>
-        <listOfReactants>
-          <speciesReference species="M_cpd00041_e0" stoichiometry="1" constant="true"/>
-          <speciesReference species="M_cpd00067_e0" stoichiometry="1" constant="true"/>
-        </listOfReactants>
-        <listOfProducts>
-          <speciesReference species="M_cpd00041_c0" stoichiometry="1" constant="true"/>
-          <speciesReference species="M_cpd00067_c0" stoichiometry="1" constant="true"/>
-        </listOfProducts>
-        <fbc:geneProductAssociation>
-          <fbc:and>
-            <fbc:geneProductRef fbc:geneProduct="G_ACZ81_RS07450"/>
-            <fbc:geneProductRef fbc:geneProduct="G_ACZ81_RS08425"/>
-          </fbc:and>
-        </fbc:geneProductAssociation>
-      </reaction>
       <reaction metaid="meta_R_rxn00366_c0" sboTerm="SBO:0000176" id="R_rxn00366_c0" name="CDP phosphohydrolase [c0]" reversible="false" fast="false" fbc:lowerFluxBound="cobra_0_bound" fbc:upperFluxBound="cobra_default_ub">
         <annotation>
           <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
@@ -36362,40 +35543,6 @@
         </listOfProducts>
         <fbc:geneProductAssociation>
           <fbc:geneProductRef fbc:geneProduct="G_ACZ81_RS08625"/>
-        </fbc:geneProductAssociation>
-      </reaction>
-      <reaction metaid="meta_R_rxn05496_c0" sboTerm="SBO:0000655" id="R_rxn05496_c0" name="TRANS-RXNBWI-115637.ce.maizeexp.L-ALPHA-ALANINE_L-ALPHA-ALANINE [c0]" reversible="true" fast="false" fbc:lowerFluxBound="cobra_default_lb" fbc:upperFluxBound="cobra_default_ub">
-        <annotation>
-          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
-            <rdf:Description rdf:about="#meta_R_rxn05496_c0">
-              <bqbiol:is>
-                <rdf:Bag>
-                  <rdf:li rdf:resource="https://identifiers.org/seed.reaction/rxn05496"/>
-                  <rdf:li rdf:resource="https://identifiers.org/bigg.reaction/GAP1_2"/>
-                  <rdf:li rdf:resource="https://identifiers.org/bigg.reaction/DIP5_2"/>
-                  <rdf:li rdf:resource="https://identifiers.org/bigg.reaction/PUT4_1"/>
-                  <rdf:li rdf:resource="https://identifiers.org/bigg.reaction/TAT2_1"/>
-                  <rdf:li rdf:resource="https://identifiers.org/bigg.reaction/ALAt2pp"/>
-                  <rdf:li rdf:resource="https://identifiers.org/bigg.reaction/ALAt2r"/>
-                  <rdf:li rdf:resource="https://identifiers.org/bigg.reaction/AGP1_2"/>
-                  <rdf:li rdf:resource="https://identifiers.org/bigg.reaction/ALAt2"/>
-                  <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR95704"/>
-                  <rdf:li rdf:resource="https://identifiers.org/biocyc/META:RXN0-5202"/>
-                </rdf:Bag>
-              </bqbiol:is>
-            </rdf:Description>
-          </rdf:RDF>
-        </annotation>
-        <listOfReactants>
-          <speciesReference species="M_cpd00035_e0" stoichiometry="1" constant="true"/>
-          <speciesReference species="M_cpd00067_e0" stoichiometry="1" constant="true"/>
-        </listOfReactants>
-        <listOfProducts>
-          <speciesReference species="M_cpd00035_c0" stoichiometry="1" constant="true"/>
-          <speciesReference species="M_cpd00067_c0" stoichiometry="1" constant="true"/>
-        </listOfProducts>
-        <fbc:geneProductAssociation>
-          <fbc:geneProductRef fbc:geneProduct="G_ACZ81_RS07230"/>
         </fbc:geneProductAssociation>
       </reaction>
       <reaction metaid="meta_R_rxn00527_c0" sboTerm="SBO:0000176" id="R_rxn00527_c0" name="L-tyrosine:2-oxoglutarate aminotransferase [c0]" reversible="true" fast="false" fbc:lowerFluxBound="cobra_default_lb" fbc:upperFluxBound="cobra_default_ub">
@@ -38225,31 +37372,6 @@
           <fbc:geneProductRef fbc:geneProduct="G_ACZ81_RS01025"/>
         </fbc:geneProductAssociation>
       </reaction>
-      <reaction metaid="meta_R_rxn09022_c0" sboTerm="SBO:0000176" id="R_rxn09022_c0" name="O16 antigen polymerase (periplasm) [c0]" reversible="true" fast="false" fbc:lowerFluxBound="cobra_default_lb" fbc:upperFluxBound="cobra_default_ub">
-        <annotation>
-          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
-            <rdf:Description rdf:about="#meta_R_rxn09022_c0">
-              <bqbiol:is>
-                <rdf:Bag>
-                  <rdf:li rdf:resource="https://identifiers.org/seed.reaction/rxn09022"/>
-                  <rdf:li rdf:resource="https://identifiers.org/bigg.reaction/O16AP1pp"/>
-                  <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR135905"/>
-                </rdf:Bag>
-              </bqbiol:is>
-            </rdf:Description>
-          </rdf:RDF>
-        </annotation>
-        <listOfReactants>
-          <speciesReference species="M_cpd15520_c0" stoichiometry="2" constant="true"/>
-        </listOfReactants>
-        <listOfProducts>
-          <speciesReference species="M_cpd02229_c0" stoichiometry="1" constant="true"/>
-          <speciesReference species="M_cpd15516_c0" stoichiometry="1" constant="true"/>
-        </listOfProducts>
-        <fbc:geneProductAssociation>
-          <fbc:geneProductRef fbc:geneProduct="G_ACZ81_RS13830"/>
-        </fbc:geneProductAssociation>
-      </reaction>
       <reaction metaid="meta_R_rxn02317_c0" sboTerm="SBO:0000176" id="R_rxn02317_c0" name="ITP:D-Tagatose 6-phosphate 1-phosphotransferase [c0]" reversible="true" fast="false" fbc:lowerFluxBound="cobra_default_lb" fbc:upperFluxBound="cobra_default_ub">
         <annotation>
           <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
@@ -39376,40 +38498,6 @@
         </listOfProducts>
         <fbc:geneProductAssociation>
           <fbc:geneProductRef fbc:geneProduct="G_ACZ81_RS02135"/>
-        </fbc:geneProductAssociation>
-      </reaction>
-      <reaction metaid="meta_R_rxn07435_c0" sboTerm="SBO:0000176" id="R_rxn07435_c0" name="R07604 [c0]" reversible="true" fast="false" fbc:lowerFluxBound="cobra_default_lb" fbc:upperFluxBound="cobra_default_ub">
-        <annotation>
-          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
-            <rdf:Description rdf:about="#meta_R_rxn07435_c0">
-              <bqbiol:is>
-                <rdf:Bag>
-                  <rdf:li rdf:resource="https://identifiers.org/seed.reaction/rxn07435"/>
-                  <rdf:li rdf:resource="https://identifiers.org/kegg.reaction/R07604"/>
-                  <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR111210"/>
-                  <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR142264"/>
-                  <rdf:li rdf:resource="https://identifiers.org/ec-code/1.2.4.4"/>
-                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K11381"/>
-                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K00166"/>
-                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K00167"/>
-                </rdf:Bag>
-              </bqbiol:is>
-            </rdf:Description>
-          </rdf:RDF>
-        </annotation>
-        <listOfReactants>
-          <speciesReference species="M_cpd14702_c0" stoichiometry="1" constant="true"/>
-          <speciesReference species="M_cpd14954_c0" stoichiometry="1" constant="true"/>
-        </listOfReactants>
-        <listOfProducts>
-          <speciesReference species="M_cpd00056_c0" stoichiometry="1" constant="true"/>
-          <speciesReference species="M_cpd14703_c0" stoichiometry="1" constant="true"/>
-        </listOfProducts>
-        <fbc:geneProductAssociation>
-          <fbc:and>
-            <fbc:geneProductRef fbc:geneProduct="G_ACZ81_RS10150"/>
-            <fbc:geneProductRef fbc:geneProduct="G_ACZ81_RS10145"/>
-          </fbc:and>
         </fbc:geneProductAssociation>
       </reaction>
       <reaction metaid="meta_R_rxn01678_c0" sboTerm="SBO:0000176" id="R_rxn01678_c0" name="ATP:dUDP phosphotransferase [c0]" reversible="true" fast="false" fbc:lowerFluxBound="cobra_default_lb" fbc:upperFluxBound="cobra_default_ub">
@@ -40981,38 +40069,6 @@
             <fbc:geneProductRef fbc:geneProduct="G_ACZ81_RS06160"/>
             <fbc:geneProductRef fbc:geneProduct="G_ACZ81_RS09365"/>
           </fbc:and>
-        </fbc:geneProductAssociation>
-      </reaction>
-      <reaction metaid="meta_R_rxn05619_c0" sboTerm="SBO:0000655" id="R_rxn05619_c0" name="ATP phosphohydrolase (molybdate-importing) [c0]" reversible="false" fast="false" fbc:lowerFluxBound="cobra_0_bound" fbc:upperFluxBound="cobra_default_ub">
-        <annotation>
-          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
-            <rdf:Description rdf:about="#meta_R_rxn05619_c0">
-              <bqbiol:is>
-                <rdf:Bag>
-                  <rdf:li rdf:resource="https://identifiers.org/seed.reaction/rxn05619"/>
-                  <rdf:li rdf:resource="https://identifiers.org/bigg.reaction/MOBDabc"/>
-                  <rdf:li rdf:resource="https://identifiers.org/bigg.reaction/MOBDabcpp"/>
-                  <rdf:li rdf:resource="https://identifiers.org/biocyc/META:3.6.3.29-RXN"/>
-                  <rdf:li rdf:resource="https://identifiers.org/ec-code/3.6.3.29"/>
-                  <rdf:li rdf:resource="https://identifiers.org/ec-code/3.A.1.8.-"/>
-                </rdf:Bag>
-              </bqbiol:is>
-            </rdf:Description>
-          </rdf:RDF>
-        </annotation>
-        <listOfReactants>
-          <speciesReference species="M_cpd00001_c0" stoichiometry="1" constant="true"/>
-          <speciesReference species="M_cpd00002_c0" stoichiometry="1" constant="true"/>
-          <speciesReference species="M_cpd11574_e0" stoichiometry="1" constant="true"/>
-        </listOfReactants>
-        <listOfProducts>
-          <speciesReference species="M_cpd00008_c0" stoichiometry="1" constant="true"/>
-          <speciesReference species="M_cpd00009_c0" stoichiometry="1" constant="true"/>
-          <speciesReference species="M_cpd00067_c0" stoichiometry="1" constant="true"/>
-          <speciesReference species="M_cpd11574_c0" stoichiometry="1" constant="true"/>
-        </listOfProducts>
-        <fbc:geneProductAssociation>
-          <fbc:geneProductRef fbc:geneProduct="G_ACZ81_RS11335"/>
         </fbc:geneProductAssociation>
       </reaction>
       <reaction metaid="meta_R_rxn08020_c0" sboTerm="SBO:0000176" id="R_rxn08020_c0" name="laurate-[acyl-carrier-protein] ligase [c0]" reversible="false" fast="false" fbc:lowerFluxBound="cobra_0_bound" fbc:upperFluxBound="cobra_default_ub">
@@ -42865,32 +41921,6 @@
           <fbc:geneProductRef fbc:geneProduct="G_ACZ81_RS00495"/>
         </fbc:geneProductAssociation>
       </reaction>
-      <reaction metaid="meta_R_rxn10313_c0" sboTerm="SBO:0000176" id="R_rxn10313_c0" name="isopentadecanoyl-lipoteichoic acid synthesis (n=24), linked, N-acetylglucosamine substituted [c0]" reversible="true" fast="false" fbc:lowerFluxBound="cobra_default_lb" fbc:upperFluxBound="cobra_default_ub">
-        <annotation>
-          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
-            <rdf:Description rdf:about="#meta_R_rxn10313_c0">
-              <bqbiol:is>
-                <rdf:Bag>
-                  <rdf:li rdf:resource="https://identifiers.org/seed.reaction/rxn10313"/>
-                  <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR136309"/>
-                  <rdf:li rdf:resource="https://identifiers.org/ec-code/2.7.8.-"/>
-                </rdf:Bag>
-              </bqbiol:is>
-            </rdf:Description>
-          </rdf:RDF>
-        </annotation>
-        <listOfReactants>
-          <speciesReference species="M_cpd00037_c0" stoichiometry="24" constant="true"/>
-          <speciesReference species="M_cpd15752_c0" stoichiometry="1" constant="true"/>
-        </listOfReactants>
-        <listOfProducts>
-          <speciesReference species="M_cpd00014_c0" stoichiometry="24" constant="true"/>
-          <speciesReference species="M_cpd15770_c0" stoichiometry="1" constant="true"/>
-        </listOfProducts>
-        <fbc:geneProductAssociation>
-          <fbc:geneProductRef fbc:geneProduct="G_ACZ81_RS04710"/>
-        </fbc:geneProductAssociation>
-      </reaction>
       <reaction metaid="meta_R_rxn00675_c0" sboTerm="SBO:0000176" id="R_rxn00675_c0" name="Propionyladenylate:CoA propionyltransferase [c0]" reversible="false" fast="false" fbc:lowerFluxBound="cobra_0_bound" fbc:upperFluxBound="cobra_default_ub">
         <annotation>
           <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
@@ -43632,35 +42662,6 @@
             <fbc:geneProductRef fbc:geneProduct="G_ACZ81_RS10335"/>
             <fbc:geneProductRef fbc:geneProduct="G_ACZ81_RS03960"/>
           </fbc:and>
-        </fbc:geneProductAssociation>
-      </reaction>
-      <reaction metaid="meta_R_rxn06586_c0" sboTerm="SBO:0000176" id="R_rxn06586_c0" name="3-methylbutanoyl-CoA:enzyme N6-(dihydrolipoyl)lysine S-(3-methylbutanoyl)transferase [c0]" reversible="true" fast="false" fbc:lowerFluxBound="cobra_default_lb" fbc:upperFluxBound="cobra_default_ub">
-        <annotation>
-          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
-            <rdf:Description rdf:about="#meta_R_rxn06586_c0">
-              <bqbiol:is>
-                <rdf:Bag>
-                  <rdf:li rdf:resource="https://identifiers.org/seed.reaction/rxn06586"/>
-                  <rdf:li rdf:resource="https://identifiers.org/kegg.reaction/R04097"/>
-                  <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR108654"/>
-                  <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR142209"/>
-                  <rdf:li rdf:resource="https://identifiers.org/ec-code/2.3.1.168"/>
-                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K09699"/>
-                </rdf:Bag>
-              </bqbiol:is>
-            </rdf:Description>
-          </rdf:RDF>
-        </annotation>
-        <listOfReactants>
-          <speciesReference species="M_cpd01882_c0" stoichiometry="1" constant="true"/>
-          <speciesReference species="M_cpd16584_c0" stoichiometry="1" constant="true"/>
-        </listOfReactants>
-        <listOfProducts>
-          <speciesReference species="M_cpd00010_c0" stoichiometry="1" constant="true"/>
-          <speciesReference species="M_cpd14699_c0" stoichiometry="1" constant="true"/>
-        </listOfProducts>
-        <fbc:geneProductAssociation>
-          <fbc:geneProductRef fbc:geneProduct="G_ACZ81_RS10155"/>
         </fbc:geneProductAssociation>
       </reaction>
       <reaction metaid="meta_R_rxn12510_c0" sboTerm="SBO:0000176" id="R_rxn12510_c0" name="ATP:pantothenate 4&apos;-phosphotransferase [c0]" reversible="false" fast="false" fbc:lowerFluxBound="cobra_0_bound" fbc:upperFluxBound="cobra_default_ub">
@@ -44976,33 +43977,6 @@
         </listOfProducts>
         <fbc:geneProductAssociation>
           <fbc:geneProductRef fbc:geneProduct="G_ACZ81_RS00130"/>
-        </fbc:geneProductAssociation>
-      </reaction>
-      <reaction metaid="meta_R_rxn05315_c0" sboTerm="SBO:0000655" id="R_rxn05315_c0" name="ZN2t4 [c0]" reversible="true" fast="false" fbc:lowerFluxBound="cobra_default_lb" fbc:upperFluxBound="cobra_default_ub">
-        <annotation>
-          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
-            <rdf:Description rdf:about="#meta_R_rxn05315_c0">
-              <bqbiol:is>
-                <rdf:Bag>
-                  <rdf:li rdf:resource="https://identifiers.org/seed.reaction/rxn05315"/>
-                  <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR105279"/>
-                </rdf:Bag>
-              </bqbiol:is>
-            </rdf:Description>
-          </rdf:RDF>
-        </annotation>
-        <listOfReactants>
-          <speciesReference species="M_cpd00034_c0" stoichiometry="1" constant="true"/>
-          <speciesReference species="M_cpd00067_e0" stoichiometry="1" constant="true"/>
-          <speciesReference species="M_cpd00205_e0" stoichiometry="1" constant="true"/>
-        </listOfReactants>
-        <listOfProducts>
-          <speciesReference species="M_cpd00034_e0" stoichiometry="1" constant="true"/>
-          <speciesReference species="M_cpd00067_c0" stoichiometry="1" constant="true"/>
-          <speciesReference species="M_cpd00205_c0" stoichiometry="1" constant="true"/>
-        </listOfProducts>
-        <fbc:geneProductAssociation>
-          <fbc:geneProductRef fbc:geneProduct="G_ACZ81_RS18540"/>
         </fbc:geneProductAssociation>
       </reaction>
       <reaction metaid="meta_R_rxn05394_c0" sboTerm="SBO:0000176" id="R_rxn05394_c0" name="9-methyl-3-hydroxy-decanoyl-ACP hydro-lyase [c0]" reversible="true" fast="false" fbc:lowerFluxBound="cobra_default_lb" fbc:upperFluxBound="cobra_default_ub">
@@ -47273,37 +46247,6 @@
           <fbc:geneProductRef fbc:geneProduct="G_ACZ81_RS04710"/>
         </fbc:geneProductAssociation>
       </reaction>
-      <reaction metaid="meta_R_rxn02021_c0" sboTerm="SBO:0000176" id="R_rxn02021_c0" name="Hg:NADP+ oxidoreductase [c0]" reversible="true" fast="false" fbc:lowerFluxBound="cobra_default_lb" fbc:upperFluxBound="cobra_default_ub">
-        <annotation>
-          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
-            <rdf:Description rdf:about="#meta_R_rxn02021_c0">
-              <bqbiol:is>
-                <rdf:Bag>
-                  <rdf:li rdf:resource="https://identifiers.org/seed.reaction/rxn02021"/>
-                  <rdf:li rdf:resource="https://identifiers.org/kegg.reaction/R02807"/>
-                  <rdf:li rdf:resource="https://identifiers.org/rhea/23859"/>
-                  <rdf:li rdf:resource="https://identifiers.org/rhea/23858"/>
-                  <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR107738"/>
-                  <rdf:li rdf:resource="https://identifiers.org/biocyc/META:MERCURY-II-REDUCTASE-RXN"/>
-                  <rdf:li rdf:resource="https://identifiers.org/ec-code/1.16.1.1"/>
-                </rdf:Bag>
-              </bqbiol:is>
-            </rdf:Description>
-          </rdf:RDF>
-        </annotation>
-        <listOfReactants>
-          <speciesReference species="M_cpd00006_c0" stoichiometry="1" constant="true"/>
-          <speciesReference species="M_cpd00965_c0" stoichiometry="1" constant="true"/>
-        </listOfReactants>
-        <listOfProducts>
-          <speciesReference species="M_cpd00005_c0" stoichiometry="1" constant="true"/>
-          <speciesReference species="M_cpd00067_c0" stoichiometry="1" constant="true"/>
-          <speciesReference species="M_cpd00531_c0" stoichiometry="1" constant="true"/>
-        </listOfProducts>
-        <fbc:geneProductAssociation>
-          <fbc:geneProductRef fbc:geneProduct="G_ACZ81_RS08905"/>
-        </fbc:geneProductAssociation>
-      </reaction>
       <reaction metaid="meta_R_rxn09211_c0" sboTerm="SBO:0000176" id="R_rxn09211_c0" name="Phosphatidylserine syntase (n-C18:1) [c0]" reversible="false" fast="false" fbc:lowerFluxBound="cobra_0_bound" fbc:upperFluxBound="cobra_default_ub">
         <annotation>
           <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
@@ -47797,33 +46740,6 @@
             <fbc:geneProductRef fbc:geneProduct="G_ACZ81_RS13925"/>
             <fbc:geneProductRef fbc:geneProduct="G_ACZ81_RS13925"/>
           </fbc:or>
-        </fbc:geneProductAssociation>
-      </reaction>
-      <reaction metaid="meta_R_rxn05517_c0" sboTerm="SBO:0000655" id="R_rxn05517_c0" name="cadminum transport out via antiport [c0]" reversible="true" fast="false" fbc:lowerFluxBound="cobra_default_lb" fbc:upperFluxBound="cobra_default_ub">
-        <annotation>
-          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
-            <rdf:Description rdf:about="#meta_R_rxn05517_c0">
-              <bqbiol:is>
-                <rdf:Bag>
-                  <rdf:li rdf:resource="https://identifiers.org/seed.reaction/rxn05517"/>
-                  <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR96498"/>
-                </rdf:Bag>
-              </bqbiol:is>
-            </rdf:Description>
-          </rdf:RDF>
-        </annotation>
-        <listOfReactants>
-          <speciesReference species="M_cpd00067_e0" stoichiometry="1" constant="true"/>
-          <speciesReference species="M_cpd00205_e0" stoichiometry="1" constant="true"/>
-          <speciesReference species="M_cpd01012_c0" stoichiometry="1" constant="true"/>
-        </listOfReactants>
-        <listOfProducts>
-          <speciesReference species="M_cpd00067_c0" stoichiometry="1" constant="true"/>
-          <speciesReference species="M_cpd00205_c0" stoichiometry="1" constant="true"/>
-          <speciesReference species="M_cpd01012_e0" stoichiometry="1" constant="true"/>
-        </listOfProducts>
-        <fbc:geneProductAssociation>
-          <fbc:geneProductRef fbc:geneProduct="G_ACZ81_RS18540"/>
         </fbc:geneProductAssociation>
       </reaction>
       <reaction metaid="meta_R_rxn03249_c0" sboTerm="SBO:0000176" id="R_rxn03249_c0" name="(S)-hydroxyhexanoyl-CoA:NAD+ oxidoreductase [c0]" reversible="true" fast="false" fbc:lowerFluxBound="cobra_default_lb" fbc:upperFluxBound="cobra_default_ub">
@@ -48515,46 +47431,6 @@
         </listOfProducts>
         <fbc:geneProductAssociation>
           <fbc:geneProductRef fbc:geneProduct="G_ACZ81_RS01015"/>
-        </fbc:geneProductAssociation>
-      </reaction>
-      <reaction metaid="meta_R_rxn00569_c0" sboTerm="SBO:0000176" id="R_rxn00569_c0" name="Nitrite reductase (NAD(P)H) [c0]" reversible="false" fast="false" fbc:lowerFluxBound="cobra_0_bound" fbc:upperFluxBound="cobra_default_ub">
-        <annotation>
-          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
-            <rdf:Description rdf:about="#meta_R_rxn00569_c0">
-              <bqbiol:is>
-                <rdf:Bag>
-                  <rdf:li rdf:resource="https://identifiers.org/seed.reaction/rxn00569"/>
-                  <rdf:li rdf:resource="https://identifiers.org/bigg.reaction/NTRIRy"/>
-                  <rdf:li rdf:resource="https://identifiers.org/bigg.reaction/NTRIR2y"/>
-                  <rdf:li rdf:resource="https://identifiers.org/kegg.reaction/R00789"/>
-                  <rdf:li rdf:resource="https://identifiers.org/rhea/24635"/>
-                  <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR102063"/>
-                  <rdf:li rdf:resource="https://identifiers.org/biocyc/META:RXN0-6377"/>
-                  <rdf:li rdf:resource="https://identifiers.org/ec-code/1.7.1.4"/>
-                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K17877"/>
-                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K26138"/>
-                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K26139"/>
-                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K00361"/>
-                </rdf:Bag>
-              </bqbiol:is>
-            </rdf:Description>
-          </rdf:RDF>
-        </annotation>
-        <listOfReactants>
-          <speciesReference species="M_cpd00005_c0" stoichiometry="3" constant="true"/>
-          <speciesReference species="M_cpd00067_c0" stoichiometry="5" constant="true"/>
-          <speciesReference species="M_cpd00075_c0" stoichiometry="1" constant="true"/>
-        </listOfReactants>
-        <listOfProducts>
-          <speciesReference species="M_cpd00001_c0" stoichiometry="2" constant="true"/>
-          <speciesReference species="M_cpd00006_c0" stoichiometry="3" constant="true"/>
-          <speciesReference species="M_cpd00013_c0" stoichiometry="1" constant="true"/>
-        </listOfProducts>
-        <fbc:geneProductAssociation>
-          <fbc:and>
-            <fbc:geneProductRef fbc:geneProduct="G_ACZ81_RS03110"/>
-            <fbc:geneProductRef fbc:geneProduct="G_ACZ81_RS03115"/>
-          </fbc:and>
         </fbc:geneProductAssociation>
       </reaction>
       <reaction metaid="meta_R_rxn05341_c0" sboTerm="SBO:0000176" id="R_rxn05341_c0" name="(3R)-3-Hydroxyoctanoyl-[acyl-carrier-protein]:NADP+ oxidoreductase [c0]" reversible="true" fast="false" fbc:lowerFluxBound="cobra_default_lb" fbc:upperFluxBound="cobra_default_ub">
@@ -49780,40 +48656,6 @@
           <fbc:geneProductRef fbc:geneProduct="G_ACZ81_RS11740"/>
         </fbc:geneProductAssociation>
       </reaction>
-      <reaction metaid="meta_R_rxn08808_c0" sboTerm="SBO:0000176" id="R_rxn08808_c0" name="Lysophospholipase L1 (2-acylglycerophosphoethanolamine, n-C18:0) (periplasm) [c0]" reversible="false" fast="false" fbc:lowerFluxBound="cobra_0_bound" fbc:upperFluxBound="cobra_default_ub">
-        <annotation>
-          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
-            <rdf:Description rdf:about="#meta_R_rxn08808_c0">
-              <bqbiol:is>
-                <rdf:Bag>
-                  <rdf:li rdf:resource="https://identifiers.org/seed.reaction/rxn08808"/>
-                  <rdf:li rdf:resource="https://identifiers.org/bigg.reaction/LPLIPAL1E180pp"/>
-                  <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR142315"/>
-                  <rdf:li rdf:resource="https://identifiers.org/ec-code/3.1.1.5"/>
-                </rdf:Bag>
-              </bqbiol:is>
-            </rdf:Description>
-          </rdf:RDF>
-        </annotation>
-        <listOfReactants>
-          <speciesReference species="M_cpd00001_c0" stoichiometry="1" constant="true"/>
-          <speciesReference species="M_cpd00067_c0" stoichiometry="1" constant="true"/>
-          <speciesReference species="M_cpd12547_c0" stoichiometry="1" constant="true"/>
-        </listOfReactants>
-        <listOfProducts>
-          <speciesReference species="M_cpd00908_c0" stoichiometry="1" constant="true"/>
-          <speciesReference species="M_cpd01080_c0" stoichiometry="1" constant="true"/>
-        </listOfProducts>
-        <fbc:geneProductAssociation>
-          <fbc:or>
-            <fbc:and>
-              <fbc:geneProductRef fbc:geneProduct="G_ACZ81_RS14850"/>
-              <fbc:geneProductRef fbc:geneProduct="G_ACZ81_RS06225"/>
-            </fbc:and>
-            <fbc:geneProductRef fbc:geneProduct="G_ACZ81_RS02100"/>
-          </fbc:or>
-        </fbc:geneProductAssociation>
-      </reaction>
       <reaction metaid="meta_R_rxn00558_c0" sboTerm="SBO:0000176" id="R_rxn00558_c0" name="D-glucose-6-phosphate aldose-ketose-isomerase [c0]" reversible="true" fast="false" fbc:lowerFluxBound="cobra_default_lb" fbc:upperFluxBound="cobra_default_ub">
         <annotation>
           <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
@@ -49885,42 +48727,6 @@
             <fbc:geneProductRef fbc:geneProduct="G_ACZ81_RS17795"/>
             <fbc:geneProductRef fbc:geneProduct="G_ACZ81_RS08315"/>
           </fbc:or>
-        </fbc:geneProductAssociation>
-      </reaction>
-      <reaction metaid="meta_R_rxn05297_c0" sboTerm="SBO:0000655" id="R_rxn05297_c0" name="TRANS-RXNBWI-115637.ce.maizeexp.GLT_GLT [c0]" reversible="true" fast="false" fbc:lowerFluxBound="cobra_default_lb" fbc:upperFluxBound="cobra_default_ub">
-        <annotation>
-          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
-            <rdf:Description rdf:about="#meta_R_rxn05297_c0">
-              <bqbiol:is>
-                <rdf:Bag>
-                  <rdf:li rdf:resource="https://identifiers.org/seed.reaction/rxn05297"/>
-                  <rdf:li rdf:resource="https://identifiers.org/bigg.reaction/GLUt2"/>
-                  <rdf:li rdf:resource="https://identifiers.org/bigg.reaction/GLUt2rpp"/>
-                  <rdf:li rdf:resource="https://identifiers.org/bigg.reaction/GLUt7"/>
-                  <rdf:li rdf:resource="https://identifiers.org/bigg.reaction/GLUt2m"/>
-                  <rdf:li rdf:resource="https://identifiers.org/bigg.reaction/GLUt6"/>
-                  <rdf:li rdf:resource="https://identifiers.org/bigg.reaction/GLUt2n"/>
-                  <rdf:li rdf:resource="https://identifiers.org/bigg.reaction/AGC1_1"/>
-                  <rdf:li rdf:resource="https://identifiers.org/bigg.reaction/GLUt2r"/>
-                  <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR100300"/>
-                </rdf:Bag>
-              </bqbiol:is>
-            </rdf:Description>
-          </rdf:RDF>
-        </annotation>
-        <listOfReactants>
-          <speciesReference species="M_cpd00023_e0" stoichiometry="1" constant="true"/>
-          <speciesReference species="M_cpd00067_e0" stoichiometry="1" constant="true"/>
-        </listOfReactants>
-        <listOfProducts>
-          <speciesReference species="M_cpd00023_c0" stoichiometry="1" constant="true"/>
-          <speciesReference species="M_cpd00067_c0" stoichiometry="1" constant="true"/>
-        </listOfProducts>
-        <fbc:geneProductAssociation>
-          <fbc:and>
-            <fbc:geneProductRef fbc:geneProduct="G_ACZ81_RS07450"/>
-            <fbc:geneProductRef fbc:geneProduct="G_ACZ81_RS08425"/>
-          </fbc:and>
         </fbc:geneProductAssociation>
       </reaction>
       <reaction metaid="meta_R_rxn00194_c0" sboTerm="SBO:0000176" id="R_rxn00194_c0" name="L-glutamate 1-carboxy-lyase (4-aminobutanoate-forming) [c0]" reversible="false" fast="false" fbc:lowerFluxBound="cobra_0_bound" fbc:upperFluxBound="cobra_default_ub">
@@ -50511,32 +49317,6 @@
         </listOfProducts>
         <fbc:geneProductAssociation>
           <fbc:geneProductRef fbc:geneProduct="G_ACZ81_RS18860"/>
-        </fbc:geneProductAssociation>
-      </reaction>
-      <reaction metaid="meta_R_rxn10309_c0" sboTerm="SBO:0000176" id="R_rxn10309_c0" name="stearoyl-lipoteichoic acid synthesis (n=24), linked, N-acetylglucosamine substituted [c0]" reversible="true" fast="false" fbc:lowerFluxBound="cobra_default_lb" fbc:upperFluxBound="cobra_default_ub">
-        <annotation>
-          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
-            <rdf:Description rdf:about="#meta_R_rxn10309_c0">
-              <bqbiol:is>
-                <rdf:Bag>
-                  <rdf:li rdf:resource="https://identifiers.org/seed.reaction/rxn10309"/>
-                  <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR136305"/>
-                  <rdf:li rdf:resource="https://identifiers.org/ec-code/2.7.8.-"/>
-                </rdf:Bag>
-              </bqbiol:is>
-            </rdf:Description>
-          </rdf:RDF>
-        </annotation>
-        <listOfReactants>
-          <speciesReference species="M_cpd00037_c0" stoichiometry="24" constant="true"/>
-          <speciesReference species="M_cpd15748_c0" stoichiometry="1" constant="true"/>
-        </listOfReactants>
-        <listOfProducts>
-          <speciesReference species="M_cpd00014_c0" stoichiometry="24" constant="true"/>
-          <speciesReference species="M_cpd15766_c0" stoichiometry="1" constant="true"/>
-        </listOfProducts>
-        <fbc:geneProductAssociation>
-          <fbc:geneProductRef fbc:geneProduct="G_ACZ81_RS04710"/>
         </fbc:geneProductAssociation>
       </reaction>
       <reaction metaid="meta_R_rxn05249_c0" sboTerm="SBO:0000176" id="R_rxn05249_c0" name="FACOAL150(ISO) [c0]" reversible="false" fast="false" fbc:lowerFluxBound="cobra_0_bound" fbc:upperFluxBound="cobra_default_ub">
@@ -51767,32 +50547,6 @@
         </listOfProducts>
         <fbc:geneProductAssociation>
           <fbc:geneProductRef fbc:geneProduct="G_ACZ81_RS12205"/>
-        </fbc:geneProductAssociation>
-      </reaction>
-      <reaction metaid="meta_R_rxn10315_c0" sboTerm="SBO:0000176" id="R_rxn10315_c0" name="isohexadecanoyl-lipoteichoic acid synthesis (n=24), linked, N-acetylglucosamine substituted [c0]" reversible="true" fast="false" fbc:lowerFluxBound="cobra_default_lb" fbc:upperFluxBound="cobra_default_ub">
-        <annotation>
-          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
-            <rdf:Description rdf:about="#meta_R_rxn10315_c0">
-              <bqbiol:is>
-                <rdf:Bag>
-                  <rdf:li rdf:resource="https://identifiers.org/seed.reaction/rxn10315"/>
-                  <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR136311"/>
-                  <rdf:li rdf:resource="https://identifiers.org/ec-code/2.7.8.-"/>
-                </rdf:Bag>
-              </bqbiol:is>
-            </rdf:Description>
-          </rdf:RDF>
-        </annotation>
-        <listOfReactants>
-          <speciesReference species="M_cpd00037_c0" stoichiometry="24" constant="true"/>
-          <speciesReference species="M_cpd15754_c0" stoichiometry="1" constant="true"/>
-        </listOfReactants>
-        <listOfProducts>
-          <speciesReference species="M_cpd00014_c0" stoichiometry="24" constant="true"/>
-          <speciesReference species="M_cpd15772_c0" stoichiometry="1" constant="true"/>
-        </listOfProducts>
-        <fbc:geneProductAssociation>
-          <fbc:geneProductRef fbc:geneProduct="G_ACZ81_RS04710"/>
         </fbc:geneProductAssociation>
       </reaction>
       <reaction metaid="meta_R_rxn01434_c0" sboTerm="SBO:0000176" id="R_rxn01434_c0" name="L-Citrulline:L-aspartate ligase (AMP-forming) [c0]" reversible="false" fast="false" fbc:lowerFluxBound="cobra_0_bound" fbc:upperFluxBound="cobra_default_ub">
@@ -54357,39 +53111,6 @@
           </fbc:or>
         </fbc:geneProductAssociation>
       </reaction>
-      <reaction metaid="meta_R_rxn01662_c0" sboTerm="SBO:0000176" id="R_rxn01662_c0" name="N6-(L-1,3-Dicarboxypropyl)-L-lysine:NAD+ oxidoreductase [c0]" reversible="true" fast="false" fbc:lowerFluxBound="cobra_default_lb" fbc:upperFluxBound="cobra_default_ub">
-        <annotation>
-          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
-            <rdf:Description rdf:about="#meta_R_rxn01662_c0">
-              <bqbiol:is>
-                <rdf:Bag>
-                  <rdf:li rdf:resource="https://identifiers.org/seed.reaction/rxn01662"/>
-                  <rdf:li rdf:resource="https://identifiers.org/kegg.reaction/R02313"/>
-                  <rdf:li rdf:resource="https://identifiers.org/rhea/24523"/>
-                  <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR105347"/>
-                  <rdf:li rdf:resource="https://identifiers.org/biocyc/META:1.5.1.9-RXN"/>
-                  <rdf:li rdf:resource="https://identifiers.org/ec-code/1.5.1.9"/>
-                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K14157"/>
-                </rdf:Bag>
-              </bqbiol:is>
-            </rdf:Description>
-          </rdf:RDF>
-        </annotation>
-        <listOfReactants>
-          <speciesReference species="M_cpd00001_c0" stoichiometry="1" constant="true"/>
-          <speciesReference species="M_cpd00003_c0" stoichiometry="1" constant="true"/>
-          <speciesReference species="M_cpd00351_c0" stoichiometry="1" constant="true"/>
-        </listOfReactants>
-        <listOfProducts>
-          <speciesReference species="M_cpd00004_c0" stoichiometry="1" constant="true"/>
-          <speciesReference species="M_cpd00023_c0" stoichiometry="1" constant="true"/>
-          <speciesReference species="M_cpd00067_c0" stoichiometry="1" constant="true"/>
-          <speciesReference species="M_cpd02522_c0" stoichiometry="1" constant="true"/>
-        </listOfProducts>
-        <fbc:geneProductAssociation>
-          <fbc:geneProductRef fbc:geneProduct="G_ACZ81_RS11415"/>
-        </fbc:geneProductAssociation>
-      </reaction>
       <reaction metaid="meta_R_rxn00342_c0" sboTerm="SBO:0000176" id="R_rxn00342_c0" name="L-Asparagine amidohydrolase [c0]" reversible="false" fast="false" fbc:lowerFluxBound="cobra_0_bound" fbc:upperFluxBound="cobra_default_ub">
         <annotation>
           <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
@@ -55406,40 +54127,6 @@
           <fbc:geneProductRef fbc:geneProduct="G_ACZ81_RS02060"/>
         </fbc:geneProductAssociation>
       </reaction>
-      <reaction metaid="meta_R_rxn02222_c0" sboTerm="SBO:0000176" id="R_rxn02222_c0" name="Indole-3-acetamide amidohydrolase [c0]" reversible="false" fast="false" fbc:lowerFluxBound="cobra_0_bound" fbc:upperFluxBound="cobra_default_ub">
-        <annotation>
-          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
-            <rdf:Description rdf:about="#meta_R_rxn02222_c0">
-              <bqbiol:is>
-                <rdf:Bag>
-                  <rdf:li rdf:resource="https://identifiers.org/seed.reaction/rxn02222"/>
-                  <rdf:li rdf:resource="https://identifiers.org/bigg.reaction/AMD2_3"/>
-                  <rdf:li rdf:resource="https://identifiers.org/bigg.reaction/AMID3"/>
-                  <rdf:li rdf:resource="https://identifiers.org/kegg.reaction/R03096"/>
-                  <rdf:li rdf:resource="https://identifiers.org/rhea/34372"/>
-                  <rdf:li rdf:resource="https://identifiers.org/rhea/34374"/>
-                  <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR95814"/>
-                  <rdf:li rdf:resource="https://identifiers.org/biocyc/META:RXNN-404"/>
-                  <rdf:li rdf:resource="https://identifiers.org/ec-code/3.5.1.4"/>
-                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K01426"/>
-                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K21801"/>
-                </rdf:Bag>
-              </bqbiol:is>
-            </rdf:Description>
-          </rdf:RDF>
-        </annotation>
-        <listOfReactants>
-          <speciesReference species="M_cpd00001_c0" stoichiometry="1" constant="true"/>
-          <speciesReference species="M_cpd01747_c0" stoichiometry="1" constant="true"/>
-        </listOfReactants>
-        <listOfProducts>
-          <speciesReference species="M_cpd00013_c0" stoichiometry="1" constant="true"/>
-          <speciesReference species="M_cpd00703_c0" stoichiometry="1" constant="true"/>
-        </listOfProducts>
-        <fbc:geneProductAssociation>
-          <fbc:geneProductRef fbc:geneProduct="G_ACZ81_RS18160"/>
-        </fbc:geneProductAssociation>
-      </reaction>
       <reaction metaid="meta_R_rxn02093_c0" sboTerm="SBO:0000176" id="R_rxn02093_c0" name="Melibiitol galactohydrolase [c0]" reversible="true" fast="false" fbc:lowerFluxBound="cobra_default_lb" fbc:upperFluxBound="cobra_default_ub">
         <annotation>
           <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
@@ -55702,32 +54389,6 @@
         </listOfProducts>
         <fbc:geneProductAssociation>
           <fbc:geneProductRef fbc:geneProduct="G_ACZ81_RS13010"/>
-        </fbc:geneProductAssociation>
-      </reaction>
-      <reaction metaid="meta_R_rxn10308_c0" sboTerm="SBO:0000176" id="R_rxn10308_c0" name="myristoyl-lipoteichoic acid synthesis (n=24), linked, N-acetylglucosamine substituted [c0]" reversible="true" fast="false" fbc:lowerFluxBound="cobra_default_lb" fbc:upperFluxBound="cobra_default_ub">
-        <annotation>
-          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
-            <rdf:Description rdf:about="#meta_R_rxn10308_c0">
-              <bqbiol:is>
-                <rdf:Bag>
-                  <rdf:li rdf:resource="https://identifiers.org/seed.reaction/rxn10308"/>
-                  <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR136304"/>
-                  <rdf:li rdf:resource="https://identifiers.org/ec-code/2.7.8.-"/>
-                </rdf:Bag>
-              </bqbiol:is>
-            </rdf:Description>
-          </rdf:RDF>
-        </annotation>
-        <listOfReactants>
-          <speciesReference species="M_cpd00037_c0" stoichiometry="24" constant="true"/>
-          <speciesReference species="M_cpd15747_c0" stoichiometry="1" constant="true"/>
-        </listOfReactants>
-        <listOfProducts>
-          <speciesReference species="M_cpd00014_c0" stoichiometry="24" constant="true"/>
-          <speciesReference species="M_cpd15765_c0" stoichiometry="1" constant="true"/>
-        </listOfProducts>
-        <fbc:geneProductAssociation>
-          <fbc:geneProductRef fbc:geneProduct="G_ACZ81_RS04710"/>
         </fbc:geneProductAssociation>
       </reaction>
       <reaction metaid="meta_R_rxn06526_c0" sboTerm="SBO:0000176" id="R_rxn06526_c0" name="protein-dithiol:NADP+ oxidoreductase [c0]" reversible="true" fast="false" fbc:lowerFluxBound="cobra_default_lb" fbc:upperFluxBound="cobra_default_ub">
@@ -57043,32 +55704,6 @@
           <fbc:geneProductRef fbc:geneProduct="G_ACZ81_RS00310"/>
         </fbc:geneProductAssociation>
       </reaction>
-      <reaction metaid="meta_R_rxn10312_c0" sboTerm="SBO:0000176" id="R_rxn10312_c0" name="isotetradecanoyl-lipoteichoic acid synthesis (n=24), linked, N-acetylglucosamine substituted [c0]" reversible="true" fast="false" fbc:lowerFluxBound="cobra_default_lb" fbc:upperFluxBound="cobra_default_ub">
-        <annotation>
-          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
-            <rdf:Description rdf:about="#meta_R_rxn10312_c0">
-              <bqbiol:is>
-                <rdf:Bag>
-                  <rdf:li rdf:resource="https://identifiers.org/seed.reaction/rxn10312"/>
-                  <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR136308"/>
-                  <rdf:li rdf:resource="https://identifiers.org/ec-code/2.7.8.-"/>
-                </rdf:Bag>
-              </bqbiol:is>
-            </rdf:Description>
-          </rdf:RDF>
-        </annotation>
-        <listOfReactants>
-          <speciesReference species="M_cpd00037_c0" stoichiometry="24" constant="true"/>
-          <speciesReference species="M_cpd15751_c0" stoichiometry="1" constant="true"/>
-        </listOfReactants>
-        <listOfProducts>
-          <speciesReference species="M_cpd00014_c0" stoichiometry="24" constant="true"/>
-          <speciesReference species="M_cpd15769_c0" stoichiometry="1" constant="true"/>
-        </listOfProducts>
-        <fbc:geneProductAssociation>
-          <fbc:geneProductRef fbc:geneProduct="G_ACZ81_RS04710"/>
-        </fbc:geneProductAssociation>
-      </reaction>
       <reaction metaid="meta_R_rxn00674_c0" sboTerm="SBO:0000176" id="R_rxn00674_c0" name="Propanoate:CoA ligase (AMP-forming) [c0]" reversible="false" fast="false" fbc:lowerFluxBound="cobra_0_bound" fbc:upperFluxBound="cobra_default_ub">
         <annotation>
           <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
@@ -57198,35 +55833,6 @@
         </listOfProducts>
         <fbc:geneProductAssociation>
           <fbc:geneProductRef fbc:geneProduct="G_ACZ81_RS02050"/>
-        </fbc:geneProductAssociation>
-      </reaction>
-      <reaction metaid="meta_R_rxn06335_c0" sboTerm="SBO:0000176" id="R_rxn06335_c0" name="(S)-2-methylbutanoyl-CoA:enzyme N6-(dihydrolipoyl)lysine S-(2-methylbutanoyl)transferase [c0]" reversible="true" fast="false" fbc:lowerFluxBound="cobra_default_lb" fbc:upperFluxBound="cobra_default_ub">
-        <annotation>
-          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
-            <rdf:Description rdf:about="#meta_R_rxn06335_c0">
-              <bqbiol:is>
-                <rdf:Bag>
-                  <rdf:li rdf:resource="https://identifiers.org/seed.reaction/rxn06335"/>
-                  <rdf:li rdf:resource="https://identifiers.org/kegg.reaction/R03174"/>
-                  <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR135216"/>
-                  <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR108002"/>
-                  <rdf:li rdf:resource="https://identifiers.org/ec-code/2.3.1.168"/>
-                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K09699"/>
-                </rdf:Bag>
-              </bqbiol:is>
-            </rdf:Description>
-          </rdf:RDF>
-        </annotation>
-        <listOfReactants>
-          <speciesReference species="M_cpd00760_c0" stoichiometry="1" constant="true"/>
-          <speciesReference species="M_cpd16584_c0" stoichiometry="1" constant="true"/>
-        </listOfReactants>
-        <listOfProducts>
-          <speciesReference species="M_cpd00010_c0" stoichiometry="1" constant="true"/>
-          <speciesReference species="M_cpd14703_c0" stoichiometry="1" constant="true"/>
-        </listOfProducts>
-        <fbc:geneProductAssociation>
-          <fbc:geneProductRef fbc:geneProduct="G_ACZ81_RS10155"/>
         </fbc:geneProductAssociation>
       </reaction>
       <reaction metaid="meta_R_rxn08849_c0" sboTerm="SBO:0000176" id="R_rxn08849_c0" name="Lysophospholipase L2 (2-acylglycerophosphoglycerol, n-C16:1) [c0]" reversible="true" fast="false" fbc:lowerFluxBound="cobra_default_lb" fbc:upperFluxBound="cobra_default_ub">
@@ -58642,34 +57248,6 @@
           <fbc:geneProductRef fbc:geneProduct="G_ACZ81_RS12805"/>
         </fbc:geneProductAssociation>
       </reaction>
-      <reaction metaid="meta_R_rxn45996_c0" sboTerm="SBO:0000176" id="R_rxn45996_c0" name="[c0]" reversible="true" fast="false" fbc:lowerFluxBound="cobra_default_lb" fbc:upperFluxBound="cobra_default_ub">
-        <annotation>
-          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
-            <rdf:Description rdf:about="#meta_R_rxn45996_c0">
-              <bqbiol:is>
-                <rdf:Bag>
-                  <rdf:li rdf:resource="https://identifiers.org/seed.reaction/rxn45996"/>
-                  <rdf:li rdf:resource="https://identifiers.org/rhea/49581"/>
-                  <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR121181"/>
-                  <rdf:li rdf:resource="https://identifiers.org/biocyc/META:RXN-17809"/>
-                  <rdf:li rdf:resource="https://identifiers.org/ec-code/4.6.1.17"/>
-                </rdf:Bag>
-              </bqbiol:is>
-            </rdf:Description>
-          </rdf:RDF>
-        </annotation>
-        <listOfReactants>
-          <speciesReference species="M_cpd00001_c0" stoichiometry="1" constant="true"/>
-          <speciesReference species="M_cpd36025_c0" stoichiometry="1" constant="true"/>
-        </listOfReactants>
-        <listOfProducts>
-          <speciesReference species="M_cpd00012_c0" stoichiometry="1" constant="true"/>
-          <speciesReference species="M_cpd19505_c0" stoichiometry="1" constant="true"/>
-        </listOfProducts>
-        <fbc:geneProductAssociation>
-          <fbc:geneProductRef fbc:geneProduct="G_ACZ81_RS11355"/>
-        </fbc:geneProductAssociation>
-      </reaction>
       <reaction metaid="meta_R_thiazol_synth" sboTerm="SBO:0000176" id="R_thiazol_synth" name="thiazole synthase [c0]" reversible="false" fast="false" fbc:lowerFluxBound="cobra_0_bound" fbc:upperFluxBound="cobra_default_ub">
         <annotation>
           <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
@@ -58737,34 +57315,6 @@
             <fbc:geneProductRef fbc:geneProduct="G_ACZ81_RS10285"/>
             <fbc:geneProductRef fbc:geneProduct="G_ACZ81_RS10285"/>
           </fbc:or>
-        </fbc:geneProductAssociation>
-      </reaction>
-      <reaction metaid="meta_R_rxn26361_c0" sboTerm="SBO:0000176" id="R_rxn26361_c0" name="molybdenum cofactor cytidylyltransferase [c0]" reversible="true" fast="false" fbc:lowerFluxBound="cobra_default_lb" fbc:upperFluxBound="cobra_default_ub">
-        <annotation>
-          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
-            <rdf:Description rdf:about="#meta_R_rxn26361_c0">
-              <bqbiol:is>
-                <rdf:Bag>
-                  <rdf:li rdf:resource="https://identifiers.org/seed.reaction/rxn26361"/>
-                  <rdf:li rdf:resource="https://identifiers.org/rhea/31338"/>
-                  <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR114874"/>
-                  <rdf:li rdf:resource="https://identifiers.org/biocyc/META:RXN0-6254"/>
-                  <rdf:li rdf:resource="https://identifiers.org/ec-code/2.7.7.76"/>
-                </rdf:Bag>
-              </bqbiol:is>
-            </rdf:Description>
-          </rdf:RDF>
-        </annotation>
-        <listOfReactants>
-          <speciesReference species="M_cpd00052_c0" stoichiometry="1" constant="true"/>
-          <speciesReference species="M_cpd19503_c0" stoichiometry="1" constant="true"/>
-        </listOfReactants>
-        <listOfProducts>
-          <speciesReference species="M_cpd00012_c0" stoichiometry="1" constant="true"/>
-          <speciesReference species="M_cpd21288_c0" stoichiometry="1" constant="true"/>
-        </listOfProducts>
-        <fbc:geneProductAssociation>
-          <fbc:geneProductRef fbc:geneProduct="G_ACZ81_RS10895"/>
         </fbc:geneProductAssociation>
       </reaction>
       <reaction metaid="meta_R_rxn47768_c0" sboTerm="SBO:0000176" id="R_rxn47768_c0" name="3-oxo-glutaryl-[acp] methyl ester synthase [c0]" reversible="true" fast="false" fbc:lowerFluxBound="cobra_default_lb" fbc:upperFluxBound="cobra_default_ub">
@@ -58938,34 +57488,6 @@
           </fbc:and>
         </fbc:geneProductAssociation>
       </reaction>
-      <reaction metaid="meta_R_rxn15972_c0" sboTerm="SBO:0000176" id="R_rxn15972_c0" name="N-acetyl-L-citrulline amidohydrolase [c0]" reversible="true" fast="false" fbc:lowerFluxBound="cobra_default_lb" fbc:upperFluxBound="cobra_default_ub">
-        <annotation>
-          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
-            <rdf:Description rdf:about="#meta_R_rxn15972_c0">
-              <bqbiol:is>
-                <rdf:Bag>
-                  <rdf:li rdf:resource="https://identifiers.org/seed.reaction/rxn15972"/>
-                  <rdf:li rdf:resource="https://identifiers.org/kegg.reaction/R09107"/>
-                  <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR112547"/>
-                  <rdf:li rdf:resource="https://identifiers.org/biocyc/META:RXN-7933"/>
-                  <rdf:li rdf:resource="https://identifiers.org/ec-code/3.5.1.16"/>
-                </rdf:Bag>
-              </bqbiol:is>
-            </rdf:Description>
-          </rdf:RDF>
-        </annotation>
-        <listOfReactants>
-          <speciesReference species="M_cpd00001_c0" stoichiometry="1" constant="true"/>
-          <speciesReference species="M_cpd11209_c0" stoichiometry="1" constant="true"/>
-        </listOfReactants>
-        <listOfProducts>
-          <speciesReference species="M_cpd00029_c0" stoichiometry="1" constant="true"/>
-          <speciesReference species="M_cpd00274_c0" stoichiometry="1" constant="true"/>
-        </listOfProducts>
-        <fbc:geneProductAssociation>
-          <fbc:geneProductRef fbc:geneProduct="G_ACZ81_RS15350"/>
-        </fbc:geneProductAssociation>
-      </reaction>
       <reaction metaid="meta_R_rxn15466_c0" sboTerm="SBO:0000176" id="R_rxn15466_c0" name="(R)-2,3-Dihydroxy-3-methylbutanoate:NADP+ oxidoreductase (isomerizing) [c0]" reversible="true" fast="false" fbc:lowerFluxBound="cobra_default_lb" fbc:upperFluxBound="cobra_default_ub">
         <annotation>
           <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
@@ -59001,31 +57523,6 @@
             <fbc:geneProductRef fbc:geneProduct="G_ACZ81_RS19620"/>
             <fbc:geneProductRef fbc:geneProduct="G_ACZ81_RS19620"/>
           </fbc:or>
-        </fbc:geneProductAssociation>
-      </reaction>
-      <reaction metaid="meta_R_rxn05121_c0" sboTerm="SBO:0000176" id="R_rxn05121_c0" name="R07412 [c0]" reversible="true" fast="false" fbc:lowerFluxBound="cobra_default_lb" fbc:upperFluxBound="cobra_default_ub">
-        <annotation>
-          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
-            <rdf:Description rdf:about="#meta_R_rxn05121_c0">
-              <bqbiol:is>
-                <rdf:Bag>
-                  <rdf:li rdf:resource="https://identifiers.org/seed.reaction/rxn05121"/>
-                  <rdf:li rdf:resource="https://identifiers.org/kegg.reaction/R07412"/>
-                  <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR100591"/>
-                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K02259"/>
-                </rdf:Bag>
-              </bqbiol:is>
-            </rdf:Description>
-          </rdf:RDF>
-        </annotation>
-        <listOfReactants>
-          <speciesReference species="M_cpd11313_c0" stoichiometry="1" constant="true"/>
-        </listOfReactants>
-        <listOfProducts>
-          <speciesReference species="M_cpd11312_c0" stoichiometry="1" constant="true"/>
-        </listOfProducts>
-        <fbc:geneProductAssociation>
-          <fbc:geneProductRef fbc:geneProduct="G_ACZ81_RS19535"/>
         </fbc:geneProductAssociation>
       </reaction>
       <reaction metaid="meta_R_rxn14427_c0" sboTerm="SBO:0000185" id="R_rxn14427_c0" name="Nitrate reductase cytochrome-c type (2 protons translocated) [c0]" reversible="false" fast="false" fbc:lowerFluxBound="cobra_0_bound" fbc:upperFluxBound="cobra_default_ub">
@@ -59337,35 +57834,6 @@
           </fbc:and>
         </fbc:geneProductAssociation>
       </reaction>
-      <reaction metaid="meta_R_rxn09003_c0" sboTerm="SBO:0000185" id="R_rxn09003_c0" name="Nitrate reductase (Menaquinol-8) (periplasm) [c0]" reversible="false" fast="false" fbc:lowerFluxBound="cobra_0_bound" fbc:upperFluxBound="cobra_default_ub">
-        <annotation>
-          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
-            <rdf:Description rdf:about="#meta_R_rxn09003_c0">
-              <bqbiol:is>
-                <rdf:Bag>
-                  <rdf:li rdf:resource="https://identifiers.org/seed.reaction/rxn09003"/>
-                  <rdf:li rdf:resource="https://identifiers.org/bigg.reaction/NO3R2"/>
-                  <rdf:li rdf:resource="https://identifiers.org/bigg.reaction/NO3R2pp"/>
-                  <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR101988"/>
-                </rdf:Bag>
-              </bqbiol:is>
-            </rdf:Description>
-          </rdf:RDF>
-        </annotation>
-        <listOfReactants>
-          <speciesReference species="M_cpd00067_e0" stoichiometry="1" constant="true"/>
-          <speciesReference species="M_cpd00209_c0" stoichiometry="1" constant="true"/>
-          <speciesReference species="M_cpd15499_c0" stoichiometry="1" constant="true"/>
-        </listOfReactants>
-        <listOfProducts>
-          <speciesReference species="M_cpd00001_c0" stoichiometry="1" constant="true"/>
-          <speciesReference species="M_cpd00075_c0" stoichiometry="1" constant="true"/>
-          <speciesReference species="M_cpd15500_c0" stoichiometry="1" constant="true"/>
-        </listOfProducts>
-        <fbc:geneProductAssociation>
-          <fbc:geneProductRef fbc:geneProduct="G_ACZ81_RS03120"/>
-        </fbc:geneProductAssociation>
-      </reaction>
       <reaction metaid="meta_R_rxn14412_c0" sboTerm="SBO:0000185" id="R_rxn14412_c0" name="cytochrome-c reductase (ubiquinol: 2 protons) [c0]" reversible="false" fast="false" fbc:lowerFluxBound="cobra_0_bound" fbc:upperFluxBound="cobra_default_ub">
         <annotation>
           <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
@@ -59523,123 +57991,6 @@
           </fbc:and>
         </fbc:geneProductAssociation>
       </reaction>
-      <reaction metaid="meta_R_rxn09001_c0" sboTerm="SBO:0000185" id="R_rxn09001_c0" name="Nitrate reductase (Ubiquinol-8) (periplasm) [c0]" reversible="false" fast="false" fbc:lowerFluxBound="cobra_0_bound" fbc:upperFluxBound="cobra_default_ub">
-        <annotation>
-          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
-            <rdf:Description rdf:about="#meta_R_rxn09001_c0">
-              <bqbiol:is>
-                <rdf:Bag>
-                  <rdf:li rdf:resource="https://identifiers.org/seed.reaction/rxn09001"/>
-                  <rdf:li rdf:resource="https://identifiers.org/bigg.reaction/NO3R1pp"/>
-                  <rdf:li rdf:resource="https://identifiers.org/bigg.reaction/NO3R1"/>
-                  <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR101986"/>
-                  <rdf:li rdf:resource="https://identifiers.org/ec-code/1.7.99.4"/>
-                </rdf:Bag>
-              </bqbiol:is>
-            </rdf:Description>
-          </rdf:RDF>
-        </annotation>
-        <listOfReactants>
-          <speciesReference species="M_cpd00067_e0" stoichiometry="1" constant="true"/>
-          <speciesReference species="M_cpd00209_c0" stoichiometry="1" constant="true"/>
-          <speciesReference species="M_cpd15561_c0" stoichiometry="1" constant="true"/>
-        </listOfReactants>
-        <listOfProducts>
-          <speciesReference species="M_cpd00001_c0" stoichiometry="1" constant="true"/>
-          <speciesReference species="M_cpd00075_c0" stoichiometry="1" constant="true"/>
-          <speciesReference species="M_cpd15560_c0" stoichiometry="1" constant="true"/>
-        </listOfProducts>
-        <fbc:geneProductAssociation>
-          <fbc:geneProductRef fbc:geneProduct="G_ACZ81_RS03120"/>
-        </fbc:geneProductAssociation>
-      </reaction>
-      <reaction metaid="meta_R_rxn14415_c0" sboTerm="SBO:0000655" id="R_rxn14415_c0" name="cytochrome-c oxidase (2 protons translocated) [c0]" reversible="true" fast="false" fbc:lowerFluxBound="cobra_default_lb" fbc:upperFluxBound="cobra_default_ub">
-        <annotation>
-          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
-            <rdf:Description rdf:about="#meta_R_rxn14415_c0">
-              <bqbiol:is>
-                <rdf:Bag>
-                  <rdf:li rdf:resource="https://identifiers.org/seed.reaction/rxn14415"/>
-                  <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR137923"/>
-                </rdf:Bag>
-              </bqbiol:is>
-            </rdf:Description>
-          </rdf:RDF>
-        </annotation>
-        <listOfReactants>
-          <speciesReference species="M_cpd00007_c0" stoichiometry="0.5" constant="true"/>
-          <speciesReference species="M_cpd00067_c0" stoichiometry="4" constant="true"/>
-          <speciesReference species="M_cpd00110_c0" stoichiometry="3" constant="true"/>
-        </listOfReactants>
-        <listOfProducts>
-          <speciesReference species="M_cpd00001_c0" stoichiometry="1" constant="true"/>
-          <speciesReference species="M_cpd00067_e0" stoichiometry="2" constant="true"/>
-          <speciesReference species="M_cpd00109_c0" stoichiometry="3" constant="true"/>
-        </listOfProducts>
-        <fbc:geneProductAssociation>
-          <fbc:and>
-            <fbc:geneProductRef fbc:geneProduct="G_ACZ81_RS19555"/>
-            <fbc:geneProductRef fbc:geneProduct="G_ACZ81_RS19565"/>
-            <fbc:geneProductRef fbc:geneProduct="G_ACZ81_RS19570"/>
-          </fbc:and>
-        </fbc:geneProductAssociation>
-      </reaction>
-      <reaction metaid="meta_R_rxn41896_c0" sboTerm="SBO:0000176" id="R_rxn41896_c0" name="[c0]" reversible="true" fast="false" fbc:lowerFluxBound="cobra_default_lb" fbc:upperFluxBound="cobra_default_ub">
-        <annotation>
-          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
-            <rdf:Description rdf:about="#meta_R_rxn41896_c0">
-              <bqbiol:is>
-                <rdf:Bag>
-                  <rdf:li rdf:resource="https://identifiers.org/seed.reaction/rxn41896"/>
-                  <rdf:li rdf:resource="https://identifiers.org/rhea/26334"/>
-                  <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR122272"/>
-                  <rdf:li rdf:resource="https://identifiers.org/biocyc/META:RXN-8342"/>
-                  <rdf:li rdf:resource="https://identifiers.org/ec-code/2.8.1.12"/>
-                </rdf:Bag>
-              </bqbiol:is>
-            </rdf:Description>
-          </rdf:RDF>
-        </annotation>
-        <listOfReactants>
-          <speciesReference species="M_cpd00001_c0" stoichiometry="1" constant="true"/>
-          <speciesReference species="M_cpd19505_c0" stoichiometry="1" constant="true"/>
-          <speciesReference species="M_cpd28260_c0" stoichiometry="2" constant="true"/>
-        </listOfReactants>
-        <listOfProducts>
-          <speciesReference species="M_cpd00067_c0" stoichiometry="4" constant="true"/>
-          <speciesReference species="M_cpd03520_c0" stoichiometry="1" constant="true"/>
-          <speciesReference species="M_cpd28253_c0" stoichiometry="2" constant="true"/>
-        </listOfProducts>
-        <fbc:geneProductAssociation>
-          <fbc:geneProductRef fbc:geneProduct="G_ACZ81_RS11345"/>
-        </fbc:geneProductAssociation>
-      </reaction>
-      <reaction metaid="meta_R_rxn21729_c0" sboTerm="SBO:0000176" id="R_rxn21729_c0" name="adenylyltransferase and sulfurtransferase MOCS3 [c0]" reversible="false" fast="false" fbc:lowerFluxBound="cobra_0_bound" fbc:upperFluxBound="cobra_default_ub">
-        <annotation>
-          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
-            <rdf:Description rdf:about="#meta_R_rxn21729_c0">
-              <bqbiol:is>
-                <rdf:Bag>
-                  <rdf:li rdf:resource="https://identifiers.org/seed.reaction/rxn21729"/>
-                  <rdf:li rdf:resource="https://identifiers.org/biocyc/META:RXN-11361"/>
-                  <rdf:li rdf:resource="https://identifiers.org/ec-code/2.7.7.80"/>
-                </rdf:Bag>
-              </bqbiol:is>
-            </rdf:Description>
-          </rdf:RDF>
-        </annotation>
-        <listOfReactants>
-          <speciesReference species="M_cpd00012_c0" stoichiometry="1" constant="true"/>
-          <speciesReference species="M_cpd26672_c0" stoichiometry="1" constant="true"/>
-        </listOfReactants>
-        <listOfProducts>
-          <speciesReference species="M_cpd00002_c0" stoichiometry="1" constant="true"/>
-          <speciesReference species="M_cpd27484_c0" stoichiometry="1" constant="true"/>
-        </listOfProducts>
-        <fbc:geneProductAssociation>
-          <fbc:geneProductRef fbc:geneProduct="G_ACZ81_RS11365"/>
-        </fbc:geneProductAssociation>
-      </reaction>
       <reaction metaid="meta_R_rxn21862_c0" sboTerm="SBO:0000176" id="R_rxn21862_c0" name="RXN-11481.c [c0]" reversible="false" fast="false" fbc:lowerFluxBound="cobra_0_bound" fbc:upperFluxBound="cobra_default_ub">
         <annotation>
           <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
@@ -59691,67 +58042,6 @@
         </listOfProducts>
         <fbc:geneProductAssociation>
           <fbc:geneProductRef fbc:geneProduct="G_ACZ81_RS07080"/>
-        </fbc:geneProductAssociation>
-      </reaction>
-      <reaction metaid="meta_R_rxn16583_c0" sboTerm="SBO:0000176" id="R_rxn16583_c0" name="adenylyl-molybdopterin:molybdate molybdate transferase (AMP-forming) [c0]" reversible="false" fast="false" fbc:lowerFluxBound="cobra_0_bound" fbc:upperFluxBound="cobra_default_ub">
-        <annotation>
-          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
-            <rdf:Description rdf:about="#meta_R_rxn16583_c0">
-              <bqbiol:is>
-                <rdf:Bag>
-                  <rdf:li rdf:resource="https://identifiers.org/seed.reaction/rxn16583"/>
-                  <rdf:li rdf:resource="https://identifiers.org/kegg.reaction/R09735"/>
-                  <rdf:li rdf:resource="https://identifiers.org/rhea/35048"/>
-                  <rdf:li rdf:resource="https://identifiers.org/rhea/35050"/>
-                  <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR139727"/>
-                  <rdf:li rdf:resource="https://identifiers.org/biocyc/META:RXN-8348"/>
-                  <rdf:li rdf:resource="https://identifiers.org/ec-code/2.10.1.1"/>
-                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K03750"/>
-                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K15376"/>
-                </rdf:Bag>
-              </bqbiol:is>
-            </rdf:Description>
-          </rdf:RDF>
-        </annotation>
-        <listOfReactants>
-          <speciesReference species="M_cpd00067_c0" stoichiometry="1" constant="true"/>
-          <speciesReference species="M_cpd11574_c0" stoichiometry="1" constant="true"/>
-          <speciesReference species="M_cpd21090_c0" stoichiometry="1" constant="true"/>
-        </listOfReactants>
-        <listOfProducts>
-          <speciesReference species="M_cpd00001_c0" stoichiometry="1" constant="true"/>
-          <speciesReference species="M_cpd00018_c0" stoichiometry="1" constant="true"/>
-          <speciesReference species="M_cpd19503_c0" stoichiometry="1" constant="true"/>
-        </listOfProducts>
-        <fbc:geneProductAssociation>
-          <fbc:geneProductRef fbc:geneProduct="G_ACZ81_RS10885"/>
-        </fbc:geneProductAssociation>
-      </reaction>
-      <reaction metaid="meta_R_rxn44539_c0" sboTerm="SBO:0000176" id="R_rxn44539_c0" name="[c0]" reversible="true" fast="false" fbc:lowerFluxBound="cobra_default_lb" fbc:upperFluxBound="cobra_default_ub">
-        <annotation>
-          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
-            <rdf:Description rdf:about="#meta_R_rxn44539_c0">
-              <bqbiol:is>
-                <rdf:Bag>
-                  <rdf:li rdf:resource="https://identifiers.org/seed.reaction/rxn44539"/>
-                  <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR120102"/>
-                  <rdf:li rdf:resource="https://identifiers.org/biocyc/META:RXN-16456"/>
-                  <rdf:li rdf:resource="https://identifiers.org/ec-code/2.7.7.77"/>
-                </rdf:Bag>
-              </bqbiol:is>
-            </rdf:Description>
-          </rdf:RDF>
-        </annotation>
-        <listOfReactants>
-          <speciesReference species="M_cpd00038_c0" stoichiometry="2" constant="true"/>
-          <speciesReference species="M_cpd33647_c0" stoichiometry="1" constant="true"/>
-        </listOfReactants>
-        <listOfProducts>
-          <speciesReference species="M_cpd00012_c0" stoichiometry="2" constant="true"/>
-          <speciesReference species="M_cpd35194_c0" stoichiometry="1" constant="true"/>
-        </listOfProducts>
-        <fbc:geneProductAssociation>
-          <fbc:geneProductRef fbc:geneProduct="G_ACZ81_RS08460"/>
         </fbc:geneProductAssociation>
       </reaction>
       <reaction metaid="meta_R_rxn16609_c0" sboTerm="SBO:0000176" id="R_rxn16609_c0" name="ATP:(KDO)-lipid IVA 3-deoxy-alpha-D-manno-oct-2-ulopyranose 4-phosphotransferase [c0]" reversible="true" fast="false" fbc:lowerFluxBound="cobra_default_lb" fbc:upperFluxBound="cobra_default_ub">
@@ -59990,33 +58280,6 @@
           <fbc:geneProductRef fbc:geneProduct="G_ACZ81_RS06660"/>
         </fbc:geneProductAssociation>
       </reaction>
-      <reaction metaid="meta_R_rxn24830_c0" sboTerm="SBO:0000176" id="R_rxn24830_c0" name="thiocarboxylated molybdopterin synthase:cyclic pyranopterin monophosphate sulfurtransferase [c0]" reversible="false" fast="false" fbc:lowerFluxBound="cobra_0_bound" fbc:upperFluxBound="cobra_default_ub">
-        <annotation>
-          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
-            <rdf:Description rdf:about="#meta_R_rxn24830_c0">
-              <bqbiol:is>
-                <rdf:Bag>
-                  <rdf:li rdf:resource="https://identifiers.org/seed.reaction/rxn24830"/>
-                  <rdf:li rdf:resource="https://identifiers.org/biocyc/META:RXN-8342"/>
-                  <rdf:li rdf:resource="https://identifiers.org/ec-code/2.8.1.12"/>
-                </rdf:Bag>
-              </bqbiol:is>
-            </rdf:Description>
-          </rdf:RDF>
-        </annotation>
-        <listOfReactants>
-          <speciesReference species="M_cpd03520_c0" stoichiometry="1" constant="true"/>
-          <speciesReference species="M_cpd27484_c0" stoichiometry="2" constant="true"/>
-        </listOfReactants>
-        <listOfProducts>
-          <speciesReference species="M_cpd00001_c0" stoichiometry="1" constant="true"/>
-          <speciesReference species="M_cpd19505_c0" stoichiometry="1" constant="true"/>
-          <speciesReference species="M_cpd28260_c0" stoichiometry="2" constant="true"/>
-        </listOfProducts>
-        <fbc:geneProductAssociation>
-          <fbc:geneProductRef fbc:geneProduct="G_ACZ81_RS11345"/>
-        </fbc:geneProductAssociation>
-      </reaction>
       <reaction metaid="meta_R_rxn42709_c0" sboTerm="SBO:0000176" id="R_rxn42709_c0" name="[c0]" reversible="false" fast="false" fbc:lowerFluxBound="cobra_0_bound" fbc:upperFluxBound="cobra_default_ub">
         <annotation>
           <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
@@ -60079,93 +58342,6 @@
         </listOfProducts>
         <fbc:geneProductAssociation>
           <fbc:geneProductRef fbc:geneProduct="G_ACZ81_RS07790"/>
-        </fbc:geneProductAssociation>
-      </reaction>
-      <reaction metaid="meta_R_rxn26021_c0" sboTerm="SBO:0000176" id="R_rxn26021_c0" name="MobA [c0]" reversible="true" fast="false" fbc:lowerFluxBound="cobra_default_lb" fbc:upperFluxBound="cobra_default_ub">
-        <annotation>
-          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
-            <rdf:Description rdf:about="#meta_R_rxn26021_c0">
-              <bqbiol:is>
-                <rdf:Bag>
-                  <rdf:li rdf:resource="https://identifiers.org/seed.reaction/rxn26021"/>
-                  <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR114873"/>
-                  <rdf:li rdf:resource="https://identifiers.org/biocyc/META:RXN0-262"/>
-                  <rdf:li rdf:resource="https://identifiers.org/ec-code/2.7.7.77"/>
-                </rdf:Bag>
-              </bqbiol:is>
-            </rdf:Description>
-          </rdf:RDF>
-        </annotation>
-        <listOfReactants>
-          <speciesReference species="M_cpd00038_c0" stoichiometry="1" constant="true"/>
-          <speciesReference species="M_cpd19503_c0" stoichiometry="1" constant="true"/>
-        </listOfReactants>
-        <listOfProducts>
-          <speciesReference species="M_cpd00012_c0" stoichiometry="1" constant="true"/>
-          <speciesReference species="M_cpd21167_c0" stoichiometry="1" constant="true"/>
-        </listOfProducts>
-        <fbc:geneProductAssociation>
-          <fbc:geneProductRef fbc:geneProduct="G_ACZ81_RS08460"/>
-        </fbc:geneProductAssociation>
-      </reaction>
-      <reaction metaid="meta_R_rxn41683_c0" sboTerm="SBO:0000176" id="R_rxn41683_c0" name="[c0]" reversible="true" fast="false" fbc:lowerFluxBound="cobra_default_lb" fbc:upperFluxBound="cobra_default_ub">
-        <annotation>
-          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
-            <rdf:Description rdf:about="#meta_R_rxn41683_c0">
-              <bqbiol:is>
-                <rdf:Bag>
-                  <rdf:li rdf:resource="https://identifiers.org/seed.reaction/rxn41683"/>
-                  <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR140619"/>
-                  <rdf:li rdf:resource="https://identifiers.org/biocyc/META:RXN-16457"/>
-                </rdf:Bag>
-              </bqbiol:is>
-            </rdf:Description>
-          </rdf:RDF>
-        </annotation>
-        <listOfReactants>
-          <speciesReference species="M_cpd00067_c0" stoichiometry="1" constant="true"/>
-          <speciesReference species="M_cpd03520_c0" stoichiometry="1" constant="true"/>
-          <speciesReference species="M_cpd19503_c0" stoichiometry="1" constant="true"/>
-        </listOfReactants>
-        <listOfProducts>
-          <speciesReference species="M_cpd00001_c0" stoichiometry="1" constant="true"/>
-          <speciesReference species="M_cpd33647_c0" stoichiometry="1" constant="true"/>
-        </listOfProducts>
-        <fbc:geneProductAssociation>
-          <fbc:geneProductRef fbc:geneProduct="G_ACZ81_RS08460"/>
-        </fbc:geneProductAssociation>
-      </reaction>
-      <reaction metaid="meta_R_rxn07436_c0" sboTerm="SBO:0000176" id="R_rxn07436_c0" name="7-aminomethyl-7-carbaguanine:NADP+ oxidoreductase [c0]" reversible="true" fast="false" fbc:lowerFluxBound="cobra_default_lb" fbc:upperFluxBound="cobra_default_ub">
-        <annotation>
-          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
-            <rdf:Description rdf:about="#meta_R_rxn07436_c0">
-              <bqbiol:is>
-                <rdf:Bag>
-                  <rdf:li rdf:resource="https://identifiers.org/seed.reaction/rxn07436"/>
-                  <rdf:li rdf:resource="https://identifiers.org/kegg.reaction/R07605"/>
-                  <rdf:li rdf:resource="https://identifiers.org/rhea/13412"/>
-                  <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR96521"/>
-                  <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR135611"/>
-                  <rdf:li rdf:resource="https://identifiers.org/biocyc/META:RXN0-4022"/>
-                  <rdf:li rdf:resource="https://identifiers.org/ec-code/1.7.1.13"/>
-                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K09457"/>
-                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K06879"/>
-                </rdf:Bag>
-              </bqbiol:is>
-            </rdf:Description>
-          </rdf:RDF>
-        </annotation>
-        <listOfReactants>
-          <speciesReference species="M_cpd00006_c0" stoichiometry="2" constant="true"/>
-          <speciesReference species="M_cpd01029_c0" stoichiometry="1" constant="true"/>
-        </listOfReactants>
-        <listOfProducts>
-          <speciesReference species="M_cpd00005_c0" stoichiometry="2" constant="true"/>
-          <speciesReference species="M_cpd00067_c0" stoichiometry="3" constant="true"/>
-          <speciesReference species="M_cpd14718_c0" stoichiometry="1" constant="true"/>
-        </listOfProducts>
-        <fbc:geneProductAssociation>
-          <fbc:geneProductRef fbc:geneProduct="G_ACZ81_RS04765"/>
         </fbc:geneProductAssociation>
       </reaction>
       <reaction metaid="meta_R_rxn16826_c0" sboTerm="SBO:0000176" id="R_rxn16826_c0" name="Ureidoacrylate amidohydrolase [c0]" reversible="false" fast="false" fbc:lowerFluxBound="cobra_0_bound" fbc:upperFluxBound="cobra_default_ub">
@@ -60293,36 +58469,6 @@
         </listOfProducts>
         <fbc:geneProductAssociation>
           <fbc:geneProductRef fbc:geneProduct="G_ACZ81_RS16595"/>
-        </fbc:geneProductAssociation>
-      </reaction>
-      <reaction metaid="meta_R_rxn03396_c0" sboTerm="SBO:0000176" id="R_rxn03396_c0" name="R04989 [c0]" reversible="false" fast="false" fbc:lowerFluxBound="cobra_0_bound" fbc:upperFluxBound="cobra_default_ub">
-        <annotation>
-          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
-            <rdf:Description rdf:about="#meta_R_rxn03396_c0">
-              <bqbiol:is>
-                <rdf:Bag>
-                  <rdf:li rdf:resource="https://identifiers.org/seed.reaction/rxn03396"/>
-                  <rdf:li rdf:resource="https://identifiers.org/kegg.reaction/R04989"/>
-                  <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR109273"/>
-                  <rdf:li rdf:resource="https://identifiers.org/ec-code/1.14.13.-"/>
-                </rdf:Bag>
-              </bqbiol:is>
-            </rdf:Description>
-          </rdf:RDF>
-        </annotation>
-        <listOfReactants>
-          <speciesReference species="M_cpd00005_c0" stoichiometry="1" constant="true"/>
-          <speciesReference species="M_cpd00007_c0" stoichiometry="1" constant="true"/>
-          <speciesReference species="M_cpd03446_c0" stoichiometry="1" constant="true"/>
-        </listOfReactants>
-        <listOfProducts>
-          <speciesReference species="M_cpd00001_c0" stoichiometry="1" constant="true"/>
-          <speciesReference species="M_cpd00006_c0" stoichiometry="1" constant="true"/>
-          <speciesReference species="M_cpd00067_c0" stoichiometry="1" constant="true"/>
-          <speciesReference species="M_cpd03447_c0" stoichiometry="1" constant="true"/>
-        </listOfProducts>
-        <fbc:geneProductAssociation>
-          <fbc:geneProductRef fbc:geneProduct="G_ACZ81_RS14545"/>
         </fbc:geneProductAssociation>
       </reaction>
       <reaction metaid="meta_R_rxn15296_c0" sboTerm="SBO:0000176" id="R_rxn15296_c0" name="6-Phospho-D-gluconate hydro-lyase(2-dehydro-3-deoxy-6-phospho-D-gluconate-forming) [c0]" reversible="false" fast="false" fbc:lowerFluxBound="cobra_0_bound" fbc:upperFluxBound="cobra_default_ub">
@@ -60919,63 +59065,6 @@
           <fbc:geneProductRef fbc:geneProduct="G_ACZ81_RS04850"/>
         </fbc:geneProductAssociation>
       </reaction>
-      <reaction metaid="meta_R_rxn09304_c0" sboTerm="SBO:0000655" id="R_rxn09304_c0" name="TRANS-RXN-244.cp [c0]" reversible="false" fast="false" fbc:lowerFluxBound="cobra_0_bound" fbc:upperFluxBound="cobra_default_ub">
-        <annotation>
-          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
-            <rdf:Description rdf:about="#meta_R_rxn09304_c0">
-              <bqbiol:is>
-                <rdf:Bag>
-                  <rdf:li rdf:resource="https://identifiers.org/seed.reaction/rxn09304"/>
-                  <rdf:li rdf:resource="https://identifiers.org/bigg.reaction/THRt3"/>
-                  <rdf:li rdf:resource="https://identifiers.org/bigg.reaction/THRt2pp"/>
-                  <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR104851"/>
-                  <rdf:li rdf:resource="https://identifiers.org/biocyc/META:TRANS-RXN0-0244"/>
-                </rdf:Bag>
-              </bqbiol:is>
-            </rdf:Description>
-          </rdf:RDF>
-        </annotation>
-        <listOfReactants>
-          <speciesReference species="M_cpd00067_e0" stoichiometry="1" constant="true"/>
-          <speciesReference species="M_cpd00161_c0" stoichiometry="1" constant="true"/>
-        </listOfReactants>
-        <listOfProducts>
-          <speciesReference species="M_cpd00067_c0" stoichiometry="1" constant="true"/>
-          <speciesReference species="M_cpd00161_e0" stoichiometry="1" constant="true"/>
-        </listOfProducts>
-        <fbc:geneProductAssociation>
-          <fbc:geneProductRef fbc:geneProduct="G_ACZ81_RS11460"/>
-        </fbc:geneProductAssociation>
-      </reaction>
-      <reaction metaid="meta_R_rxn08722_c0" sboTerm="SBO:0000655" id="R_rxn08722_c0" name="TRANS-RXN-242.cp [c0]" reversible="false" fast="false" fbc:lowerFluxBound="cobra_0_bound" fbc:upperFluxBound="cobra_default_ub">
-        <annotation>
-          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
-            <rdf:Description rdf:about="#meta_R_rxn08722_c0">
-              <bqbiol:is>
-                <rdf:Bag>
-                  <rdf:li rdf:resource="https://identifiers.org/seed.reaction/rxn08722"/>
-                  <rdf:li rdf:resource="https://identifiers.org/bigg.reaction/HOMt"/>
-                  <rdf:li rdf:resource="https://identifiers.org/bigg.reaction/HOMt2pp"/>
-                  <rdf:li rdf:resource="https://identifiers.org/rhea/35028"/>
-                  <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR100676"/>
-                  <rdf:li rdf:resource="https://identifiers.org/biocyc/META:TRANS-RXN-242"/>
-                </rdf:Bag>
-              </bqbiol:is>
-            </rdf:Description>
-          </rdf:RDF>
-        </annotation>
-        <listOfReactants>
-          <speciesReference species="M_cpd00067_e0" stoichiometry="1" constant="true"/>
-          <speciesReference species="M_cpd00227_c0" stoichiometry="1" constant="true"/>
-        </listOfReactants>
-        <listOfProducts>
-          <speciesReference species="M_cpd00067_c0" stoichiometry="1" constant="true"/>
-          <speciesReference species="M_cpd00227_e0" stoichiometry="1" constant="true"/>
-        </listOfProducts>
-        <fbc:geneProductAssociation>
-          <fbc:geneProductRef fbc:geneProduct="G_ACZ81_RS11460"/>
-        </fbc:geneProductAssociation>
-      </reaction>
       <reaction metaid="meta_R_rxn08062_c0" sboTerm="SBO:0000655" id="R_rxn08062_c0" name="Na+/Acetate symport (periplasm) [c0]" reversible="true" fast="false" fbc:lowerFluxBound="cobra_default_lb" fbc:upperFluxBound="cobra_default_ub">
         <annotation>
           <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
@@ -61003,33 +59092,6 @@
         </listOfProducts>
         <fbc:geneProductAssociation>
           <fbc:geneProductRef fbc:geneProduct="G_ACZ81_RS16805"/>
-        </fbc:geneProductAssociation>
-      </reaction>
-      <reaction metaid="meta_R_rxn21863_c0" sboTerm="SBO:0000176" id="R_rxn21863_c0" name="RXN-11482.c [c0]" reversible="true" fast="false" fbc:lowerFluxBound="cobra_default_lb" fbc:upperFluxBound="cobra_default_ub">
-        <annotation>
-          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
-            <rdf:Description rdf:about="#meta_R_rxn21863_c0">
-              <bqbiol:is>
-                <rdf:Bag>
-                  <rdf:li rdf:resource="https://identifiers.org/seed.reaction/rxn21863"/>
-                  <rdf:li rdf:resource="https://identifiers.org/biocyc/META:RXN-11482"/>
-                  <rdf:li rdf:resource="https://identifiers.org/ec-code/1.3.1.10"/>
-                </rdf:Bag>
-              </bqbiol:is>
-            </rdf:Description>
-          </rdf:RDF>
-        </annotation>
-        <listOfReactants>
-          <speciesReference species="M_cpd00005_c0" stoichiometry="1" constant="true"/>
-          <speciesReference species="M_cpd00067_c0" stoichiometry="1" constant="true"/>
-          <speciesReference species="M_cpd27021_c0" stoichiometry="1" constant="true"/>
-        </listOfReactants>
-        <listOfProducts>
-          <speciesReference species="M_cpd00006_c0" stoichiometry="1" constant="true"/>
-          <speciesReference species="M_cpd21088_c0" stoichiometry="1" constant="true"/>
-        </listOfProducts>
-        <fbc:geneProductAssociation>
-          <fbc:geneProductRef fbc:geneProduct="G_ACZ81_RS16715"/>
         </fbc:geneProductAssociation>
       </reaction>
       <reaction metaid="meta_R_rxn40037_c0" sboTerm="SBO:0000176" id="R_rxn40037_c0" name="L-aspartate-4-semialdehyde hydro-lyase [adding pyruvate and cyclizing; (2S,4S)-4-hydroxy-2,3,4,5-tetrahydrodipicolinate-forming] [c0]" reversible="false" fast="false" fbc:lowerFluxBound="cobra_0_bound" fbc:upperFluxBound="cobra_default_ub">
@@ -61062,33 +59124,6 @@
             <fbc:geneProductRef fbc:geneProduct="G_ACZ81_RS10760"/>
             <fbc:geneProductRef fbc:geneProduct="G_ACZ81_RS00905"/>
           </fbc:and>
-        </fbc:geneProductAssociation>
-      </reaction>
-      <reaction metaid="meta_R_rxn21859_c0" sboTerm="SBO:0000176" id="R_rxn21859_c0" name="RXN-11478.c [c0]" reversible="true" fast="false" fbc:lowerFluxBound="cobra_default_lb" fbc:upperFluxBound="cobra_default_ub">
-        <annotation>
-          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
-            <rdf:Description rdf:about="#meta_R_rxn21859_c0">
-              <bqbiol:is>
-                <rdf:Bag>
-                  <rdf:li rdf:resource="https://identifiers.org/seed.reaction/rxn21859"/>
-                  <rdf:li rdf:resource="https://identifiers.org/biocyc/META:RXN-11478"/>
-                  <rdf:li rdf:resource="https://identifiers.org/ec-code/1.3.1.10"/>
-                </rdf:Bag>
-              </bqbiol:is>
-            </rdf:Description>
-          </rdf:RDF>
-        </annotation>
-        <listOfReactants>
-          <speciesReference species="M_cpd00005_c0" stoichiometry="1" constant="true"/>
-          <speciesReference species="M_cpd00067_c0" stoichiometry="1" constant="true"/>
-          <speciesReference species="M_cpd27020_c0" stoichiometry="1" constant="true"/>
-        </listOfReactants>
-        <listOfProducts>
-          <speciesReference species="M_cpd00006_c0" stoichiometry="1" constant="true"/>
-          <speciesReference species="M_cpd27180_c0" stoichiometry="1" constant="true"/>
-        </listOfProducts>
-        <fbc:geneProductAssociation>
-          <fbc:geneProductRef fbc:geneProduct="G_ACZ81_RS16715"/>
         </fbc:geneProductAssociation>
       </reaction>
       <reaction metaid="meta_R_rxn20643_c0" sboTerm="SBO:0000176" id="R_rxn20643_c0" name="thiC (gene name) [c0]" reversible="false" fast="false" fbc:lowerFluxBound="cobra_0_bound" fbc:upperFluxBound="cobra_default_ub">
@@ -61156,35 +59191,6 @@
         </listOfProducts>
         <fbc:geneProductAssociation>
           <fbc:geneProductRef fbc:geneProduct="G_ACZ81_RS15195"/>
-        </fbc:geneProductAssociation>
-      </reaction>
-      <reaction metaid="meta_R_rxn17731_c0" sboTerm="SBO:0000176" id="R_rxn17731_c0" name="biotin synthase [c0]" reversible="false" fast="false" fbc:lowerFluxBound="cobra_0_bound" fbc:upperFluxBound="cobra_default_ub">
-        <annotation>
-          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
-            <rdf:Description rdf:about="#meta_R_rxn17731_c0">
-              <bqbiol:is>
-                <rdf:Bag>
-                  <rdf:li rdf:resource="https://identifiers.org/seed.reaction/rxn17731"/>
-                  <rdf:li rdf:resource="https://identifiers.org/biocyc/META:2.8.1.6-RXN"/>
-                  <rdf:li rdf:resource="https://identifiers.org/ec-code/2.8.1.6"/>
-                </rdf:Bag>
-              </bqbiol:is>
-            </rdf:Description>
-          </rdf:RDF>
-        </annotation>
-        <listOfReactants>
-          <speciesReference species="M_cpd00017_c0" stoichiometry="2" constant="true"/>
-          <speciesReference species="M_cpd00084_c0" stoichiometry="1" constant="true"/>
-          <speciesReference species="M_cpd01311_c0" stoichiometry="1" constant="true"/>
-        </listOfReactants>
-        <listOfProducts>
-          <speciesReference species="M_cpd00035_c0" stoichiometry="1" constant="true"/>
-          <speciesReference species="M_cpd00060_c0" stoichiometry="2" constant="true"/>
-          <speciesReference species="M_cpd00104_c0" stoichiometry="1" constant="true"/>
-          <speciesReference species="M_cpd03091_c0" stoichiometry="2" constant="true"/>
-        </listOfProducts>
-        <fbc:geneProductAssociation>
-          <fbc:geneProductRef fbc:geneProduct="G_ACZ81_RS06665"/>
         </fbc:geneProductAssociation>
       </reaction>
       <reaction metaid="meta_R_rxn21860_c0" sboTerm="SBO:0000176" id="R_rxn21860_c0" name="RXN-11479.c [c0]" reversible="false" fast="false" fbc:lowerFluxBound="cobra_0_bound" fbc:upperFluxBound="cobra_default_ub">
@@ -61289,31 +59295,6 @@
             <fbc:geneProductRef fbc:geneProduct="G_ACZ81_RS19530"/>
             <fbc:geneProductRef fbc:geneProduct="G_ACZ81_RS18990"/>
           </fbc:and>
-        </fbc:geneProductAssociation>
-      </reaction>
-      <reaction metaid="meta_R_rxn16828_c0" sboTerm="SBO:0000176" id="R_rxn16828_c0" name="R09982 [c0]" reversible="false" fast="false" fbc:lowerFluxBound="cobra_0_bound" fbc:upperFluxBound="cobra_default_ub">
-        <annotation>
-          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
-            <rdf:Description rdf:about="#meta_R_rxn16828_c0">
-              <bqbiol:is>
-                <rdf:Bag>
-                  <rdf:li rdf:resource="https://identifiers.org/seed.reaction/rxn16828"/>
-                  <rdf:li rdf:resource="https://identifiers.org/kegg.reaction/R09982"/>
-                  <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR113373"/>
-                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K09021"/>
-                </rdf:Bag>
-              </bqbiol:is>
-            </rdf:Description>
-          </rdf:RDF>
-        </annotation>
-        <listOfReactants>
-          <speciesReference species="M_cpd21486_c0" stoichiometry="1" constant="true"/>
-        </listOfReactants>
-        <listOfProducts>
-          <speciesReference species="M_cpd21482_c0" stoichiometry="1" constant="true"/>
-        </listOfProducts>
-        <fbc:geneProductAssociation>
-          <fbc:geneProductRef fbc:geneProduct="G_ACZ81_RS16600"/>
         </fbc:geneProductAssociation>
       </reaction>
       <reaction metaid="meta_R_rxn15750_c0" sboTerm="SBO:0000176" id="R_rxn15750_c0" name="R08570 [c0]" reversible="true" fast="false" fbc:lowerFluxBound="cobra_default_lb" fbc:upperFluxBound="cobra_default_ub">
@@ -62037,28 +60018,6 @@
           <speciesReference species="M_cpd00040_c0" stoichiometry="1" constant="true"/>
         </listOfProducts>
       </reaction>
-      <reaction metaid="meta_R_rxn08502_e0" sboTerm="SBO:0000176" id="R_rxn08502_e0" name="enterobactin Fe(III) binding (spontaneous) [e0]" reversible="true" fast="false" fbc:lowerFluxBound="cobra_default_lb" fbc:upperFluxBound="cobra_default_ub">
-        <annotation>
-          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
-            <rdf:Description rdf:about="#meta_R_rxn08502_e0">
-              <bqbiol:is>
-                <rdf:Bag>
-                  <rdf:li rdf:resource="https://identifiers.org/seed.reaction/rxn08502"/>
-                  <rdf:li rdf:resource="https://identifiers.org/bigg.reaction/FEENTERexs"/>
-                  <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR135812"/>
-                </rdf:Bag>
-              </bqbiol:is>
-            </rdf:Description>
-          </rdf:RDF>
-        </annotation>
-        <listOfReactants>
-          <speciesReference species="M_cpd03453_e0" stoichiometry="1" constant="true"/>
-          <speciesReference species="M_cpd10516_e0" stoichiometry="1" constant="true"/>
-        </listOfReactants>
-        <listOfProducts>
-          <speciesReference species="M_cpd03726_e0" stoichiometry="1" constant="true"/>
-        </listOfProducts>
-      </reaction>
       <reaction metaid="meta_R_rxn08428_c0" sboTerm="SBO:0000655" id="R_rxn08428_c0" name="ethanol transport via diffusion (extracellular to periplasm) [c0]" reversible="true" fast="false" fbc:lowerFluxBound="cobra_default_lb" fbc:upperFluxBound="cobra_default_ub">
         <annotation>
           <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
@@ -62455,11 +60414,6 @@
           <speciesReference species="M_cpd00092_e0" stoichiometry="1" constant="true"/>
         </listOfReactants>
       </reaction>
-      <reaction metaid="meta_R_EX_cpd00041_e0" sboTerm="SBO:0000627" id="R_EX_cpd00041_e0" name="Exchange for L-Aspartate [e0]" reversible="true" fast="false" fbc:lowerFluxBound="cobra_default_lb" fbc:upperFluxBound="cobra_default_ub">
-        <listOfReactants>
-          <speciesReference species="M_cpd00041_e0" stoichiometry="1" constant="true"/>
-        </listOfReactants>
-      </reaction>
       <reaction metaid="meta_R_EX_cpd00030_e0" sboTerm="SBO:0000627" id="R_EX_cpd00030_e0" name="Exchange for Mn2+ [e0]" reversible="true" fast="false" fbc:lowerFluxBound="cobra_default_lb" fbc:upperFluxBound="cobra_default_ub">
         <listOfReactants>
           <speciesReference species="M_cpd00030_e0" stoichiometry="1" constant="true"/>
@@ -62503,11 +60457,6 @@
       <reaction metaid="meta_R_EX_cpd00034_e0" sboTerm="SBO:0000627" id="R_EX_cpd00034_e0" name="Exchange for Zn2+ [e0]" reversible="true" fast="false" fbc:lowerFluxBound="cobra_default_lb" fbc:upperFluxBound="cobra_default_ub">
         <listOfReactants>
           <speciesReference species="M_cpd00034_e0" stoichiometry="1" constant="true"/>
-        </listOfReactants>
-      </reaction>
-      <reaction metaid="meta_R_EX_cpd11574_e0" sboTerm="SBO:0000627" id="R_EX_cpd11574_e0" name="Exchange for Molybdate [e0]" reversible="true" fast="false" fbc:lowerFluxBound="cobra_default_lb" fbc:upperFluxBound="cobra_default_ub">
-        <listOfReactants>
-          <speciesReference species="M_cpd11574_e0" stoichiometry="1" constant="true"/>
         </listOfReactants>
       </reaction>
       <reaction metaid="meta_R_EX_cpd00058_e0" sboTerm="SBO:0000627" id="R_EX_cpd00058_e0" name="Exchange for Cu2+ [e0]" reversible="true" fast="false" fbc:lowerFluxBound="cobra_default_lb" fbc:upperFluxBound="cobra_default_ub">
@@ -62710,19 +60659,9 @@
           <speciesReference species="M_cpd00012_e0" stoichiometry="1" constant="true"/>
         </listOfReactants>
       </reaction>
-      <reaction metaid="meta_R_EX_cpd03726_e0" sboTerm="SBO:0000627" id="R_EX_cpd03726_e0" name="Exchange for Fe-enterochlin [e0]" reversible="true" fast="false" fbc:lowerFluxBound="cobra_default_lb" fbc:upperFluxBound="cobra_default_ub">
-        <listOfReactants>
-          <speciesReference species="M_cpd03726_e0" stoichiometry="1" constant="true"/>
-        </listOfReactants>
-      </reaction>
       <reaction metaid="meta_R_EX_cpd00309_e0" sboTerm="SBO:0000627" id="R_EX_cpd00309_e0" name="Exchange for XAN [e0]" reversible="true" fast="false" fbc:lowerFluxBound="cobra_default_lb" fbc:upperFluxBound="cobra_default_ub">
         <listOfReactants>
           <speciesReference species="M_cpd00309_e0" stoichiometry="1" constant="true"/>
-        </listOfReactants>
-      </reaction>
-      <reaction metaid="meta_R_EX_cpd01012_e0" sboTerm="SBO:0000627" id="R_EX_cpd01012_e0" name="Exchange for Cd2+ [e0]" reversible="true" fast="false" fbc:lowerFluxBound="cobra_default_lb" fbc:upperFluxBound="cobra_default_ub">
-        <listOfReactants>
-          <speciesReference species="M_cpd01012_e0" stoichiometry="1" constant="true"/>
         </listOfReactants>
       </reaction>
       <reaction metaid="meta_R_EX_cpd00161_e0" sboTerm="SBO:0000627" id="R_EX_cpd00161_e0" name="Exchange for L-Threonine [e0]" reversible="true" fast="false" fbc:lowerFluxBound="cobra_default_lb" fbc:upperFluxBound="cobra_default_ub">
@@ -62788,11 +60727,6 @@
       <reaction metaid="meta_R_EX_cpd00254_e0" sboTerm="SBO:0000627" id="R_EX_cpd00254_e0" name="Exchange for Mg [e0]" reversible="true" fast="false" fbc:lowerFluxBound="cobra_default_lb" fbc:upperFluxBound="cobra_default_ub">
         <listOfReactants>
           <speciesReference species="M_cpd00254_e0" stoichiometry="1" constant="true"/>
-        </listOfReactants>
-      </reaction>
-      <reaction metaid="meta_R_EX_cpd03453_e0" sboTerm="SBO:0000627" id="R_EX_cpd03453_e0" name="Exchange for Enterobactin [e0]" reversible="true" fast="false" fbc:lowerFluxBound="cobra_default_lb" fbc:upperFluxBound="cobra_default_ub">
-        <listOfReactants>
-          <speciesReference species="M_cpd03453_e0" stoichiometry="1" constant="true"/>
         </listOfReactants>
       </reaction>
       <reaction metaid="meta_R_EX_cpd00075_e0" sboTerm="SBO:0000627" id="R_EX_cpd00075_e0" name="Exchange for Nitrite [e0]" reversible="true" fast="false" fbc:lowerFluxBound="cobra_default_lb" fbc:upperFluxBound="cobra_default_ub">
@@ -63182,28 +61116,6 @@
         <listOfProducts>
           <speciesReference species="M_cpd00067_c0" stoichiometry="1" constant="true"/>
           <speciesReference species="M_cpd00069_c0" stoichiometry="1" constant="true"/>
-        </listOfProducts>
-      </reaction>
-      <reaction metaid="meta_R_rxn05669_c0" sboTerm="SBO:0000185" id="R_rxn05669_c0" name="L-Valine:proton symport" reversible="false" fast="false" fbc:lowerFluxBound="cobra_0_bound" fbc:upperFluxBound="cobra_default_ub">
-        <annotation>
-          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
-            <rdf:Description rdf:about="#meta_R_rxn05669_c0">
-              <bqbiol:is>
-                <rdf:Bag>
-                  <rdf:li rdf:resource="https://identifiers.org/bigg.reaction/VALt2r"/>
-                  <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR105188"/>
-                </rdf:Bag>
-              </bqbiol:is>
-            </rdf:Description>
-          </rdf:RDF>
-        </annotation>
-        <listOfReactants>
-          <speciesReference species="M_cpd00156_e0" stoichiometry="1" constant="true"/>
-          <speciesReference species="M_cpd00067_e0" stoichiometry="1" constant="true"/>
-        </listOfReactants>
-        <listOfProducts>
-          <speciesReference species="M_cpd00067_c0" stoichiometry="1" constant="true"/>
-          <speciesReference species="M_cpd00156_c0" stoichiometry="1" constant="true"/>
         </listOfProducts>
       </reaction>
       <reaction metaid="meta_R_rxn05242_c0" sboTerm="SBO:0000185" id="R_rxn05242_c0" name="L-Valine:sodium symport" reversible="false" fast="false" fbc:lowerFluxBound="cobra_0_bound" fbc:upperFluxBound="cobra_default_ub">
@@ -64131,34 +62043,6 @@
           <speciesReference species="M_cpd23538_e0" stoichiometry="1" constant="true"/>
         </listOfReactants>
       </reaction>
-      <reaction metaid="meta_R_rxn00196_c0" sboTerm="SBO:0000176" id="R_rxn00196_c0" name="2,5-dioxopentanoate:NADP+ 5-oxidoreductase [c0]" reversible="false" fast="false" fbc:lowerFluxBound="cobra_default_ub" fbc:upperFluxBound="cobra_default_ub">
-        <annotation>
-          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
-            <rdf:Description rdf:about="#meta_R_rxn00196_c0">
-              <bqbiol:is>
-                <rdf:Bag>
-                  <rdf:li rdf:resource="https://identifiers.org/ec-code/1.2.1.26"/>
-                  <rdf:li rdf:resource="https://identifiers.org/ec-code/1.2.1.3"/>
-                  <rdf:li rdf:resource="https://identifiers.org/kegg.reaction/R00264"/>
-                  <rdf:li rdf:resource="https://identifiers.org/seed.reaction/rxn00196_c0"/>
-                </rdf:Bag>
-              </bqbiol:is>
-            </rdf:Description>
-          </rdf:RDF>
-        </annotation>
-        <listOfReactants>
-          <speciesReference species="M_cpd00001_c0" stoichiometry="1" constant="true"/>
-          <speciesReference species="M_cpd00006_c0" stoichiometry="2" constant="true"/>
-        </listOfReactants>
-        <listOfProducts>
-          <speciesReference species="M_cpd00005_c0" stoichiometry="1" constant="true"/>
-          <speciesReference species="M_cpd00024_c0" stoichiometry="1" constant="true"/>
-          <speciesReference species="M_cpd00067_c0" stoichiometry="2" constant="true"/>
-        </listOfProducts>
-        <fbc:geneProductAssociation>
-          <fbc:geneProductRef fbc:geneProduct="G_ACZ81_RS14055"/>
-        </fbc:geneProductAssociation>
-      </reaction>
       <reaction metaid="meta_R_rxn00275_c0" sboTerm="SBO:0000176" id="R_rxn00275_c0" name="Glycine:2-oxoglutarate aminotransferase [c0]" reversible="false" fast="false" fbc:lowerFluxBound="cobra_default_ub" fbc:upperFluxBound="cobra_default_ub">
         <annotation>
           <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
@@ -64183,35 +62067,6 @@
         </listOfProducts>
         <fbc:geneProductAssociation>
           <fbc:geneProductRef fbc:geneProduct="G_ACZ81_RS01905"/>
-        </fbc:geneProductAssociation>
-      </reaction>
-      <reaction metaid="meta_R_rxn00309_c0" sboTerm="SBO:0000176" id="R_rxn00309_c0" name="L-Lysine:NAD+ 6-oxidoreductase (deaminating) [c0]" reversible="false" fast="false" fbc:lowerFluxBound="cobra_default_ub" fbc:upperFluxBound="cobra_default_ub">
-        <annotation>
-          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
-            <rdf:Description rdf:about="#meta_R_rxn00309_c0">
-              <bqbiol:is>
-                <rdf:Bag>
-                  <rdf:li rdf:resource="https://identifiers.org/ec-code/1.4.1.18"/>
-                  <rdf:li rdf:resource="https://identifiers.org/kegg.reaction/R00446"/>
-                  <rdf:li rdf:resource="https://identifiers.org/seed.reaction/rxn00309_c0"/>
-                </rdf:Bag>
-              </bqbiol:is>
-            </rdf:Description>
-          </rdf:RDF>
-        </annotation>
-        <listOfReactants>
-          <speciesReference species="M_cpd00001_c0" stoichiometry="1" constant="true"/>
-          <speciesReference species="M_cpd00003_c0" stoichiometry="1" constant="true"/>
-          <speciesReference species="M_cpd00039_c0" stoichiometry="1" constant="true"/>
-        </listOfReactants>
-        <listOfProducts>
-          <speciesReference species="M_cpd00004_c0" stoichiometry="1" constant="true"/>
-          <speciesReference species="M_cpd00013_c0" stoichiometry="1" constant="true"/>
-          <speciesReference species="M_cpd00067_c0" stoichiometry="1" constant="true"/>
-          <speciesReference species="M_cpd02522_c0" stoichiometry="1" constant="true"/>
-        </listOfProducts>
-        <fbc:geneProductAssociation>
-          <fbc:geneProductRef fbc:geneProduct="G_ACZ81_RS18260"/>
         </fbc:geneProductAssociation>
       </reaction>
       <reaction metaid="meta_R_rxn00320_c0" sboTerm="SBO:0000176" id="R_rxn00320_c0" name="lysine racemase [c0]" reversible="false" fast="false" fbc:lowerFluxBound="cobra_default_ub" fbc:upperFluxBound="cobra_default_ub">
@@ -65000,34 +62855,6 @@
         </listOfProducts>
         <fbc:geneProductAssociation>
           <fbc:geneProductRef fbc:geneProduct="G_ACZ81_RS09935"/>
-        </fbc:geneProductAssociation>
-      </reaction>
-      <reaction metaid="meta_R_rxn01032_c0" sboTerm="SBO:0000176" id="R_rxn01032_c0" name="Benzaldehyde:NAD+ oxidoreductase [c0]" reversible="false" fast="false" fbc:lowerFluxBound="cobra_default_ub" fbc:upperFluxBound="cobra_default_ub">
-        <annotation>
-          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
-            <rdf:Description rdf:about="#meta_R_rxn01032_c0">
-              <bqbiol:is>
-                <rdf:Bag>
-                  <rdf:li rdf:resource="https://identifiers.org/ec-code/1.2.1.28"/>
-                  <rdf:li rdf:resource="https://identifiers.org/ec-code/1.2.1.29"/>
-                  <rdf:li rdf:resource="https://identifiers.org/kegg.reaction/R01419"/>
-                  <rdf:li rdf:resource="https://identifiers.org/seed.reaction/rxn01032_c0"/>
-                </rdf:Bag>
-              </bqbiol:is>
-            </rdf:Description>
-          </rdf:RDF>
-        </annotation>
-        <listOfReactants>
-          <speciesReference species="M_cpd00001_c0" stoichiometry="1" constant="true"/>
-          <speciesReference species="M_cpd00003_c0" stoichiometry="2" constant="true"/>
-        </listOfReactants>
-        <listOfProducts>
-          <speciesReference species="M_cpd00004_c0" stoichiometry="1" constant="true"/>
-          <speciesReference species="M_cpd00067_c0" stoichiometry="2" constant="true"/>
-          <speciesReference species="M_cpd00153_c0" stoichiometry="1" constant="true"/>
-        </listOfProducts>
-        <fbc:geneProductAssociation>
-          <fbc:geneProductRef fbc:geneProduct="G_ACZ81_RS19350"/>
         </fbc:geneProductAssociation>
       </reaction>
       <reaction metaid="meta_R_rxn01042_c0" sboTerm="SBO:0000176" id="R_rxn01042_c0" name="D-xylose:NADP+ 1-oxidoreductase [c0]" reversible="false" fast="false" fbc:lowerFluxBound="cobra_default_ub" fbc:upperFluxBound="cobra_default_ub">
@@ -66789,6 +64616,1264 @@
           <fbc:geneProductRef fbc:geneProduct="G_ACZ81_RS05095"/>
         </fbc:geneProductAssociation>
       </reaction>
+      <reaction metaid="meta_R_cpd00992_trans" sboTerm="SBO:0000658" id="R_cpd00992_trans" name="Transport of 1,2-Ethanediol" reversible="false" fast="false" fbc:lowerFluxBound="cobra_default_ub" fbc:upperFluxBound="cobra_default_ub">
+        <listOfReactants>
+          <speciesReference species="M_cpd00992_c0" stoichiometry="1" constant="true"/>
+        </listOfReactants>
+        <listOfProducts>
+          <speciesReference species="M_cpd00992_e0" stoichiometry="1" constant="true"/>
+        </listOfProducts>
+      </reaction>
+      <reaction metaid="meta_R_EX_cpd00054_e0" sboTerm="SBO:0000627" id="R_EX_cpd00054_e0" name="Exchange of L-Serine [e0]" reversible="false" fast="false" fbc:lowerFluxBound="cobra_default_ub" fbc:upperFluxBound="cobra_default_ub">
+        <listOfReactants>
+          <speciesReference species="M_cpd00054_e0" stoichiometry="1" constant="true"/>
+        </listOfReactants>
+      </reaction>
+      <reaction metaid="meta_R_EX_cpd00085_e0" sboTerm="SBO:0000627" id="R_EX_cpd00085_e0" name="Exchange of beta-Alanine [e0]" reversible="false" fast="false" fbc:lowerFluxBound="cobra_default_ub" fbc:upperFluxBound="cobra_default_ub">
+        <listOfReactants>
+          <speciesReference species="M_cpd00085_e0" stoichiometry="1" constant="true"/>
+        </listOfReactants>
+      </reaction>
+      <reaction metaid="meta_R_EX_cpd00132_e0" sboTerm="SBO:0000627" id="R_EX_cpd00132_e0" name="Exchange of L-Asparagine [e0]" reversible="false" fast="false" fbc:lowerFluxBound="cobra_default_ub" fbc:upperFluxBound="cobra_default_ub">
+        <listOfReactants>
+          <speciesReference species="M_cpd00132_e0" stoichiometry="1" constant="true"/>
+        </listOfReactants>
+      </reaction>
+      <reaction metaid="meta_R_EX_cpd00992_e0" sboTerm="SBO:0000627" id="R_EX_cpd00992_e0" name="Exchange of 1,2-Ethanediol [e0]" reversible="false" fast="false" fbc:lowerFluxBound="cobra_default_ub" fbc:upperFluxBound="cobra_default_ub">
+        <listOfReactants>
+          <speciesReference species="M_cpd00992_e0" stoichiometry="1" constant="true"/>
+        </listOfReactants>
+      </reaction>
+      <reaction metaid="meta_R_EX_cpd30760_e0" sboTerm="SBO:0000627" id="R_EX_cpd30760_e0" name="Exchange of Cu+ [e0]" reversible="false" fast="false" fbc:lowerFluxBound="cobra_default_ub" fbc:upperFluxBound="cobra_default_ub">
+        <listOfReactants>
+          <speciesReference species="M_cpd30760_e0" stoichiometry="1" constant="true"/>
+        </listOfReactants>
+      </reaction>
+      <reaction metaid="meta_R_isc_split" sboTerm="SBO:0000176" id="R_isc_split" name="Oxidative cleavage of 4Fe4S by sufA" reversible="false" fast="false" fbc:lowerFluxBound="cobra_default_ub" fbc:upperFluxBound="cobra_default_ub">
+        <listOfReactants>
+          <speciesReference species="M_cpd24682_c0" stoichiometry="2" constant="true"/>
+          <speciesReference species="M_cpd00007_c0" stoichiometry="1" constant="true"/>
+          <speciesReference species="M_cpd00067_c0" stoichiometry="8" constant="true"/>
+        </listOfReactants>
+        <listOfProducts>
+          <speciesReference species="M_cpd24604_c0" stoichiometry="2" constant="true"/>
+          <speciesReference species="M_cpd10516_c0" stoichiometry="4" constant="true"/>
+          <speciesReference species="M_cpd00239_c0" stoichiometry="4" constant="true"/>
+          <speciesReference species="M_cpd00001_c0" stoichiometry="2" constant="true"/>
+        </listOfProducts>
+        <fbc:geneProductAssociation>
+          <fbc:geneProductRef fbc:geneProduct="G_ACZ81_RS13510"/>
+        </fbc:geneProductAssociation>
+      </reaction>
+      <reaction metaid="meta_R_mmal_sald_redox" sboTerm="SBO:0000176" id="R_mmal_sald_redox" name="2-methyl-3-oxopropanoate:NADP+ oxidoreductase [c0]" reversible="false" fast="false" fbc:lowerFluxBound="cobra_default_ub" fbc:upperFluxBound="cobra_default_ub">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_R_mmal_sald_redox">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/ec-code/1.1.1.2"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+        <listOfReactants>
+          <speciesReference species="M_cpd00876_c0" stoichiometry="1" constant="true"/>
+          <speciesReference species="M_cpd00006_c0" stoichiometry="1" constant="true"/>
+        </listOfReactants>
+        <listOfProducts>
+          <speciesReference species="M_cpd00005_c0" stoichiometry="1" constant="true"/>
+          <speciesReference species="M_cpd00067_c0" stoichiometry="1" constant="true"/>
+          <speciesReference species="M_cpd00287_c0" stoichiometry="1" constant="true"/>
+        </listOfProducts>
+        <fbc:geneProductAssociation>
+          <fbc:or>
+            <fbc:geneProductRef fbc:geneProduct="G_ACZ81_RS02770"/>
+            <fbc:geneProductRef fbc:geneProduct="G_ACZ81_RS18510"/>
+            <fbc:geneProductRef fbc:geneProduct="G_ACZ81_RS07295"/>
+          </fbc:or>
+        </fbc:geneProductAssociation>
+      </reaction>
+      <reaction metaid="meta_R_rxn00333_c0" sboTerm="SBO:0000176" id="R_rxn00333_c0" name="Glycolate:oxygen 2-oxidoreductase" reversible="false" fast="false" fbc:lowerFluxBound="cobra_default_ub" fbc:upperFluxBound="cobra_default_ub">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_R_rxn00333_c0">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/bigg.reaction/GLYCTO1"/>
+                  <rdf:li rdf:resource="https://identifiers.org/biocyc.reaction/META:RXN-969"/>
+                  <rdf:li rdf:resource="https://identifiers.org/ec-code/1.1.3.15"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.reaction/R00475"/>
+                  <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR100338"/>
+                  <rdf:li rdf:resource="https://identifiers.org/seed.reaction/rxn00333"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+        <listOfReactants>
+          <speciesReference species="M_cpd00007_c0" stoichiometry="1" constant="true"/>
+          <speciesReference species="M_cpd00139_c0" stoichiometry="1" constant="true"/>
+        </listOfReactants>
+        <listOfProducts>
+          <speciesReference species="M_cpd00025_c0" stoichiometry="1" constant="true"/>
+          <speciesReference species="M_cpd00040_c0" stoichiometry="1" constant="true"/>
+        </listOfProducts>
+        <fbc:geneProductAssociation>
+          <fbc:geneProductRef fbc:geneProduct="G_ACZ81_RS17970"/>
+        </fbc:geneProductAssociation>
+      </reaction>
+      <reaction metaid="meta_R_rxn00346_c0" sboTerm="SBO:0000176" id="R_rxn00346_c0" name="L-aspartate 1-carboxy-lyase (beta-alanine-forming)" reversible="false" fast="false" fbc:lowerFluxBound="cobra_default_ub" fbc:upperFluxBound="cobra_default_ub">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_R_rxn00346_c0">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/bigg.reaction/ASP1DC"/>
+                  <rdf:li rdf:resource="https://identifiers.org/biocyc/META:ASPDECARBOX-RXN"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K18933"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K24264"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K01579"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K01580"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K18966"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.reaction/R00489"/>
+                  <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR96077"/>
+                  <rdf:li rdf:resource="https://identifiers.org/seed.reaction/rxn00346"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+        <listOfReactants>
+          <speciesReference species="M_cpd00041_c0" stoichiometry="1" constant="true"/>
+          <speciesReference species="M_cpd00067_c0" stoichiometry="1" constant="true"/>
+        </listOfReactants>
+        <listOfProducts>
+          <speciesReference species="M_cpd00011_c0" stoichiometry="1" constant="true"/>
+          <speciesReference species="M_cpd00085_c0" stoichiometry="1" constant="true"/>
+        </listOfProducts>
+        <fbc:geneProductAssociation>
+          <fbc:geneProductRef fbc:geneProduct="G_ACZ81_RS17835"/>
+        </fbc:geneProductAssociation>
+      </reaction>
+      <reaction metaid="meta_R_rxn00509_c0" sboTerm="SBO:0000176" id="R_rxn00509_c0" name="4-Oxobutanoate:NADP+ oxidoreductase [c0]" reversible="false" fast="false" fbc:lowerFluxBound="cobra_default_ub" fbc:upperFluxBound="cobra_default_ub">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_R_rxn00509_c0">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/seed.reaction/rxn00509"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.reaction/R00714"/>
+                  <rdf:li rdf:resource="https://identifiers.org/bigg.reaction/SSALy"/>
+                  <rdf:li rdf:resource="https://identifiers.org/biocyc/META:RXN0-5293"/>
+                  <rdf:li rdf:resource="https://identifiers.org/biocyc/SUCCSEMIALDDEHYDROG-RXN"/>
+                  <rdf:li rdf:resource="https://identifiers.org/ec-code/1.2.1.16"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+        <listOfReactants>
+          <speciesReference species="M_cpd00199_c0" stoichiometry="1" constant="true"/>
+          <speciesReference species="M_cpd00006_c0" stoichiometry="1" constant="true"/>
+          <speciesReference species="M_cpd00001_c0" stoichiometry="1" constant="true"/>
+        </listOfReactants>
+        <listOfProducts>
+          <speciesReference species="M_cpd00036_c0" stoichiometry="1" constant="true"/>
+          <speciesReference species="M_cpd00005_c0" stoichiometry="1" constant="true"/>
+          <speciesReference species="M_cpd00067_c0" stoichiometry="2" constant="true"/>
+        </listOfProducts>
+        <fbc:geneProductAssociation>
+          <fbc:or>
+            <fbc:geneProductRef fbc:geneProduct="G_ACZ81_RS14055"/>
+            <fbc:geneProductRef fbc:geneProduct="G_ACZ81_RS19350"/>
+          </fbc:or>
+        </fbc:geneProductAssociation>
+      </reaction>
+      <reaction id="R_rxn01011_c0" name="Glycerate:NAD+ oxidoreductase [c0]" reversible="false" fast="false" fbc:lowerFluxBound="cobra_default_ub" fbc:upperFluxBound="cobra_default_ub">
+        <listOfReactants>
+          <speciesReference species="M_cpd00145_c0" stoichiometry="1" constant="true"/>
+          <speciesReference species="M_cpd00004_c0" stoichiometry="1" constant="true"/>
+          <speciesReference species="M_cpd00067_c0" stoichiometry="1" constant="true"/>
+        </listOfReactants>
+        <listOfProducts>
+          <speciesReference species="M_cpd00223_c0" stoichiometry="1" constant="true"/>
+          <speciesReference species="M_cpd00003_c0" stoichiometry="1" constant="true"/>
+        </listOfProducts>
+        <fbc:geneProductAssociation>
+          <fbc:or>
+            <fbc:geneProductRef fbc:geneProduct="G_ACZ81_RS02770"/>
+            <fbc:geneProductRef fbc:geneProduct="G_ACZ81_RS07000"/>
+            <fbc:geneProductRef fbc:geneProduct="G_ACZ81_RS19665"/>
+            <fbc:geneProductRef fbc:geneProduct="G_ACZ81_RS09935"/>
+          </fbc:or>
+        </fbc:geneProductAssociation>
+      </reaction>
+      <reaction id="R_rxn01013_c0" name="Glycerate:NAD+ oxidoreductase [c0]" reversible="false" fast="false" fbc:lowerFluxBound="cobra_default_ub" fbc:upperFluxBound="cobra_default_ub">
+        <listOfReactants>
+          <speciesReference species="M_cpd00145_c0" stoichiometry="1" constant="true"/>
+          <speciesReference species="M_cpd00005_c0" stoichiometry="1" constant="true"/>
+          <speciesReference species="M_cpd00067_c0" stoichiometry="1" constant="true"/>
+        </listOfReactants>
+        <listOfProducts>
+          <speciesReference species="M_cpd00223_c0" stoichiometry="1" constant="true"/>
+          <speciesReference species="M_cpd00006_c0" stoichiometry="1" constant="true"/>
+        </listOfProducts>
+        <fbc:geneProductAssociation>
+          <fbc:or>
+            <fbc:geneProductRef fbc:geneProduct="G_ACZ81_RS02770"/>
+            <fbc:geneProductRef fbc:geneProduct="G_ACZ81_RS18510"/>
+            <fbc:geneProductRef fbc:geneProduct="G_ACZ81_RS07295"/>
+            <fbc:geneProductRef fbc:geneProduct="G_ACZ81_RS09945"/>
+            <fbc:geneProductRef fbc:geneProduct="G_ACZ81_RS15450"/>
+          </fbc:or>
+        </fbc:geneProductAssociation>
+      </reaction>
+      <reaction metaid="meta_R_rxn01053_c0" sboTerm="SBO:0000176" id="R_rxn01053_c0" name="(S)-lactaldehyde:NAD+ oxidoreductase [c0]" reversible="false" fast="false" fbc:lowerFluxBound="cobra_default_ub" fbc:upperFluxBound="cobra_default_ub">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_R_rxn01053_c0">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/bigg.reaction/LCADm"/>
+                  <rdf:li rdf:resource="https://identifiers.org/bigg.reaction/LCAD"/>
+                  <rdf:li rdf:resource="https://identifiers.org/bigg.reaction/LCADi"/>
+                  <rdf:li rdf:resource="https://identifiers.org/bigg.reaction/ALD5_2"/>
+                  <rdf:li rdf:resource="https://identifiers.org/biocyc/META:LACTALDDEHYDROG-RXN"/>
+                  <rdf:li rdf:resource="https://identifiers.org/biocyc/META:ALDEHYDE-DEHYDROGENASE-NADORNOP+-RXN"/>
+                  <rdf:li rdf:resource="https://identifiers.org/biocyc/META:RXN-12166"/>
+                  <rdf:li rdf:resource="https://identifiers.org/ec-code/1.2.1.21"/>
+                  <rdf:li rdf:resource="https://identifiers.org/ec-code/1.2.1.22"/>
+                  <rdf:li rdf:resource="https://identifiers.org/ec-code/1.2.1.-"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K07248"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K19266"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.reaction/R01446"/>
+                  <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR101018"/>
+                  <rdf:li rdf:resource="https://identifiers.org/rhea/14280"/>
+                  <rdf:li rdf:resource="https://identifiers.org/rhea/14278"/>
+                  <rdf:li rdf:resource="https://identifiers.org/seed.reaction/rxn01053"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+        <listOfReactants>
+          <speciesReference species="M_cpd00334_c0" stoichiometry="1" constant="true"/>
+          <speciesReference species="M_cpd00001_c0" stoichiometry="1" constant="true"/>
+          <speciesReference species="M_cpd00003_c0" stoichiometry="1" constant="true"/>
+        </listOfReactants>
+        <listOfProducts>
+          <speciesReference species="M_cpd00004_c0" stoichiometry="1" constant="true"/>
+          <speciesReference species="M_cpd00067_c0" stoichiometry="2" constant="true"/>
+          <speciesReference species="M_cpd00159_c0" stoichiometry="1" constant="true"/>
+        </listOfProducts>
+        <fbc:geneProductAssociation>
+          <fbc:or>
+            <fbc:geneProductRef fbc:geneProduct="G_ACZ81_RS14055"/>
+            <fbc:geneProductRef fbc:geneProduct="G_ACZ81_RS02375"/>
+          </fbc:or>
+        </fbc:geneProductAssociation>
+      </reaction>
+      <reaction metaid="meta_R_rxn01199_c0" sboTerm="SBO:0000176" id="R_rxn01199_c0" name="ATP:D-xylulose 5-phosphotransferase [c0]" reversible="false" fast="false" fbc:lowerFluxBound="cobra_default_ub" fbc:upperFluxBound="cobra_default_ub">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_R_rxn01199_c0">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/ec-code/2.7.1.17"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.reaction/R01639"/>
+                  <rdf:li rdf:resource="https://identifiers.org/seed.reaction/rxn01199_c0"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+        <listOfReactants>
+          <speciesReference species="M_cpd00259_c0" stoichiometry="1" constant="true"/>
+          <speciesReference species="M_cpd00002_c0" stoichiometry="1" constant="true"/>
+        </listOfReactants>
+        <listOfProducts>
+          <speciesReference species="M_cpd00008_c0" stoichiometry="1" constant="true"/>
+          <speciesReference species="M_cpd00067_c0" stoichiometry="1" constant="true"/>
+          <speciesReference species="M_cpd00198_c0" stoichiometry="1" constant="true"/>
+        </listOfProducts>
+        <fbc:geneProductAssociation>
+          <fbc:geneProductRef fbc:geneProduct="G_ACZ81_RS01015"/>
+        </fbc:geneProductAssociation>
+      </reaction>
+      <reaction metaid="meta_R_rxn01305_c0" sboTerm="SBO:0000176" id="R_rxn01305_c0" name="1,2-Ethanediol:NAD+ oxidoreductase [c0]" reversible="false" fast="false" fbc:lowerFluxBound="cobra_default_ub" fbc:upperFluxBound="cobra_default_ub">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_R_rxn01305_c0">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/seed.reaction/rxn01305"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.reaction/R01781"/>
+                  <rdf:li rdf:resource="https://identifiers.org/biocyc/META:GLYCOLALDREDUCT-RXN"/>
+                  <rdf:li rdf:resource="https://identifiers.org/ec-code/1.1.1.77"/>
+                  <rdf:li rdf:resource="https://identifiers.org/ec-code/1.1.1.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+        <listOfReactants>
+          <speciesReference species="M_cpd00229_c0" stoichiometry="1" constant="true"/>
+          <speciesReference species="M_cpd00004_c0" stoichiometry="1" constant="true"/>
+          <speciesReference species="M_cpd00067_c0" stoichiometry="1" constant="true"/>
+        </listOfReactants>
+        <listOfProducts>
+          <speciesReference species="M_cpd00992_c0" stoichiometry="1" constant="true"/>
+          <speciesReference species="M_cpd00003_c0" stoichiometry="1" constant="true"/>
+        </listOfProducts>
+        <fbc:geneProductAssociation>
+          <fbc:or>
+            <fbc:geneProductRef fbc:geneProduct="G_ACZ81_RS02770"/>
+            <fbc:geneProductRef fbc:geneProduct="G_ACZ81_RS07000"/>
+          </fbc:or>
+        </fbc:geneProductAssociation>
+      </reaction>
+      <reaction metaid="meta_R_rxn01802_c0" sboTerm="SBO:0000176" id="R_rxn01802_c0" name="Glutaryl-CoA:FAD 2,3-oxidoreductase (decarboxylating) [c0]" reversible="false" fast="false" fbc:lowerFluxBound="cobra_default_ub" fbc:upperFluxBound="cobra_default_ub">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_R_rxn01802_c0">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/seed.reaction/rxn01802"/>
+                  <rdf:li rdf:resource="https://identifiers.org/bigg.reaction/GLUTCOADHc"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.reaction/R02487"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+        <listOfReactants>
+          <speciesReference species="M_cpd00413_c0" stoichiometry="1" constant="true"/>
+          <speciesReference species="M_cpd00015_c0" stoichiometry="1" constant="true"/>
+          <speciesReference species="M_cpd00067_c0" stoichiometry="2" constant="true"/>
+        </listOfReactants>
+        <listOfProducts>
+          <speciesReference species="M_cpd00650_c0" stoichiometry="1" constant="true"/>
+          <speciesReference species="M_cpd00982_c0" stoichiometry="1" constant="true"/>
+          <speciesReference species="M_cpd00011_c0" stoichiometry="1" constant="true"/>
+        </listOfProducts>
+        <fbc:geneProductAssociation>
+          <fbc:geneProductRef fbc:geneProduct="G_ACZ81_RS08270"/>
+        </fbc:geneProductAssociation>
+      </reaction>
+      <reaction metaid="meta_R_rxn02226_c0" sboTerm="SBO:0000176" id="R_rxn02226_c0" name="2-Amino-6-oxohexanoate:NAD+ oxidoreductase [c0]" reversible="false" fast="false" fbc:lowerFluxBound="cobra_default_ub" fbc:upperFluxBound="cobra_default_ub">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_R_rxn02226_c0">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/seed.reaction/rxn02226"/>
+                  <rdf:li rdf:resource="https://identifiers.org/bigg.reaction/AASAD3"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.reaction/R03102"/>
+                  <rdf:li rdf:resource="https://identifiers.org/biocyc/META:1.2.1.31-RXN"/>
+                  <rdf:li rdf:resource="https://identifiers.org/biocyc/META:ALLYSINE-DEHYDROG-RXN"/>
+                  <rdf:li rdf:resource="https://identifiers.org/ec-code/1.2.1.31"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+        <listOfReactants>
+          <speciesReference species="M_cpd02522_c0" stoichiometry="1" constant="true"/>
+          <speciesReference species="M_cpd00003_c0" stoichiometry="1" constant="true"/>
+          <speciesReference species="M_cpd00001_c0" stoichiometry="1" constant="true"/>
+        </listOfReactants>
+        <listOfProducts>
+          <speciesReference species="M_cpd00705_c0" stoichiometry="1" constant="true"/>
+          <speciesReference species="M_cpd00004_c0" stoichiometry="1" constant="true"/>
+          <speciesReference species="M_cpd00067_c0" stoichiometry="2" constant="true"/>
+        </listOfProducts>
+        <fbc:geneProductAssociation>
+          <fbc:or>
+            <fbc:geneProductRef fbc:geneProduct="G_ACZ81_RS14055"/>
+            <fbc:geneProductRef fbc:geneProduct="G_ACZ81_RS02375"/>
+          </fbc:or>
+        </fbc:geneProductAssociation>
+      </reaction>
+      <reaction metaid="meta_R_rxn02271_c0" sboTerm="SBO:0000176" id="R_rxn02271_c0" name="(S)-2-methylbutanoyl-CoA:enzyme N6-(dihydrolipoyl)lysine S-(2-methylbutanoyl)transferase [c0]" reversible="false" fast="false" fbc:lowerFluxBound="cobra_default_ub" fbc:upperFluxBound="cobra_default_ub">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_R_rxn02271_c0">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/ec-code/2.3.1.168"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K09699"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.reaction/R03174"/>
+                  <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR135216"/>
+                  <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR108002"/>
+                  <rdf:li rdf:resource="https://identifiers.org/seed.reaction/rxn02271"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+        <listOfReactants>
+          <speciesReference species="M_cpd00760_c0" stoichiometry="1" constant="true"/>
+          <speciesReference species="M_cpd16584_c0" stoichiometry="1" constant="true"/>
+        </listOfReactants>
+        <listOfProducts>
+          <speciesReference species="M_cpd03045_c0" stoichiometry="1" constant="true"/>
+          <speciesReference species="M_cpd00010_c0" stoichiometry="1" constant="true"/>
+        </listOfProducts>
+        <fbc:geneProductAssociation>
+          <fbc:geneProductRef fbc:geneProduct="G_ACZ81_RS10155"/>
+        </fbc:geneProductAssociation>
+      </reaction>
+      <reaction metaid="meta_R_rxn02867_c0" sboTerm="SBO:0000176" id="R_rxn02867_c0" name="3-methylbutanoyl-CoA:enzyme N6-(dihydrolipoyl)lysine S-(3-methylbutanoyl)transferase [c0]" reversible="false" fast="false" fbc:lowerFluxBound="cobra_default_ub" fbc:upperFluxBound="cobra_default_ub">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_R_rxn02867_c0">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/ec-code/2.3.1.168"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K09699"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.reaction/R04097"/>
+                  <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR142209"/>
+                  <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR108654"/>
+                  <rdf:li rdf:resource="https://identifiers.org/seed.reaction/rxn02867"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+        <listOfReactants>
+          <speciesReference species="M_cpd01882_c0" stoichiometry="1" constant="true"/>
+          <speciesReference species="M_cpd16584_c0" stoichiometry="1" constant="true"/>
+        </listOfReactants>
+        <listOfProducts>
+          <speciesReference species="M_cpd03046_c0" stoichiometry="1" constant="true"/>
+          <speciesReference species="M_cpd00010_c0" stoichiometry="1" constant="true"/>
+        </listOfProducts>
+        <fbc:geneProductAssociation>
+          <fbc:geneProductRef fbc:geneProduct="G_ACZ81_RS10155"/>
+        </fbc:geneProductAssociation>
+      </reaction>
+      <reaction metaid="meta_R_rxn05039_c0" sboTerm="SBO:0000176" id="R_rxn05039_c0" name="5-amino-6-(5-phosphoribitylamino)uracil phosphatase" reversible="false" fast="false" fbc:lowerFluxBound="cobra_default_ub" fbc:upperFluxBound="cobra_default_ub">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_R_rxn05039_c0">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/bigg.reaction/PMDPHT"/>
+                  <rdf:li rdf:resource="https://identifiers.org/biocyc/META:RIBOPHOSPHAT-RXN"/>
+                  <rdf:li rdf:resource="https://identifiers.org/ec-code/3.1.3.104"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K22912"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K20861"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K21063"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K20860"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K20862"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K21064"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.reaction/R07280"/>
+                  <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR96145"/>
+                  <rdf:li rdf:resource="https://identifiers.org/seed.reaction/rxn05039"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+        <listOfReactants>
+          <speciesReference species="M_cpd00001_c0" stoichiometry="1" constant="true"/>
+          <speciesReference species="M_cpd02720_c0" stoichiometry="1" constant="true"/>
+        </listOfReactants>
+        <listOfProducts>
+          <speciesReference species="M_cpd00009_c0" stoichiometry="1" constant="true"/>
+          <speciesReference species="M_cpd02882_c0" stoichiometry="1" constant="true"/>
+        </listOfProducts>
+        <fbc:geneProductAssociation>
+          <fbc:geneProductRef fbc:geneProduct="G_ACZ81_RS00825"/>
+        </fbc:geneProductAssociation>
+      </reaction>
+      <reaction metaid="meta_R_rxn05212_c0" sboTerm="SBO:0000587" id="R_rxn05212_c0" name="Uptake of divalent copper by CopCD" reversible="false" fast="false" fbc:lowerFluxBound="cobra_default_ub" fbc:upperFluxBound="cobra_default_ub">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_R_rxn05212_c0">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/seed.reaction/rxn05212"/>
+                  <rdf:li rdf:resource="https://identifiers.org/bigg.reaction/CU2text"/>
+                  <rdf:li rdf:resource="https://identifiers.org/bigg.reaction/CU2tpp"/>
+                  <rdf:li rdf:resource="https://identifiers.org/biocyc/META:RXN0-14"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+        <listOfReactants>
+          <speciesReference species="M_cpd00058_e0" stoichiometry="1" constant="true"/>
+        </listOfReactants>
+        <listOfProducts>
+          <speciesReference species="M_cpd00058_c0" stoichiometry="1" constant="true"/>
+        </listOfProducts>
+        <fbc:geneProductAssociation>
+          <fbc:and>
+            <fbc:geneProductRef fbc:geneProduct="G_ACZ81_RS20345"/>
+            <fbc:geneProductRef fbc:geneProduct="G_ACZ81_RS20340"/>
+          </fbc:and>
+        </fbc:geneProductAssociation>
+      </reaction>
+      <reaction metaid="meta_R_rxn05464_c0" sboTerm="SBO:0000176" id="R_rxn05464_c0" name="Octadecanoyl-ACP:NADP+ oxidoreductase" reversible="false" fast="false" fbc:lowerFluxBound="cobra_default_ub" fbc:upperFluxBound="cobra_default_ub">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_R_rxn05464_c0">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/bigg.reaction/EAR180y"/>
+                  <rdf:li rdf:resource="https://identifiers.org/ec-code/1.3.1.9"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K00665"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K00208"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K00668"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K07512"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K10780"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.reaction/R01404"/>
+                  <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR97860"/>
+                  <rdf:li rdf:resource="https://identifiers.org/seed.reaction/rxn05464"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+        <listOfReactants>
+          <speciesReference species="M_cpd00004_c0" stoichiometry="1" constant="true"/>
+          <speciesReference species="M_cpd00067_c0" stoichiometry="1" constant="true"/>
+          <speciesReference species="M_cpd11572_c0" stoichiometry="1" constant="true"/>
+        </listOfReactants>
+        <listOfProducts>
+          <speciesReference species="M_cpd00003_c0" stoichiometry="1" constant="true"/>
+          <speciesReference species="M_cpd15268_c0" stoichiometry="1" constant="true"/>
+        </listOfProducts>
+        <fbc:geneProductAssociation>
+          <fbc:geneProductRef fbc:geneProduct="G_ACZ81_RS16715"/>
+        </fbc:geneProductAssociation>
+      </reaction>
+      <reaction metaid="meta_R_rxn05495_c0" sboTerm="SBO:0000185" id="R_rxn05495_c0" name="beta-Alanine transport via sodium symport" reversible="false" fast="false" fbc:lowerFluxBound="cobra_default_ub" fbc:upperFluxBound="cobra_default_ub">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_R_rxn05495_c0">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/seed.reaction/rxn05495"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+        <listOfReactants>
+          <speciesReference species="M_cpd00085_e0" stoichiometry="1" constant="true"/>
+          <speciesReference species="M_cpd00971_e0" stoichiometry="1" constant="true"/>
+        </listOfReactants>
+        <listOfProducts>
+          <speciesReference species="M_cpd00971_c0" stoichiometry="1" constant="true"/>
+          <speciesReference species="M_cpd00085_c0" stoichiometry="1" constant="true"/>
+        </listOfProducts>
+        <fbc:geneProductAssociation>
+          <fbc:geneProductRef fbc:geneProduct="G_ACZ81_RS11460"/>
+        </fbc:geneProductAssociation>
+      </reaction>
+      <reaction metaid="meta_R_rxn05684_c0" sboTerm="SBO:0000655" id="R_rxn05684_c0" name="TRANS-RXN-242.cp [c0]" reversible="false" fast="false" fbc:lowerFluxBound="cobra_default_ub" fbc:upperFluxBound="cobra_default_ub">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_R_rxn05684_c0">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/bigg.reaction/HOMt"/>
+                  <rdf:li rdf:resource="https://identifiers.org/bigg.reaction/HOMt2pp"/>
+                  <rdf:li rdf:resource="https://identifiers.org/biocyc/META:TRANS-RXN-242"/>
+                  <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR100676"/>
+                  <rdf:li rdf:resource="https://identifiers.org/rhea/35028"/>
+                  <rdf:li rdf:resource="https://identifiers.org/seed.reaction/rxn05684"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+        <listOfReactants>
+          <speciesReference species="M_cpd00227_c0" stoichiometry="1" constant="true"/>
+          <speciesReference species="M_cpd00971_c0" stoichiometry="1" constant="true"/>
+        </listOfReactants>
+        <listOfProducts>
+          <speciesReference species="M_cpd00227_e0" stoichiometry="1" constant="true"/>
+          <speciesReference species="M_cpd00971_e0" stoichiometry="1" constant="true"/>
+        </listOfProducts>
+        <fbc:geneProductAssociation>
+          <fbc:geneProductRef fbc:geneProduct="G_ACZ81_RS11460"/>
+        </fbc:geneProductAssociation>
+      </reaction>
+      <reaction metaid="meta_R_rxn05894_c0" sboTerm="SBO:0000176" id="R_rxn05894_c0" name="Nitrate:ferredoxin oxidoreductase [c0]" reversible="false" fast="false" fbc:lowerFluxBound="cobra_default_ub" fbc:upperFluxBound="cobra_default_ub">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_R_rxn05894_c0">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/seed.reaction/rxn05894_c0"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.reaction/R00791"/>
+                  <rdf:li rdf:resource="https://identifiers.org/ec-code/1.7.7.2"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+        <listOfReactants>
+          <speciesReference species="M_cpd00209_c0" stoichiometry="1" constant="true"/>
+          <speciesReference species="M_cpd11620_c0" stoichiometry="1" constant="true"/>
+          <speciesReference species="M_cpd00067_c0" stoichiometry="2" constant="true"/>
+        </listOfReactants>
+        <listOfProducts>
+          <speciesReference species="M_cpd00075_c0" stoichiometry="1" constant="true"/>
+          <speciesReference species="M_cpd11621_c0" stoichiometry="1" constant="true"/>
+          <speciesReference species="M_cpd00001_c0" stoichiometry="1" constant="true"/>
+        </listOfProducts>
+        <fbc:geneProductAssociation>
+          <fbc:geneProductRef fbc:geneProduct="G_ACZ81_RS16285"/>
+        </fbc:geneProductAssociation>
+      </reaction>
+      <reaction metaid="meta_R_rxn06937_c0" sboTerm="SBO:0000176" id="R_rxn06937_c0" name="L-glutamate:tRNA(Glu) ligase (AMP-forming)" reversible="false" fast="false" fbc:lowerFluxBound="cobra_default_ub" fbc:upperFluxBound="cobra_default_ub">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_R_rxn06937_c0">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/bigg.reaction/GLUTRS"/>
+                  <rdf:li rdf:resource="https://identifiers.org/ec-code/6.1.1.17"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K01885"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K09698"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K14163"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.reaction/R05578"/>
+                  <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR145083"/>
+                  <rdf:li rdf:resource="https://identifiers.org/seed.reaction/rxn06937"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+        <listOfReactants>
+          <speciesReference species="M_cpd00002_c0" stoichiometry="1" constant="true"/>
+          <speciesReference species="M_cpd00023_c0" stoichiometry="1" constant="true"/>
+          <speciesReference species="M_cpd11912_c0" stoichiometry="1" constant="true"/>
+        </listOfReactants>
+        <listOfProducts>
+          <speciesReference species="M_cpd00012_c0" stoichiometry="1" constant="true"/>
+          <speciesReference species="M_cpd00018_c0" stoichiometry="1" constant="true"/>
+          <speciesReference species="M_cpd00067_c0" stoichiometry="1" constant="true"/>
+          <speciesReference species="M_cpd12227_c0" stoichiometry="1" constant="true"/>
+        </listOfProducts>
+        <fbc:geneProductAssociation>
+          <fbc:geneProductRef fbc:geneProduct="G_ACZ81_RS06785"/>
+        </fbc:geneProductAssociation>
+      </reaction>
+      <reaction metaid="meta_R_rxn09247_c0" sboTerm="SBO:0000185" id="R_rxn09247_c0" name="L-Serine transport via sodium symport" reversible="false" fast="false" fbc:lowerFluxBound="cobra_default_ub" fbc:upperFluxBound="cobra_default_ub">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_R_rxn09247_c0">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/seed.reaction/rxn09247"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+        <listOfReactants>
+          <speciesReference species="M_cpd00054_e0" stoichiometry="1" constant="true"/>
+          <speciesReference species="M_cpd00971_e0" stoichiometry="1" constant="true"/>
+        </listOfReactants>
+        <listOfProducts>
+          <speciesReference species="M_cpd00971_c0" stoichiometry="1" constant="true"/>
+          <speciesReference species="M_cpd00054_c0" stoichiometry="1" constant="true"/>
+        </listOfProducts>
+        <fbc:geneProductAssociation>
+          <fbc:geneProductRef fbc:geneProduct="G_ACZ81_RS11460"/>
+        </fbc:geneProductAssociation>
+      </reaction>
+      <reaction metaid="meta_R_rxn09306_c0" sboTerm="SBO:0000655" id="R_rxn09306_c0" name="TRANS-RXN-244.cp [c0]" reversible="false" fast="false" fbc:lowerFluxBound="cobra_default_ub" fbc:upperFluxBound="cobra_default_ub">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_R_rxn09306_c0">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/bigg.reaction/THRt2pp"/>
+                  <rdf:li rdf:resource="https://identifiers.org/bigg.reaction/THRt3"/>
+                  <rdf:li rdf:resource="https://identifiers.org/biocyc/META:TRANS-RXN0-0244"/>
+                  <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR104851"/>
+                  <rdf:li rdf:resource="https://identifiers.org/seed.reaction/rxn09306"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+        <listOfReactants>
+          <speciesReference species="M_cpd00161_c0" stoichiometry="1" constant="true"/>
+          <speciesReference species="M_cpd00971_c0" stoichiometry="1" constant="true"/>
+        </listOfReactants>
+        <listOfProducts>
+          <speciesReference species="M_cpd00161_e0" stoichiometry="1" constant="true"/>
+          <speciesReference species="M_cpd00971_e0" stoichiometry="1" constant="true"/>
+        </listOfProducts>
+        <fbc:geneProductAssociation>
+          <fbc:geneProductRef fbc:geneProduct="G_ACZ81_RS11460"/>
+        </fbc:geneProductAssociation>
+      </reaction>
+      <reaction metaid="meta_R_rxn11955_c0" sboTerm="SBO:0000176" id="R_rxn11955_c0" name="2-Oxoadipate:lipoamide 2-oxidoreductase (decarboxylating and acceptor-succinylating) [c0]" reversible="false" fast="false" fbc:lowerFluxBound="cobra_default_ub" fbc:upperFluxBound="cobra_default_ub">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_R_rxn11955_c0">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/seed.reaction/rxn11955"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.reaction/R01940"/>
+                  <rdf:li rdf:resource="https://identifiers.org/ec-code/1.2.4.2"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+        <listOfReactants>
+          <speciesReference species="M_cpd00269_c0" stoichiometry="1" constant="true"/>
+          <speciesReference species="M_cpd14954_c0" stoichiometry="1" constant="true"/>
+          <speciesReference species="M_cpd00067_c0" stoichiometry="1" constant="true"/>
+        </listOfReactants>
+        <listOfProducts>
+          <speciesReference species="M_cpd16479_c0" stoichiometry="1" constant="true"/>
+          <speciesReference species="M_cpd00011_c0" stoichiometry="1" constant="true"/>
+        </listOfProducts>
+        <fbc:geneProductAssociation>
+          <fbc:and>
+            <fbc:geneProductRef fbc:geneProduct="G_ACZ81_RS09795"/>
+            <fbc:geneProductRef fbc:geneProduct="G_ACZ81_RS09800"/>
+          </fbc:and>
+        </fbc:geneProductAssociation>
+      </reaction>
+      <reaction metaid="meta_R_rxn11960_c0" sboTerm="SBO:0000176" id="R_rxn11960_c0" name="Glutaryl-CoA:dihydrolipoamide S-succinyltransferase [c0]" reversible="false" fast="false" fbc:lowerFluxBound="cobra_default_ub" fbc:upperFluxBound="cobra_default_ub">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_R_rxn11960_c0">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/seed.reaction/rxn11960"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.reaction/R02571"/>
+                  <rdf:li rdf:resource="https://identifiers.org/ec-code/2.3.1.61"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+        <listOfReactants>
+          <speciesReference species="M_cpd16479_c0" stoichiometry="1" constant="true"/>
+          <speciesReference species="M_cpd00010_c0" stoichiometry="1" constant="true"/>
+        </listOfReactants>
+        <listOfProducts>
+          <speciesReference species="M_cpd00413_c0" stoichiometry="1" constant="true"/>
+          <speciesReference species="M_cpd16584_c0" stoichiometry="1" constant="true"/>
+        </listOfProducts>
+        <fbc:geneProductAssociation>
+          <fbc:and>
+            <fbc:geneProductRef fbc:geneProduct="G_ACZ81_RS09800"/>
+            <fbc:geneProductRef fbc:geneProduct="G_ACZ81_RS14645"/>
+          </fbc:and>
+        </fbc:geneProductAssociation>
+      </reaction>
+      <reaction metaid="meta_R_rxn12191_c0" sboTerm="SBO:0000176" id="R_rxn12191_c0" name="Choline:NADP+ oxidoreductase [c0]" reversible="false" fast="false" fbc:lowerFluxBound="cobra_default_ub" fbc:upperFluxBound="cobra_default_ub">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_R_rxn12191_c0">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/seed.reaction/rxn01043"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.reaction/R08558"/>
+                  <rdf:li rdf:resource="https://identifiers.org/biocyc/META:RXN-12582"/>
+                  <rdf:li rdf:resource="https://identifiers.org/ec-code/1.1.1.2"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+        <listOfReactants>
+          <speciesReference species="M_cpd00447_c0" stoichiometry="1" constant="true"/>
+          <speciesReference species="M_cpd00005_c0" stoichiometry="1" constant="true"/>
+          <speciesReference species="M_cpd00067_c0" stoichiometry="1" constant="true"/>
+        </listOfReactants>
+        <listOfProducts>
+          <speciesReference species="M_cpd00098_c0" stoichiometry="1" constant="true"/>
+          <speciesReference species="M_cpd00006_c0" stoichiometry="1" constant="true"/>
+        </listOfProducts>
+        <fbc:geneProductAssociation>
+          <fbc:or>
+            <fbc:geneProductRef fbc:geneProduct="G_ACZ81_RS02770"/>
+            <fbc:geneProductRef fbc:geneProduct="G_ACZ81_RS18510"/>
+            <fbc:geneProductRef fbc:geneProduct="G_ACZ81_RS07295"/>
+            <fbc:geneProductRef fbc:geneProduct="G_ACZ81_RS14060"/>
+            <fbc:geneProductRef fbc:geneProduct="G_ACZ81_RS12500"/>
+          </fbc:or>
+        </fbc:geneProductAssociation>
+      </reaction>
+      <reaction metaid="meta_R_rxn12224_c0" sboTerm="SBO:0000176" id="R_rxn12224_c0" name="R04989 [c0]" reversible="false" fast="false" fbc:lowerFluxBound="cobra_default_ub" fbc:upperFluxBound="cobra_default_ub">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_R_rxn12224_c0">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/ec-code/1.14.13.-"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.reaction/R12658"/>
+                  <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR109273"/>
+                  <rdf:li rdf:resource="https://identifiers.org/seed.reaction/rxn12224"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+        <listOfReactants>
+          <speciesReference species="M_cpd00007_c0" stoichiometry="1" constant="true"/>
+          <speciesReference species="M_cpd03446_c0" stoichiometry="1" constant="true"/>
+        </listOfReactants>
+        <listOfProducts>
+          <speciesReference species="M_cpd00001_c0" stoichiometry="1" constant="true"/>
+          <speciesReference species="M_cpd03447_c0" stoichiometry="1" constant="true"/>
+        </listOfProducts>
+        <fbc:geneProductAssociation>
+          <fbc:geneProductRef fbc:geneProduct="G_ACZ81_RS14545"/>
+        </fbc:geneProductAssociation>
+      </reaction>
+      <reaction metaid="meta_R_rxn13688_c0" sboTerm="SBO:0000655" id="R_rxn13688_c0" name="cytochrome-c oxidase (2 protons translocated) [c0]" reversible="false" fast="false" fbc:lowerFluxBound="cobra_default_ub" fbc:upperFluxBound="cobra_default_ub">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_R_rxn13688_c0">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/seed.reaction/rxn13688"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+        <listOfReactants>
+          <speciesReference species="M_cpd00007_c0" stoichiometry="0.5" constant="true"/>
+          <speciesReference species="M_cpd00067_c0" stoichiometry="4" constant="true"/>
+          <speciesReference species="M_cpd00110_c0" stoichiometry="2" constant="true"/>
+        </listOfReactants>
+        <listOfProducts>
+          <speciesReference species="M_cpd00001_c0" stoichiometry="1" constant="true"/>
+          <speciesReference species="M_cpd00067_e0" stoichiometry="2" constant="true"/>
+          <speciesReference species="M_cpd00109_c0" stoichiometry="2" constant="true"/>
+        </listOfProducts>
+        <fbc:geneProductAssociation>
+          <fbc:and>
+            <fbc:geneProductRef fbc:geneProduct="G_ACZ81_RS19555"/>
+            <fbc:geneProductRef fbc:geneProduct="G_ACZ81_RS19565"/>
+            <fbc:geneProductRef fbc:geneProduct="G_ACZ81_RS19570"/>
+          </fbc:and>
+        </fbc:geneProductAssociation>
+      </reaction>
+      <reaction metaid="meta_R_rxn14045_c0" sboTerm="SBO:0000176" id="R_rxn14045_c0" name="biotin synthase [c0]" reversible="false" fast="false" fbc:lowerFluxBound="cobra_default_ub" fbc:upperFluxBound="cobra_default_ub">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_R_rxn14045_c0">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/biocyc/META:2.8.1.6-RXN"/>
+                  <rdf:li rdf:resource="https://identifiers.org/ec-code/2.8.1.6"/>
+                  <rdf:li rdf:resource="https://identifiers.org/seed.reaction/rxn17731"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+        <listOfReactants>
+          <speciesReference species="M_cpd00017_c0" stoichiometry="2" constant="true"/>
+          <speciesReference species="M_cpd01311_c0" stoichiometry="1" constant="true"/>
+          <speciesReference species="M_cpd24604_c0" stoichiometry="1" constant="true"/>
+          <speciesReference species="M_cpd11620_c0" stoichiometry="1" constant="true"/>
+          <speciesReference species="M_cpd00067_c0" stoichiometry="1" constant="true"/>
+        </listOfReactants>
+        <listOfProducts>
+          <speciesReference species="M_cpd00060_c0" stoichiometry="2" constant="true"/>
+          <speciesReference species="M_cpd00104_c0" stoichiometry="1" constant="true"/>
+          <speciesReference species="M_cpd03091_c0" stoichiometry="2" constant="true"/>
+          <speciesReference species="M_cpd11621_c0" stoichiometry="1" constant="true"/>
+          <speciesReference species="M_cpd10515_c0" stoichiometry="2" constant="true"/>
+          <speciesReference species="M_cpd00239_c0" stoichiometry="1" constant="true"/>
+        </listOfProducts>
+        <fbc:geneProductAssociation>
+          <fbc:and>
+            <fbc:geneProductRef fbc:geneProduct="G_ACZ81_RS06665"/>
+            <fbc:or>
+              <fbc:geneProductRef fbc:geneProduct="G_ACZ81_RS13510"/>
+              <fbc:geneProductRef fbc:geneProduct="G_ACZ81_RS13505"/>
+            </fbc:or>
+          </fbc:and>
+        </fbc:geneProductAssociation>
+      </reaction>
+      <reaction metaid="meta_R_rxn15341_c0" sboTerm="SBO:0000176" id="R_rxn15341_c0" name="Lactaldehyde:NAD+ 1-oxidoreductase [c0]" reversible="false" fast="false" fbc:lowerFluxBound="cobra_default_ub" fbc:upperFluxBound="cobra_default_ub">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_R_rxn15341_c0">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/seed.reaction/rxn15341"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.reaction/R02531"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.reaction/R10715"/>
+                  <rdf:li rdf:resource="https://identifiers.org/ec-code/1.1.1.1"/>
+                  <rdf:li rdf:resource="https://identifiers.org/ec-code/1.1.1.21"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+        <listOfReactants>
+          <speciesReference species="M_cpd00334_c0" stoichiometry="1" constant="true"/>
+          <speciesReference species="M_cpd00003_c0" stoichiometry="1" constant="true"/>
+        </listOfReactants>
+        <listOfProducts>
+          <speciesReference species="M_cpd00428_c0" stoichiometry="1" constant="true"/>
+          <speciesReference species="M_cpd00004_c0" stoichiometry="1" constant="true"/>
+          <speciesReference species="M_cpd00067_c0" stoichiometry="1" constant="true"/>
+        </listOfProducts>
+        <fbc:geneProductAssociation>
+          <fbc:or>
+            <fbc:geneProductRef fbc:geneProduct="G_ACZ81_RS02770"/>
+            <fbc:geneProductRef fbc:geneProduct="G_ACZ81_RS07000"/>
+          </fbc:or>
+        </fbc:geneProductAssociation>
+      </reaction>
+      <reaction metaid="meta_R_rxn16141_c0" sboTerm="SBO:0000176" id="R_rxn16141_c0" name="4-Hydroxybutanoate:NADP+ oxidoreductase [c0]" reversible="false" fast="false" fbc:lowerFluxBound="cobra_default_ub" fbc:upperFluxBound="cobra_default_ub">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_R_rxn16141_c0">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/seed.reaction/rxn16141"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.reaction/R09281"/>
+                  <rdf:li rdf:resource="https://identifiers.org/biocyc/META:RXN-11002"/>
+                  <rdf:li rdf:resource="https://identifiers.org/biocyc/RXN-6903"/>
+                  <rdf:li rdf:resource="https://identifiers.org/ec-code/1.1.1.2"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+        <listOfReactants>
+          <speciesReference species="M_cpd00199_c0" stoichiometry="1" constant="true"/>
+          <speciesReference species="M_cpd00005_c0" stoichiometry="1" constant="true"/>
+          <speciesReference species="M_cpd00067_c0" stoichiometry="1" constant="true"/>
+        </listOfReactants>
+        <listOfProducts>
+          <speciesReference species="M_cpd00728_c0" stoichiometry="1" constant="true"/>
+          <speciesReference species="M_cpd00006_c0" stoichiometry="1" constant="true"/>
+        </listOfProducts>
+        <fbc:geneProductAssociation>
+          <fbc:or>
+            <fbc:geneProductRef fbc:geneProduct="G_ACZ81_RS02770"/>
+            <fbc:geneProductRef fbc:geneProduct="G_ACZ81_RS18510"/>
+            <fbc:geneProductRef fbc:geneProduct="G_ACZ81_RS07295"/>
+            <fbc:geneProductRef fbc:geneProduct="G_ACZ81_RS09945"/>
+          </fbc:or>
+        </fbc:geneProductAssociation>
+      </reaction>
+      <reaction metaid="meta_R_rxn26398_c0" sboTerm="SBO:0000176" id="R_rxn26398_c0" name="R09982 [c0]" reversible="false" fast="false" fbc:lowerFluxBound="cobra_default_ub" fbc:upperFluxBound="cobra_default_ub">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_R_rxn26398_c0">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K09021"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.reaction/R09982"/>
+                  <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR113373"/>
+                  <rdf:li rdf:resource="https://identifiers.org/seed.reaction/rxn26398"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+        <listOfReactants>
+          <speciesReference species="M_cpd21482_c0" stoichiometry="1" constant="true"/>
+          <speciesReference species="M_cpd00004_c0" stoichiometry="1" constant="true"/>
+        </listOfReactants>
+        <listOfProducts>
+          <speciesReference species="M_cpd21486_c0" stoichiometry="1" constant="true"/>
+          <speciesReference species="M_cpd00003_c0" stoichiometry="1" constant="true"/>
+          <speciesReference species="M_cpd00001_c0" stoichiometry="1" constant="true"/>
+        </listOfProducts>
+        <fbc:geneProductAssociation>
+          <fbc:geneProductRef fbc:geneProduct="G_ACZ81_RS16600"/>
+        </fbc:geneProductAssociation>
+      </reaction>
+      <reaction metaid="meta_R_rxn29147_c0" sboTerm="SBO:0000587" id="R_rxn29147_c0" name="copper transport out via proton antiport [c0]" reversible="false" fast="false" fbc:lowerFluxBound="cobra_default_ub" fbc:upperFluxBound="cobra_default_ub">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_R_rxn29147_c0">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/seed.reaction/rxn29147"/>
+                  <rdf:li rdf:resource="https://identifiers.org/bigg.reaction/CUtex"/>
+                  <rdf:li rdf:resource="https://identifiers.org/biocyc/META:TRANS-RXN0-280"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+        <listOfReactants>
+          <speciesReference species="M_cpd30760_c0" stoichiometry="1" constant="true"/>
+          <speciesReference species="M_cpd00067_e0" stoichiometry="1" constant="true"/>
+        </listOfReactants>
+        <listOfProducts>
+          <speciesReference species="M_cpd00067_c0" stoichiometry="1" constant="true"/>
+          <speciesReference species="M_cpd30760_e0" stoichiometry="1" constant="true"/>
+        </listOfProducts>
+        <fbc:geneProductAssociation>
+          <fbc:and>
+            <fbc:geneProductRef fbc:geneProduct="G_ACZ81_RS14830"/>
+            <fbc:or>
+              <fbc:geneProductRef fbc:geneProduct="G_ACZ81_RS20360"/>
+              <fbc:geneProductRef fbc:geneProduct="G_ACZ81_RS14835"/>
+            </fbc:or>
+          </fbc:and>
+        </fbc:geneProductAssociation>
+      </reaction>
+      <reaction metaid="meta_R_rxn34491_c0" sboTerm="SBO:0000185" id="R_rxn34491_c0" name="L-Asparagine transport via sodium symport" reversible="false" fast="false" fbc:lowerFluxBound="cobra_default_ub" fbc:upperFluxBound="cobra_default_ub">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_R_rxn34491_c0">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/seed.reaction/rxn34491"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+        <listOfReactants>
+          <speciesReference species="M_cpd00132_e0" stoichiometry="1" constant="true"/>
+          <speciesReference species="M_cpd00971_e0" stoichiometry="1" constant="true"/>
+        </listOfReactants>
+        <listOfProducts>
+          <speciesReference species="M_cpd00971_c0" stoichiometry="1" constant="true"/>
+          <speciesReference species="M_cpd00132_c0" stoichiometry="1" constant="true"/>
+        </listOfProducts>
+        <fbc:geneProductAssociation>
+          <fbc:geneProductRef fbc:geneProduct="G_ACZ81_RS11460"/>
+        </fbc:geneProductAssociation>
+      </reaction>
+      <reaction metaid="meta_R_rxn35550_c0" sboTerm="SBO:0000176" id="R_rxn35550_c0" name="R07604 [c0]" reversible="false" fast="false" fbc:lowerFluxBound="cobra_default_ub" fbc:upperFluxBound="cobra_default_ub">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_R_rxn35550_c0">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/ec-code/1.2.4.4"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K11381"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K00166"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K00167"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.reaction/R07604"/>
+                  <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR111210"/>
+                  <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR142264"/>
+                  <rdf:li rdf:resource="https://identifiers.org/seed.reaction/rxn35550"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+        <listOfReactants>
+          <speciesReference species="M_cpd14702_c0" stoichiometry="1" constant="true"/>
+          <speciesReference species="M_cpd14954_c0" stoichiometry="1" constant="true"/>
+        </listOfReactants>
+        <listOfProducts>
+          <speciesReference species="M_cpd00056_c0" stoichiometry="1" constant="true"/>
+          <speciesReference species="M_cpd03045_c0" stoichiometry="1" constant="true"/>
+        </listOfProducts>
+        <fbc:geneProductAssociation>
+          <fbc:and>
+            <fbc:geneProductRef fbc:geneProduct="G_ACZ81_RS10150"/>
+            <fbc:geneProductRef fbc:geneProduct="G_ACZ81_RS10145"/>
+          </fbc:and>
+        </fbc:geneProductAssociation>
+      </reaction>
+      <reaction metaid="meta_R_rxn35552_c0" sboTerm="SBO:0000176" id="R_rxn35552_c0" name="R07602 [c0]" reversible="false" fast="false" fbc:lowerFluxBound="cobra_default_ub" fbc:upperFluxBound="cobra_default_ub">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_R_rxn35552_c0">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/ec-code/1.2.4.4"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K11381"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K00166"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K00167"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.reaction/R07602"/>
+                  <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR111209"/>
+                  <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR142262"/>
+                  <rdf:li rdf:resource="https://identifiers.org/seed.reaction/rxn35552"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+        <listOfReactants>
+          <speciesReference species="M_cpd14698_c0" stoichiometry="1" constant="true"/>
+          <speciesReference species="M_cpd14954_c0" stoichiometry="1" constant="true"/>
+        </listOfReactants>
+        <listOfProducts>
+          <speciesReference species="M_cpd00056_c0" stoichiometry="1" constant="true"/>
+          <speciesReference species="M_cpd03046_c0" stoichiometry="1" constant="true"/>
+        </listOfProducts>
+        <fbc:geneProductAssociation>
+          <fbc:and>
+            <fbc:geneProductRef fbc:geneProduct="G_ACZ81_RS10150"/>
+            <fbc:geneProductRef fbc:geneProduct="G_ACZ81_RS10145"/>
+          </fbc:and>
+        </fbc:geneProductAssociation>
+      </reaction>
+      <reaction metaid="meta_R_rxn36075_c0" sboTerm="SBO:0000176" id="R_rxn36075_c0" name="Propanal:NADP+ oxidoreductase [c0]" reversible="false" fast="false" fbc:lowerFluxBound="cobra_default_ub" fbc:upperFluxBound="cobra_default_ub">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_R_rxn36075_c0">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/seed.reaction/rxn36075"/>
+                  <rdf:li rdf:resource="https://identifiers.org/biocyc/META:ALCOHOL-DEHYDROGENASE-NADP+-RXN"/>
+                  <rdf:li rdf:resource="https://identifiers.org/ec-code/1.1.1.2"/>
+                  <rdf:li rdf:resource="https://identifiers.org/ec-code/1.1.1.71"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+        <listOfReactants>
+          <speciesReference species="M_cpd03559_c0" stoichiometry="1" constant="true"/>
+          <speciesReference species="M_cpd00006_c0" stoichiometry="1" constant="true"/>
+        </listOfReactants>
+        <listOfProducts>
+          <speciesReference species="M_cpd00005_c0" stoichiometry="1" constant="true"/>
+          <speciesReference species="M_cpd00067_c0" stoichiometry="1" constant="true"/>
+          <speciesReference species="M_cpd00371_c0" stoichiometry="1" constant="true"/>
+        </listOfProducts>
+        <fbc:geneProductAssociation>
+          <fbc:or>
+            <fbc:geneProductRef fbc:geneProduct="G_ACZ81_RS02770"/>
+            <fbc:geneProductRef fbc:geneProduct="G_ACZ81_RS18510"/>
+            <fbc:geneProductRef fbc:geneProduct="G_ACZ81_RS07295"/>
+          </fbc:or>
+        </fbc:geneProductAssociation>
+      </reaction>
+      <reaction metaid="meta_R_rxn39829_c0" sboTerm="SBO:0000176" id="R_rxn39829_c0" name="7-aminomethyl-7-carbaguanine:NADP+ oxidoreductase [c0]" reversible="false" fast="false" fbc:lowerFluxBound="cobra_default_ub" fbc:upperFluxBound="cobra_default_ub">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_R_rxn39829_c0">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/biocyc/META:RXN0-4022"/>
+                  <rdf:li rdf:resource="https://identifiers.org/ec-code/1.7.1.13"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K09457"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K06879"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.reaction/R07605"/>
+                  <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR135611"/>
+                  <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR96521"/>
+                  <rdf:li rdf:resource="https://identifiers.org/rhea/13412"/>
+                  <rdf:li rdf:resource="https://identifiers.org/seed.reaction/rxn39829"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+        <listOfReactants>
+          <speciesReference species="M_cpd19185_c0" stoichiometry="1" constant="true"/>
+          <speciesReference species="M_cpd00006_c0" stoichiometry="2" constant="true"/>
+        </listOfReactants>
+        <listOfProducts>
+          <speciesReference species="M_cpd00005_c0" stoichiometry="2" constant="true"/>
+          <speciesReference species="M_cpd00067_c0" stoichiometry="3" constant="true"/>
+          <speciesReference species="M_cpd14718_c0" stoichiometry="1" constant="true"/>
+        </listOfProducts>
+        <fbc:geneProductAssociation>
+          <fbc:geneProductRef fbc:geneProduct="G_ACZ81_RS04765"/>
+        </fbc:geneProductAssociation>
+      </reaction>
+      <reaction metaid="meta_R_rxn43611_c0" sboTerm="SBO:0000176" id="R_rxn43611_c0" name="1,2-Ethanediol:NADP+ oxidoreductase [c0]" reversible="false" fast="false" fbc:lowerFluxBound="cobra_default_ub" fbc:upperFluxBound="cobra_default_ub">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_R_rxn43611_c0">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/seed.reaction/rxn43611"/>
+                  <rdf:li rdf:resource="https://identifiers.org/biocyc/META:RXN-14023"/>
+                  <rdf:li rdf:resource="https://identifiers.org/ec-code/1.1.1.2"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+        <listOfReactants>
+          <speciesReference species="M_cpd00229_c0" stoichiometry="1" constant="true"/>
+          <speciesReference species="M_cpd00005_c0" stoichiometry="1" constant="true"/>
+          <speciesReference species="M_cpd00067_c0" stoichiometry="1" constant="true"/>
+        </listOfReactants>
+        <listOfProducts>
+          <speciesReference species="M_cpd00006_c0" stoichiometry="1" constant="true"/>
+          <speciesReference species="M_cpd00992_c0" stoichiometry="1" constant="true"/>
+        </listOfProducts>
+        <fbc:geneProductAssociation>
+          <fbc:or>
+            <fbc:geneProductRef fbc:geneProduct="G_ACZ81_RS02770"/>
+            <fbc:geneProductRef fbc:geneProduct="G_ACZ81_RS18510"/>
+            <fbc:geneProductRef fbc:geneProduct="G_ACZ81_RS07295"/>
+          </fbc:or>
+        </fbc:geneProductAssociation>
+      </reaction>
+      <reaction metaid="meta_R_rxn45550_c0" sboTerm="SBO:0000176" id="R_rxn45550_c0" name="RXN-11482.c [c0]" reversible="false" fast="false" fbc:lowerFluxBound="cobra_default_ub" fbc:upperFluxBound="cobra_default_ub">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_R_rxn45550_c0">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/biocyc/META:RXN-11482"/>
+                  <rdf:li rdf:resource="https://identifiers.org/ec-code/1.3.1.9"/>
+                  <rdf:li rdf:resource="https://identifiers.org/seed.reaction/rxn45550"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+        <listOfReactants>
+          <speciesReference species="M_cpd00067_c0" stoichiometry="1" constant="true"/>
+          <speciesReference species="M_cpd27021_c0" stoichiometry="1" constant="true"/>
+          <speciesReference species="M_cpd00004_c0" stoichiometry="1" constant="true"/>
+        </listOfReactants>
+        <listOfProducts>
+          <speciesReference species="M_cpd21088_c0" stoichiometry="1" constant="true"/>
+          <speciesReference species="M_cpd00003_c0" stoichiometry="1" constant="true"/>
+        </listOfProducts>
+        <fbc:geneProductAssociation>
+          <fbc:geneProductRef fbc:geneProduct="G_ACZ81_RS16715"/>
+        </fbc:geneProductAssociation>
+      </reaction>
+      <reaction metaid="meta_R_rxn46124_c0" sboTerm="SBO:0000176" id="R_rxn46124_c0" name="RXN-11478.c [c0]" reversible="false" fast="false" fbc:lowerFluxBound="cobra_default_ub" fbc:upperFluxBound="cobra_default_ub">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_R_rxn46124_c0">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/biocyc/META:RXN-11478"/>
+                  <rdf:li rdf:resource="https://identifiers.org/ec-code/1.3.1.9"/>
+                  <rdf:li rdf:resource="https://identifiers.org/seed.reaction/rxn46124"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+        <listOfReactants>
+          <speciesReference species="M_cpd00067_c0" stoichiometry="1" constant="true"/>
+          <speciesReference species="M_cpd27020_c0" stoichiometry="1" constant="true"/>
+          <speciesReference species="M_cpd00004_c0" stoichiometry="1" constant="true"/>
+        </listOfReactants>
+        <listOfProducts>
+          <speciesReference species="M_cpd27180_c0" stoichiometry="1" constant="true"/>
+          <speciesReference species="M_cpd00003_c0" stoichiometry="1" constant="true"/>
+        </listOfProducts>
+        <fbc:geneProductAssociation>
+          <fbc:geneProductRef fbc:geneProduct="G_ACZ81_RS16715"/>
+        </fbc:geneProductAssociation>
+      </reaction>
     </listOfReactions>
     <fbc:listOfObjectives fbc:activeObjective="obj">
       <fbc:objective fbc:id="obj" fbc:type="maximize">
@@ -68202,19 +67287,6 @@
           </rdf:RDF>
         </annotation>
       </fbc:geneProduct>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS01880" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS01880" fbc:name="ACZ81_RS01880" fbc:label="G_ACZ81_RS01880">
-        <annotation>
-          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
-            <rdf:Description rdf:about="#meta_G_ACZ81_RS01880">
-              <bqbiol:is>
-                <rdf:Bag>
-                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014948016.1"/>
-                </rdf:Bag>
-              </bqbiol:is>
-            </rdf:Description>
-          </rdf:RDF>
-        </annotation>
-      </fbc:geneProduct>
       <fbc:geneProduct metaid="meta_G_ACZ81_RS17710" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS17710" fbc:name="ACZ81_RS17710" fbc:label="G_ACZ81_RS17710">
         <annotation>
           <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
@@ -69054,32 +68126,6 @@
               <bqbiol:is>
                 <rdf:Bag>
                   <rdf:li rdf:resource="https://identifiers.org/refseq/WP_061486411.1"/>
-                </rdf:Bag>
-              </bqbiol:is>
-            </rdf:Description>
-          </rdf:RDF>
-        </annotation>
-      </fbc:geneProduct>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS14840" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS14840" fbc:name="ACZ81_RS14840" fbc:label="G_ACZ81_RS14840">
-        <annotation>
-          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
-            <rdf:Description rdf:about="#meta_G_ACZ81_RS14840">
-              <bqbiol:is>
-                <rdf:Bag>
-                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_061486413.1"/>
-                </rdf:Bag>
-              </bqbiol:is>
-            </rdf:Description>
-          </rdf:RDF>
-        </annotation>
-      </fbc:geneProduct>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS20365" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS20365" fbc:name="ACZ81_RS20365" fbc:label="G_ACZ81_RS20365">
-        <annotation>
-          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
-            <rdf:Description rdf:about="#meta_G_ACZ81_RS20365">
-              <bqbiol:is>
-                <rdf:Bag>
-                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014996986.1"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -71062,19 +70108,6 @@
           </rdf:RDF>
         </annotation>
       </fbc:geneProduct>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS12215" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS12215" fbc:name="ACZ81_RS12215" fbc:label="G_ACZ81_RS12215">
-        <annotation>
-          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
-            <rdf:Description rdf:about="#meta_G_ACZ81_RS12215">
-              <bqbiol:is>
-                <rdf:Bag>
-                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_061486079.1"/>
-                </rdf:Bag>
-              </bqbiol:is>
-            </rdf:Description>
-          </rdf:RDF>
-        </annotation>
-      </fbc:geneProduct>
       <fbc:geneProduct metaid="meta_G_ACZ81_RS16725" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS16725" fbc:name="ACZ81_RS16725" fbc:label="G_ACZ81_RS16725">
         <annotation>
           <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
@@ -71641,19 +70674,6 @@
               <bqbiol:is>
                 <rdf:Bag>
                   <rdf:li rdf:resource="https://identifiers.org/refseq/WP_061439488.1"/>
-                </rdf:Bag>
-              </bqbiol:is>
-            </rdf:Description>
-          </rdf:RDF>
-        </annotation>
-      </fbc:geneProduct>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS08425" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS08425" fbc:name="ACZ81_RS08425" fbc:label="G_ACZ81_RS08425">
-        <annotation>
-          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
-            <rdf:Description rdf:about="#meta_G_ACZ81_RS08425">
-              <bqbiol:is>
-                <rdf:Bag>
-                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014949187.1"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -73181,19 +72201,6 @@
           </rdf:RDF>
         </annotation>
       </fbc:geneProduct>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS13830" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS13830" fbc:name="ACZ81_RS13830" fbc:label="G_ACZ81_RS13830">
-        <annotation>
-          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
-            <rdf:Description rdf:about="#meta_G_ACZ81_RS13830">
-              <bqbiol:is>
-                <rdf:Bag>
-                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_061486247.1"/>
-                </rdf:Bag>
-              </bqbiol:is>
-            </rdf:Description>
-          </rdf:RDF>
-        </annotation>
-      </fbc:geneProduct>
       <fbc:geneProduct metaid="meta_G_ACZ81_RS01925" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS01925" fbc:name="ACZ81_RS01925" fbc:label="G_ACZ81_RS01925">
         <annotation>
           <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
@@ -73682,19 +72689,6 @@
               <bqbiol:is>
                 <rdf:Bag>
                   <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014951072.1"/>
-                </rdf:Bag>
-              </bqbiol:is>
-            </rdf:Description>
-          </rdf:RDF>
-        </annotation>
-      </fbc:geneProduct>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS11335" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS11335" fbc:name="ACZ81_RS11335" fbc:label="G_ACZ81_RS11335">
-        <annotation>
-          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
-            <rdf:Description rdf:about="#meta_G_ACZ81_RS11335">
-              <bqbiol:is>
-                <rdf:Bag>
-                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_061486011.1"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -74468,19 +73462,6 @@
           </rdf:RDF>
         </annotation>
       </fbc:geneProduct>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS18540" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS18540" fbc:name="ACZ81_RS18540" fbc:label="G_ACZ81_RS18540">
-        <annotation>
-          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
-            <rdf:Description rdf:about="#meta_G_ACZ81_RS18540">
-              <bqbiol:is>
-                <rdf:Bag>
-                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_039229202.1"/>
-                </rdf:Bag>
-              </bqbiol:is>
-            </rdf:Description>
-          </rdf:RDF>
-        </annotation>
-      </fbc:geneProduct>
       <fbc:geneProduct metaid="meta_G_ACZ81_RS08255" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS08255" fbc:name="ACZ81_RS08255" fbc:label="G_ACZ81_RS08255">
         <annotation>
           <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
@@ -75177,19 +74158,6 @@
               <bqbiol:is>
                 <rdf:Bag>
                   <rdf:li rdf:resource="https://identifiers.org/refseq/WP_061485678.1"/>
-                </rdf:Bag>
-              </bqbiol:is>
-            </rdf:Description>
-          </rdf:RDF>
-        </annotation>
-      </fbc:geneProduct>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS08905" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS08905" fbc:name="ACZ81_RS08905" fbc:label="G_ACZ81_RS08905">
-        <annotation>
-          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
-            <rdf:Description rdf:about="#meta_G_ACZ81_RS08905">
-              <bqbiol:is>
-                <rdf:Bag>
-                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_061485755.1"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -76548,19 +75516,6 @@
           </rdf:RDF>
         </annotation>
       </fbc:geneProduct>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS11415" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS11415" fbc:name="ACZ81_RS11415" fbc:label="G_ACZ81_RS11415">
-        <annotation>
-          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
-            <rdf:Description rdf:about="#meta_G_ACZ81_RS11415">
-              <bqbiol:is>
-                <rdf:Bag>
-                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_061486019.1"/>
-                </rdf:Bag>
-              </bqbiol:is>
-            </rdf:Description>
-          </rdf:RDF>
-        </annotation>
-      </fbc:geneProduct>
       <fbc:geneProduct metaid="meta_G_ACZ81_RS09275" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS09275" fbc:name="ACZ81_RS09275" fbc:label="G_ACZ81_RS09275">
         <annotation>
           <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
@@ -77289,19 +76244,6 @@
           </rdf:RDF>
         </annotation>
       </fbc:geneProduct>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS11355" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS11355" fbc:name="ACZ81_RS11355" fbc:label="G_ACZ81_RS11355">
-        <annotation>
-          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
-            <rdf:Description rdf:about="#meta_G_ACZ81_RS11355">
-              <bqbiol:is>
-                <rdf:Bag>
-                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014949774.1"/>
-                </rdf:Bag>
-              </bqbiol:is>
-            </rdf:Description>
-          </rdf:RDF>
-        </annotation>
-      </fbc:geneProduct>
       <fbc:geneProduct metaid="meta_G_ACZ81_RS00480" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS00480" fbc:name="ACZ81_RS00480" fbc:label="G_ACZ81_RS00480">
         <annotation>
           <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
@@ -77315,19 +76257,6 @@
           </rdf:RDF>
         </annotation>
       </fbc:geneProduct>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS10895" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS10895" fbc:name="ACZ81_RS10895" fbc:label="G_ACZ81_RS10895">
-        <annotation>
-          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
-            <rdf:Description rdf:about="#meta_G_ACZ81_RS10895">
-              <bqbiol:is>
-                <rdf:Bag>
-                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_061485959.1"/>
-                </rdf:Bag>
-              </bqbiol:is>
-            </rdf:Description>
-          </rdf:RDF>
-        </annotation>
-      </fbc:geneProduct>
       <fbc:geneProduct metaid="meta_G_ACZ81_RS00490" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS00490" fbc:name="ACZ81_RS00490" fbc:label="G_ACZ81_RS00490">
         <annotation>
           <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
@@ -77335,19 +76264,6 @@
               <bqbiol:is>
                 <rdf:Bag>
                   <rdf:li rdf:resource="https://identifiers.org/refseq/WP_061438944.1"/>
-                </rdf:Bag>
-              </bqbiol:is>
-            </rdf:Description>
-          </rdf:RDF>
-        </annotation>
-      </fbc:geneProduct>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS19535" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS19535" fbc:name="ACZ81_RS19535" fbc:label="G_ACZ81_RS19535">
-        <annotation>
-          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
-            <rdf:Description rdf:about="#meta_G_ACZ81_RS19535">
-              <bqbiol:is>
-                <rdf:Bag>
-                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_061487021.1"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -77751,58 +76667,6 @@
               <bqbiol:is>
                 <rdf:Bag>
                   <rdf:li rdf:resource="https://identifiers.org/refseq/WP_081106125.1"/>
-                </rdf:Bag>
-              </bqbiol:is>
-            </rdf:Description>
-          </rdf:RDF>
-        </annotation>
-      </fbc:geneProduct>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS11345" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS11345" fbc:name="ACZ81_RS11345" fbc:label="G_ACZ81_RS11345">
-        <annotation>
-          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
-            <rdf:Description rdf:about="#meta_G_ACZ81_RS11345">
-              <bqbiol:is>
-                <rdf:Bag>
-                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014949772.1"/>
-                </rdf:Bag>
-              </bqbiol:is>
-            </rdf:Description>
-          </rdf:RDF>
-        </annotation>
-      </fbc:geneProduct>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS11365" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS11365" fbc:name="ACZ81_RS11365" fbc:label="G_ACZ81_RS11365">
-        <annotation>
-          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
-            <rdf:Description rdf:about="#meta_G_ACZ81_RS11365">
-              <bqbiol:is>
-                <rdf:Bag>
-                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_061486013.1"/>
-                </rdf:Bag>
-              </bqbiol:is>
-            </rdf:Description>
-          </rdf:RDF>
-        </annotation>
-      </fbc:geneProduct>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS10885" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS10885" fbc:name="ACZ81_RS10885" fbc:label="G_ACZ81_RS10885">
-        <annotation>
-          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
-            <rdf:Description rdf:about="#meta_G_ACZ81_RS10885">
-              <bqbiol:is>
-                <rdf:Bag>
-                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_061485957.1"/>
-                </rdf:Bag>
-              </bqbiol:is>
-            </rdf:Description>
-          </rdf:RDF>
-        </annotation>
-      </fbc:geneProduct>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS08460" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS08460" fbc:name="ACZ81_RS08460" fbc:label="G_ACZ81_RS08460">
-        <annotation>
-          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
-            <rdf:Description rdf:about="#meta_G_ACZ81_RS08460">
-              <bqbiol:is>
-                <rdf:Bag>
-                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_061485677.1"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -78371,6 +77235,12 @@
       <fbc:geneProduct fbc:id="G_ACZ81_RS15305" fbc:name="prpF" fbc:label="G_ACZ81_RS15305"/>
       <fbc:geneProduct fbc:id="G_ACZ81_RS05535" fbc:name="G_ACZ81_RS05535" fbc:label="G_ACZ81_RS05535"/>
       <fbc:geneProduct fbc:id="G_ACZ81_RS05095" fbc:name="G_ACZ81_RS05095" fbc:label="G_ACZ81_RS05095"/>
+      <fbc:geneProduct fbc:id="G_ACZ81_RS20260" fbc:name="G_ACZ81_RS20260" fbc:label="G_ACZ81_RS20260"/>
+      <fbc:geneProduct fbc:id="G_ACZ81_RS13510" fbc:name="G_ACZ81_RS13510" fbc:label="G_ACZ81_RS13510"/>
+      <fbc:geneProduct fbc:id="G_ACZ81_RS00825" fbc:name="G_ACZ81_RS00825" fbc:label="G_ACZ81_RS00825"/>
+      <fbc:geneProduct fbc:id="G_ACZ81_RS20345" fbc:name="G_ACZ81_RS20345" fbc:label="G_ACZ81_RS20345"/>
+      <fbc:geneProduct fbc:id="G_ACZ81_RS20340" fbc:name="G_ACZ81_RS20340" fbc:label="G_ACZ81_RS20340"/>
+      <fbc:geneProduct fbc:id="G_ACZ81_RS20360" fbc:name="G_ACZ81_RS20360" fbc:label="G_ACZ81_RS20360"/>
     </fbc:listOfGeneProducts>
   </model>
 </sbml>


### PR DESCRIPTION
#### Main improvements in this PR:

This pull request:

- Adds `rxn06937_c0` with GPR `ACZ81_RS06785`; see [MIT1002 PR #135](https://github.com/C-CoMP-STC/GEM-mit1002/pull/135)
- Adds `rxn00346_c0` with GPR `ACZ81_RS17835`; see [MIT1002 PR #138](https://github.com/C-CoMP-STC/GEM-mit1002/pull/138)
- Removes `rxn15972_c0` and `cpd11209_c0` because `rxn00469_c0` is already in model; see [MIT1002 PR #143](https://github.com/C-CoMP-STC/GEM-mit1002/pull/143)
- Adds `rxn00333_c0` with GPR `ACZ81_RS17970`; see [MIT1002 PR #176](https://github.com/C-CoMP-STC/GEM-mit1002/pull/176)
- Adds `rxn05464_c0` with GPR: `ACZ81_RS16715`; see [MIT1002 PR #194](https://github.com/C-CoMP-STC/GEM-mit1002/pull/194)
- Adds `cpd00259_c0` and `rxn01199_c0` with GPR: `ACZ81_RS01015`; see [MIT1002 PR #229](https://github.com/C-CoMP-STC/GEM-mit1002/pull/229)
- Replaces `rxn14415_c0` with `rxn13688_c0`, GPR: `ACZ81_RS19555 and ACZ81_RS19565 and ACZ81_RS19570`; see [MIT1002 PR #274](https://github.com/C-CoMP-STC/GEM-mit1002/pull/274)
- Removes `rxn09001_c0` and `rxn09003_c0`; see [MIT1002 PR #275](https://github.com/C-CoMP-STC/GEM-mit1002/pull/275)
- Adds `cpd24604_c0`, `ACZ81_RS13510`, and `isc_split` (GPR: `ACZ81_RS13510`); see [MIT1002 PR #277](https://github.com/C-CoMP-STC/GEM-mit1002/pull/277)
- Replaces `rxn17731_c0` with `rxn14045_c0` (GPR: `ACZ81_RS06665 and (ACZ81_RS13510 or ACZ81_RS13505)`); see [MIT1002 PR #277](https://github.com/C-CoMP-STC/GEM-mit1002/pull/277)
- Removes `EX_cpd11574_e0`, `rxn05619_c0`, `rxn16583_c0`, `rxn21729_c0`, `rxn24830_c0`, `rxn26021_c0`, `rxn26361_c0`, `rxn41683_c0`, `rxn41896_c0`, `rxn44539_c0`, `rxn45996_c0`, `cpd03520_c0`, `cpd11574_c0`, `cpd11574_e0`, `cpd19503_c0`, `cpd19505_c0`, `cpd21090_c0`, `cpd21167_c0`, `cpd21288_c0`, `cpd26672_c0`, `cpd27484_c0`, `cpd28253_c0`, `cpd28260_c0`, `cpd33647_c0`, `cpd35194_c0`, `cpd36025_c0`, `ACZ81_RS08460`, `ACZ81_RS10885`, `ACZ81_RS10895`, `ACZ81_RS11335`, `ACZ81_RS11345`, `ACZ81_RS11355`, and `ACZ81_RS11365`; see MIT1002 PRs [#278](https://github.com/C-CoMP-STC/GEM-mit1002/pull/278) and [#301](https://github.com/C-CoMP-STC/GEM-mit1002/pull/301)
- Removes `rxn08808_c0`, `rxn08809_c0`, and `cpd12547_c0`; see [MIT1002 PR #279](https://github.com/C-CoMP-STC/GEM-mit1002/pull/279)
- Replaces `cpd01029_c0` with `cpd19185_c0`, `cpd14699_c0` with `cpd03046_c0`, `cpd14703_c0` with `cpd03045_c0`, `rxn03396_c0` with `rxn12224_c0`, `rxn06335_c0` with `rxn02271_c0`, `rxn06586_c0` with `rxn02867_c0`, `rxn07433_c0` with `rxn35552_c0`, `rxn07435_c0` with `rxn35550_c0`, `rxn07436_c0` with `rxn39829_c0`, and `rxn16828_c0` with `rxn26398_c0`; see [MIT1002 PR #280](https://github.com/C-CoMP-STC/GEM-mit1002/pull/280)
- Removes `rxn05121_c0`, `rxn08502_e0`, `EX_cpd03726_e0`, `EX_cpd03453_e0`, `cpd03453_e0`, `cpd03726_e0`, `cpd11312_c0`, and `ACZ81_RS19535`; see [MIT1002 PR #280](https://github.com/C-CoMP-STC/GEM-mit1002/pull/280)
- Adds `cpd00054_e0`, `cpd00085_e0`, `cpd00132_e0`, `EX_cpd00054_e0`, `EX_cpd00085_e0`, `EX_cpd00132_e0`, `rxn05495_c0`, `rxn09247_c0`, and `rxn34491_c0` (GPRs of non-exchange reactions all `ACZ81_RS11460`); see [MIT1002 PR #281](https://github.com/C-CoMP-STC/GEM-mit1002/pull/281)
- Replaces `rxn08722_c0` with `rxn05684_c0` and `rxn09304_c0` with `rxn09306_c0`; see [MIT1002 PR #281](https://github.com/C-CoMP-STC/GEM-mit1002/pull/281)
- Removes `EX_cpd00041_e0`, `rxn05217_c0`, `rxn05496_c0`, `rxn05297_c0`, `rxn05669_c0`, `cpd00041_e0`, and `ACZ81_RS08425`; see [MIT1002 PR #281](https://github.com/C-CoMP-STC/GEM-mit1002/pull/281)
- Adds `cpd00992_c0`, `cpd00992_e0`, `cpd00992_trans`, `EX_cpd0992_e0`, and `rxn01305_c0` (GPR: `ACZ81_RS02770 or ACZ81_RS07000`); see [MIT1002 PR #285](https://github.com/C-CoMP-STC/GEM-mit1002/pull/285)
- Adds `rxn01011_c0` with GPR `ACZ81_RS02770 or ACZ81_RS07000 or ACZ81_RS19665 or ACZ81_RS09935`; see [MIT1002 PR #285](https://github.com/C-CoMP-STC/GEM-mit1002/pull/285)
- Adds `mmal_sald_redox`, `rxn36075_c0`, and `rxn43611_c0` (all GPRs: `ACZ81_RS02770 or ACZ81_RS18510 or ACZ81_RS07295`); see MIT1002 PRs [#285](https://github.com/C-CoMP-STC/GEM-mit1002/pull/285) and [#300](https://github.com/C-CoMP-STC/GEM-mit1002/pull/300)
- Adds `rxn01013_c0` with GPR `ACZ81_RS02770 or ACZ81_RS18510 or ACZ81_RS07295 or ACZ81_RS09945 or ACZ81_RS15450`; see [MIT1002 PR #285](https://github.com/C-CoMP-STC/GEM-mit1002/pull/285)
- Adds `rxn12191_c0` with GPR `ACZ81_RS02770 or ACZ81_RS18510 or ACZ81_RS07295 or ACZ81_RS14060 or ACZ81_RS12500`; see [MIT1002 PR #285](https://github.com/C-CoMP-STC/GEM-mit1002/pull/285)
- Adds `rxn16141_c0` with GPR `ACZ81_RS02770 or ACZ81_RS18510 or ACZ81_RS07295 or ACZ81_RS09945`; see [MIT1002 PR #285](https://github.com/C-CoMP-STC/GEM-mit1002/pull/285)
- Removes `rxn00668_c0`, `cpd00663_c0`, and `ACZ81_RS12215`; see [MIT1002 PR #286](https://github.com/C-CoMP-STC/GEM-mit1002/pull/286)
- Adds `rxn00509_c0` with GPR `ACZ81_RS14055 or ACZ81_RS19350`; see [MIT1002 PR #288](https://github.com/C-CoMP-STC/GEM-mit1002/pull/288)
- Adds `cpd00334_c0`, `cpd00705_c0`, `rxn01053_c0` and `rxn02226_c0` (both GPRs: `ACZ81_RS14055 or ACZ81_RS02375`); see [MIT1002 PR #288](https://github.com/C-CoMP-STC/GEM-mit1002/pull/288)
- Adds `cpd00269_c0`, `cpd00413_c0`, `cpd16479_c0`, `rxn01802_c0` (GPR: `ACZ81_RS08270`), `rxn11955_c0` (GPR: `ACZ81_RS09795 and ACZ81_RS09800`), and `rxn11960_c0` (GPR: `ACZ81_RS09800 and ACZ81_RS14645`); see [MIT1002 PR #289](https://github.com/C-CoMP-STC/GEM-mit1002/pull/289)
- Removes `rxn02222_c0`, `cpd00703_c0`, and `cpd01747_c0`; see [MIT1002 PR #293](https://github.com/C-CoMP-STC/GEM-mit1002/pull/293)
- Adds `rxn05894_c0` with GPR `ACZ81_RS16285`; see [MIT1002 PR #299](https://github.com/C-CoMP-STC/GEM-mit1002/pull/299)
- Removes `rxn00569_c0`; see [MIT1002 PR #299](https://github.com/C-CoMP-STC/GEM-mit1002/pull/299)
- Adds `ACZ81_RS20340`, `ACZ81_RS20345`, `ACZ81_RS20360`, `cpd30760_c0`, `cpd30760_e0`, `EX_cpd30760_e0`, and `rxn05212_c0` (GPR: `ACZ81_RS20345 and ACZ81_RS20340`); see [MIT1002 PR #303](https://github.com/C-CoMP-STC/GEM-mit1002/pull/303)
- Replaces `rxn08275_c0` with `rxn29147_c0` (GPR: `ACZ81_RS14830 and (ACZ81_RS20360 or ACZ81_RS14835)`); see [MIT1002 PR #303](https://github.com/C-CoMP-STC/GEM-mit1002/pull/303)
- Removes `EX_cpd01012_e0`, `rxn02021_c0`, `rxn05315_c0`, `rxn05517_c0`, `rxn10481_c0`, `cpd01012_c0`, `cpd01012_e0`, `cpd00531_c0`, `cpd00965_c0`, `ACZ81_RS08905`, `ACZ81_RS14840`, `ACZ81_RS18540`, and `ACZ81_RS20365`; see [MIT1002 PR #303](https://github.com/C-CoMP-STC/GEM-mit1002/pull/303)
- Replaces `rxn21859_c0` with `rxn46124_c0` and `rxn21863_c0` with `rxn45550_c0`; see [MIT1002 PR #306](https://github.com/C-CoMP-STC/GEM-mit1002/pull/306)
- Adds `ACZ81_RS00825` and `rxn05039_c0` (GPR: `ACZ81_RS00825`); see [MIT1002 PR #307](https://github.com/C-CoMP-STC/GEM-mit1002/pull/307)
- Removes `rxn00309_c0`, `rxn01662_c0`, and `ACZ81_RS11415`; see [MIT1002 PR #312](https://github.com/C-CoMP-STC/GEM-mit1002/pull/312)
- Removes `rxn01203_c0`, `rxn09022_c0`, `rxn10307_c0`, `rxn10308_c0`, `rxn10309_c0`, `rxn10312_c0`, `rxn10313_c0`, `rxn10314_c0`, `rxn10315_c0`, `cpd03708_c0`, `cpd15516_c0`, `cpd15520_c0`, `cpd15746_c0`, `cpd15747_c0`, `cpd15748_c0`, `cpd15749_c0`, `cpd15750_c0`, `cpd15751_c0`, `cpd15752_c0`, `cpd15753_c0`, `cpd15754_c0`, `cpd15764_c0`, `cpd15765_c0`, `cpd15766_c0`, `cpd15769_c0`, `cpd15770_c0`, `cpd15771_c0`, `cpd15772_c0`, `ACZ81_RS01880`, and `ACZ81_RS13830`; see [MIT1002 PR #315](https://github.com/C-CoMP-STC/GEM-mit1002/pull/315)
- Removes `rxn00196_c0` and `rxn01302_c0`; see [MIT1002 PR #316](https://github.com/C-CoMP-STC/GEM-mit1002/pull/316)
- Adds `rxn15341_c0` with GPR `ACZ81_RS02770 or ACZ81_RS07000`; see [MIT1002 PR #317](https://github.com/C-CoMP-STC/GEM-mit1002/pull/317)

All removed genes were reciprocal best hits of genes that were removed in the indicated MIT1002 PR and had identical annotations, and all genes in the GPRs of new reactions were reciprocal best hits of genes in the GPRs of the corresponding MIT1002 reactions.

**I hereby confirm that I have:**
- [X] Made my edits to the model on the XML file
- [ ] Tested my code on my own computer for running the model
- [X] Selected `develop` as a target branch
- [ ] Any removed reactions and metabolites have been moved to the corresponding deprecated identifier lists
