### PR TITLE
Fix: Copy recent fixes to MIT1002 GPRs

### DIFF
--- a/model.xml
+++ b/model.xml
@@ -22908,7 +22908,10 @@
           <speciesReference species="M_cpd00540_c0" stoichiometry="1" constant="true"/>
         </listOfProducts>
         <fbc:geneProductAssociation>
-          <fbc:geneProductRef fbc:geneProduct="G_ACZ81_RS14055"/>
+          <fbc:or>
+            <fbc:geneProductRef fbc:geneProduct="G_ACZ81_RS14055"/>
+            <fbc:geneProductRef fbc:geneProduct="G_ACZ81_RS02375"/>
+          </fbc:or>
         </fbc:geneProductAssociation>
       </reaction>
       <reaction metaid="meta_R_rxn10270_c0" sboTerm="SBO:0000176" id="R_rxn10270_c0" name="isohexadecanoyl-Phosphatidylglycerophosphate phosphohydrolase [c0]" reversible="false" fast="false" fbc:lowerFluxBound="cobra_0_bound" fbc:upperFluxBound="cobra_default_ub">
@@ -25191,10 +25194,10 @@
           <speciesReference species="M_cpd00971_c0" stoichiometry="1" constant="true"/>
         </listOfProducts>
         <fbc:geneProductAssociation>
-          <fbc:and>
+          <fbc:or>
             <fbc:geneProductRef fbc:geneProduct="G_ACZ81_RS09455"/>
             <fbc:geneProductRef fbc:geneProduct="G_ACZ81_RS06100"/>
-          </fbc:and>
+          </fbc:or>
         </fbc:geneProductAssociation>
       </reaction>
       <reaction metaid="meta_R_rxn08308_c0" sboTerm="SBO:0000176" id="R_rxn08308_c0" name="CDP-diacylglycerol synthetase (n-C14:1) [c0]" reversible="false" fast="false" fbc:lowerFluxBound="cobra_0_bound" fbc:upperFluxBound="cobra_default_ub">
@@ -25491,7 +25494,7 @@
           <speciesReference species="M_cpd00067_c0" stoichiometry="1" constant="true"/>
         </listOfProducts>
         <fbc:geneProductAssociation>
-          <fbc:geneProductRef fbc:geneProduct="G_ACZ81_RS18645"/>
+          <fbc:geneProductRef fbc:geneProduct="G_ACZ81_RS18215"/>
         </fbc:geneProductAssociation>
       </reaction>
       <reaction metaid="meta_R_rxn03248_c0" sboTerm="SBO:0000176" id="R_rxn03248_c0" name="Hexanoyl-CoA:acetyl-CoA C-acyltransferase [c0]" reversible="false" fast="false" fbc:lowerFluxBound="cobra_0_bound" fbc:upperFluxBound="cobra_default_ub">
@@ -27133,7 +27136,7 @@
           <speciesReference species="M_cpd00971_c0" stoichiometry="1" constant="true"/>
         </listOfProducts>
         <fbc:geneProductAssociation>
-          <fbc:geneProductRef fbc:geneProduct="G_ACZ81_RS07450"/>
+          <fbc:geneProductRef fbc:geneProduct="G_ACZ81_RS11460"/>
         </fbc:geneProductAssociation>
       </reaction>
       <reaction metaid="meta_R_rxn00383_c0" sboTerm="SBO:0000176" id="R_rxn00383_c0" name="Sulfite:oxygen oxidoreductase [c0]" reversible="false" fast="false" fbc:lowerFluxBound="cobra_0_bound" fbc:upperFluxBound="cobra_default_ub">
@@ -28489,10 +28492,10 @@
           <speciesReference species="M_cpd00067_c0" stoichiometry="2" constant="true"/>
         </listOfProducts>
         <fbc:geneProductAssociation>
-          <fbc:and>
-            <fbc:geneProductRef fbc:geneProduct="G_ACZ81_RS15990"/>
+          <fbc:or>
+            <fbc:geneProductRef fbc:geneProduct="G_ACZ81_RS14055"/>
             <fbc:geneProductRef fbc:geneProduct="G_ACZ81_RS02375"/>
-          </fbc:and>
+          </fbc:or>
         </fbc:geneProductAssociation>
       </reaction>
       <reaction metaid="meta_R_rxn10060_c0" sboTerm="SBO:0000176" id="R_rxn10060_c0" name="NAD kinase (dTTP) [c0]" reversible="false" fast="false" fbc:lowerFluxBound="cobra_0_bound" fbc:upperFluxBound="cobra_default_ub">
@@ -30395,7 +30398,10 @@
           <speciesReference species="M_cpd00843_c0" stoichiometry="1" constant="true"/>
         </listOfProducts>
         <fbc:geneProductAssociation>
-          <fbc:geneProductRef fbc:geneProduct="G_ACZ81_RS09945"/>
+          <fbc:or>
+            <fbc:geneProductRef fbc:geneProduct="G_ACZ81_RS02770"/>
+            <fbc:geneProductRef fbc:geneProduct="G_ACZ81_RS07000"/>
+          </fbc:or>
         </fbc:geneProductAssociation>
       </reaction>
       <reaction metaid="meta_R_rxn05581_c0" sboTerm="SBO:0000655" id="R_rxn05581_c0" name="RXN0-1683.ce.maizeexp.GLYCEROL_GLYCEROL [c0]" reversible="true" fast="false" fbc:lowerFluxBound="cobra_default_lb" fbc:upperFluxBound="cobra_default_ub">
@@ -34884,10 +34890,10 @@
           <speciesReference species="M_cpd00067_c0" stoichiometry="2" constant="true"/>
         </listOfProducts>
         <fbc:geneProductAssociation>
-          <fbc:and>
-            <fbc:geneProductRef fbc:geneProduct="G_ACZ81_RS15990"/>
+          <fbc:or>
+            <fbc:geneProductRef fbc:geneProduct="G_ACZ81_RS14055"/>
             <fbc:geneProductRef fbc:geneProduct="G_ACZ81_RS02375"/>
-          </fbc:and>
+          </fbc:or>
         </fbc:geneProductAssociation>
       </reaction>
       <reaction metaid="meta_R_rxn00904_c0" sboTerm="SBO:0000176" id="R_rxn00904_c0" name="L-Valine:pyruvate aminotransferase [c0]" reversible="true" fast="false" fbc:lowerFluxBound="cobra_default_lb" fbc:upperFluxBound="cobra_default_ub">
@@ -35336,7 +35342,11 @@
           <speciesReference species="M_cpd00843_c0" stoichiometry="1" constant="true"/>
         </listOfProducts>
         <fbc:geneProductAssociation>
-          <fbc:geneProductRef fbc:geneProduct="G_ACZ81_RS09945"/>
+          <fbc:or>
+            <fbc:geneProductRef fbc:geneProduct="G_ACZ81_RS02770"/>
+            <fbc:geneProductRef fbc:geneProduct="G_ACZ81_RS18510"/>
+            <fbc:geneProductRef fbc:geneProduct="G_ACZ81_RS07295"/>
+          </fbc:or>
         </fbc:geneProductAssociation>
       </reaction>
       <reaction metaid="meta_R_rxn01670_c0" sboTerm="SBO:0000176" id="R_rxn01670_c0" name="Nicotinamide ribonucleotide phosphohydrolase [c0]" reversible="false" fast="false" fbc:lowerFluxBound="cobra_0_bound" fbc:upperFluxBound="cobra_default_ub">
@@ -37154,7 +37164,10 @@
           <speciesReference species="M_cpd00067_c0" stoichiometry="2" constant="true"/>
         </listOfProducts>
         <fbc:geneProductAssociation>
-          <fbc:geneProductRef fbc:geneProduct="G_ACZ81_RS19350"/>
+          <fbc:or>
+            <fbc:geneProductRef fbc:geneProduct="G_ACZ81_RS14055"/>
+            <fbc:geneProductRef fbc:geneProduct="G_ACZ81_RS02375"/>
+          </fbc:or>
         </fbc:geneProductAssociation>
       </reaction>
       <reaction metaid="meta_R_rxn08352_c0" sboTerm="SBO:0000176" id="R_rxn08352_c0" name="R08210 [c0]" reversible="false" fast="false" fbc:lowerFluxBound="cobra_0_bound" fbc:upperFluxBound="cobra_default_ub">
@@ -37361,11 +37374,11 @@
           <speciesReference species="M_cpd00067_c0" stoichiometry="1" constant="true"/>
         </listOfProducts>
         <fbc:geneProductAssociation>
-          <fbc:and>
+          <fbc:or>
+            <fbc:geneProductRef fbc:geneProduct="G_ACZ81_RS02770"/>
+            <fbc:geneProductRef fbc:geneProduct="G_ACZ81_RS07000"/>
             <fbc:geneProductRef fbc:geneProduct="G_ACZ81_RS09935"/>
-            <fbc:geneProductRef fbc:geneProduct="G_ACZ81_RS16060"/>
-            <fbc:geneProductRef fbc:geneProduct="G_ACZ81_RS12895"/>
-          </fbc:and>
+          </fbc:or>
         </fbc:geneProductAssociation>
       </reaction>
       <reaction metaid="meta_R_rxn05734_c0" sboTerm="SBO:0000176" id="R_rxn05734_c0" name="aldehyde dehydrogenase (glyoxylate, NAD) [c0]" reversible="true" fast="false" fbc:lowerFluxBound="cobra_default_lb" fbc:upperFluxBound="cobra_default_ub">
@@ -37394,10 +37407,10 @@
           <speciesReference species="M_cpd00180_c0" stoichiometry="1" constant="true"/>
         </listOfProducts>
         <fbc:geneProductAssociation>
-          <fbc:and>
-            <fbc:geneProductRef fbc:geneProduct="G_ACZ81_RS15990"/>
+          <fbc:or>
+            <fbc:geneProductRef fbc:geneProduct="G_ACZ81_RS14055"/>
             <fbc:geneProductRef fbc:geneProduct="G_ACZ81_RS02375"/>
-          </fbc:and>
+          </fbc:or>
         </fbc:geneProductAssociation>
       </reaction>
       <reaction metaid="meta_R_rxn00772_c0" sboTerm="SBO:0000176" id="R_rxn00772_c0" name="ATP:D-ribose 5-phosphotransferase [c0]" reversible="false" fast="false" fbc:lowerFluxBound="cobra_0_bound" fbc:upperFluxBound="cobra_default_ub">
@@ -37814,10 +37827,10 @@
           <speciesReference species="M_cpd01831_c0" stoichiometry="1" constant="true"/>
         </listOfProducts>
         <fbc:geneProductAssociation>
-          <fbc:and>
-            <fbc:geneProductRef fbc:geneProduct="G_ACZ81_RS15990"/>
+          <fbc:or>
+            <fbc:geneProductRef fbc:geneProduct="G_ACZ81_RS14055"/>
             <fbc:geneProductRef fbc:geneProduct="G_ACZ81_RS02375"/>
-          </fbc:and>
+          </fbc:or>
         </fbc:geneProductAssociation>
       </reaction>
       <reaction metaid="meta_R_rxn01515_c0" sboTerm="SBO:0000176" id="R_rxn01515_c0" name="dTTP:cytidine 5&apos;-phosphotransferase [c0]" reversible="false" fast="false" fbc:lowerFluxBound="cobra_0_bound" fbc:upperFluxBound="cobra_default_ub">
@@ -38801,8 +38814,12 @@
               <fbc:geneProductRef fbc:geneProduct="G_ACZ81_RS04635"/>
               <fbc:geneProductRef fbc:geneProduct="G_ACZ81_RS04625"/>
               <fbc:geneProductRef fbc:geneProduct="G_ACZ81_RS04620"/>
+              <fbc:geneProductRef fbc:geneProduct="G_ACZ81_RS04630"/>
             </fbc:and>
-            <fbc:geneProductRef fbc:geneProduct="G_ACZ81_RS04630"/>
+            <fbc:and>
+              <fbc:geneProductRef fbc:geneProduct="G_ACZ81_RS18590"/>
+              <fbc:geneProductRef fbc:geneProduct="G_ACZ81_RS18595"/>
+            </fbc:and>
           </fbc:or>
         </fbc:geneProductAssociation>
       </reaction>
@@ -41467,7 +41484,6 @@
         <fbc:geneProductAssociation>
           <fbc:or>
             <fbc:geneProductRef fbc:geneProduct="G_ACZ81_RS02770"/>
-            <fbc:geneProductRef fbc:geneProduct="G_ACZ81_RS01595"/>
             <fbc:geneProductRef fbc:geneProduct="G_ACZ81_RS07000"/>
           </fbc:or>
         </fbc:geneProductAssociation>
@@ -44276,11 +44292,10 @@
           <speciesReference species="M_cpd15561_c0" stoichiometry="1" constant="true"/>
         </listOfProducts>
         <fbc:geneProductAssociation>
-          <fbc:and>
-            <fbc:geneProductRef fbc:geneProduct="G_ACZ81_RS09935"/>
-            <fbc:geneProductRef fbc:geneProduct="G_ACZ81_RS16060"/>
+          <fbc:or>
             <fbc:geneProductRef fbc:geneProduct="G_ACZ81_RS12895"/>
-          </fbc:and>
+            <fbc:geneProductRef fbc:geneProduct="G_ACZ81_RS16060"/>
+          </fbc:or>
         </fbc:geneProductAssociation>
       </reaction>
       <reaction metaid="meta_R_rxn01827_c0" sboTerm="SBO:0000176" id="R_rxn01827_c0" name="4-Hydroxyphenylpyruvate:oxygen oxidoreductase (hydroxylating,decarboxylating) [c0]" reversible="false" fast="false" fbc:lowerFluxBound="cobra_0_bound" fbc:upperFluxBound="cobra_default_ub">
@@ -44616,7 +44631,10 @@
           <speciesReference species="M_cpd00971_c0" stoichiometry="1" constant="true"/>
         </listOfProducts>
         <fbc:geneProductAssociation>
-          <fbc:geneProductRef fbc:geneProduct="G_ACZ81_RS07230"/>
+          <fbc:or>
+            <fbc:geneProductRef fbc:geneProduct="G_ACZ81_RS07230"/>
+            <fbc:geneProductRef fbc:geneProduct="G_ACZ81_RS11680"/>
+          </fbc:or>
         </fbc:geneProductAssociation>
       </reaction>
       <reaction metaid="meta_R_rxn01122_c0" sboTerm="SBO:0000176" id="R_rxn01122_c0" name="D-altronate hydro-lyase (2-dehydro-3-deoxy-D-gluconate-forming) [c0]" reversible="false" fast="false" fbc:lowerFluxBound="cobra_0_bound" fbc:upperFluxBound="cobra_default_ub">
@@ -48800,10 +48818,7 @@
           <speciesReference species="M_cpd00281_c0" stoichiometry="1" constant="true"/>
         </listOfProducts>
         <fbc:geneProductAssociation>
-          <fbc:and>
-            <fbc:geneProductRef fbc:geneProduct="G_ACZ81_RS15990"/>
-            <fbc:geneProductRef fbc:geneProduct="G_ACZ81_RS02375"/>
-          </fbc:and>
+          <fbc:geneProductRef fbc:geneProduct="G_ACZ81_RS14055"/>
         </fbc:geneProductAssociation>
       </reaction>
       <reaction metaid="meta_R_rxn05252_c0" sboTerm="SBO:0000176" id="R_rxn05252_c0" name="FACOAL170(ISO) [c0]" reversible="false" fast="false" fbc:lowerFluxBound="cobra_0_bound" fbc:upperFluxBound="cobra_default_ub">
@@ -49175,11 +49190,10 @@
           <speciesReference species="M_cpd02069_c0" stoichiometry="1" constant="true"/>
         </listOfProducts>
         <fbc:geneProductAssociation>
-          <fbc:and>
-            <fbc:geneProductRef fbc:geneProduct="G_ACZ81_RS15450"/>
-            <fbc:geneProductRef fbc:geneProduct="G_ACZ81_RS19665"/>
-            <fbc:geneProductRef fbc:geneProduct="G_ACZ81_RS14595"/>
-          </fbc:and>
+          <fbc:or>
+            <fbc:geneProductRef fbc:geneProduct="G_ACZ81_RS02770"/>
+            <fbc:geneProductRef fbc:geneProduct="G_ACZ81_RS07000"/>
+          </fbc:or>
         </fbc:geneProductAssociation>
       </reaction>
       <reaction metaid="meta_R_rxn00355_c0" sboTerm="SBO:0000176" id="R_rxn00355_c0" name="UTP:alpha-D-galactose-1-phosphate uridylyltransferase [c0]" reversible="false" fast="false" fbc:lowerFluxBound="cobra_0_bound" fbc:upperFluxBound="cobra_default_ub">
@@ -49678,10 +49692,11 @@
           <speciesReference species="M_cpd00281_c0" stoichiometry="1" constant="true"/>
         </listOfProducts>
         <fbc:geneProductAssociation>
-          <fbc:and>
-            <fbc:geneProductRef fbc:geneProduct="G_ACZ81_RS15990"/>
+          <fbc:or>
+            <fbc:geneProductRef fbc:geneProduct="G_ACZ81_RS14055"/>
             <fbc:geneProductRef fbc:geneProduct="G_ACZ81_RS02375"/>
-          </fbc:and>
+            <fbc:geneProductRef fbc:geneProduct="G_ACZ81_RS15990"/>
+          </fbc:or>
         </fbc:geneProductAssociation>
       </reaction>
       <reaction metaid="meta_R_rxn00507_c0" sboTerm="SBO:0000176" id="R_rxn00507_c0" name="Acetaldehyde:NADP+ oxidoreductase [c0]" reversible="false" fast="false" fbc:lowerFluxBound="cobra_0_bound" fbc:upperFluxBound="cobra_default_ub">
@@ -49723,10 +49738,7 @@
           <speciesReference species="M_cpd00067_c0" stoichiometry="2" constant="true"/>
         </listOfProducts>
         <fbc:geneProductAssociation>
-          <fbc:or>
-            <fbc:geneProductRef fbc:geneProduct="G_ACZ81_RS11975"/>
-            <fbc:geneProductRef fbc:geneProduct="G_ACZ81_RS15990"/>
-          </fbc:or>
+          <fbc:geneProductRef fbc:geneProduct="G_ACZ81_RS14055"/>
         </fbc:geneProductAssociation>
       </reaction>
       <reaction metaid="meta_R_rxn09449_c0" sboTerm="SBO:0000176" id="R_rxn09449_c0" name="acyl-coenzyme A ligase [c0]" reversible="false" fast="false" fbc:lowerFluxBound="cobra_0_bound" fbc:upperFluxBound="cobra_default_ub">
@@ -50601,10 +50613,9 @@
         </listOfProducts>
         <fbc:geneProductAssociation>
           <fbc:or>
-            <fbc:geneProductRef fbc:geneProduct="G_ACZ81_RS16020"/>
             <fbc:geneProductRef fbc:geneProduct="G_ACZ81_RS02770"/>
-            <fbc:geneProductRef fbc:geneProduct="G_ACZ81_RS01595"/>
             <fbc:geneProductRef fbc:geneProduct="G_ACZ81_RS07000"/>
+            <fbc:geneProductRef fbc:geneProduct="G_ACZ81_RS16020"/>
           </fbc:or>
         </fbc:geneProductAssociation>
       </reaction>
@@ -51093,7 +51104,6 @@
         <fbc:geneProductAssociation>
           <fbc:or>
             <fbc:geneProductRef fbc:geneProduct="G_ACZ81_RS02770"/>
-            <fbc:geneProductRef fbc:geneProduct="G_ACZ81_RS01595"/>
             <fbc:geneProductRef fbc:geneProduct="G_ACZ81_RS07000"/>
           </fbc:or>
         </fbc:geneProductAssociation>
@@ -52111,7 +52121,11 @@
           <speciesReference species="M_cpd03105_c0" stoichiometry="1" constant="true"/>
         </listOfProducts>
         <fbc:geneProductAssociation>
-          <fbc:geneProductRef fbc:geneProduct="G_ACZ81_RS11975"/>
+          <fbc:or>
+            <fbc:geneProductRef fbc:geneProduct="G_ACZ81_RS18510"/>
+            <fbc:geneProductRef fbc:geneProduct="G_ACZ81_RS07295"/>
+            <fbc:geneProductRef fbc:geneProduct="G_ACZ81_RS11975"/>
+          </fbc:or>
         </fbc:geneProductAssociation>
       </reaction>
       <reaction metaid="meta_R_rxn09012_c0" sboTerm="SBO:0000176" id="R_rxn09012_c0" name="RXN0-5074.c [c0]" reversible="false" fast="false" fbc:lowerFluxBound="cobra_0_bound" fbc:upperFluxBound="cobra_default_ub">
@@ -53687,10 +53701,10 @@
           <speciesReference species="M_cpd01504_c0" stoichiometry="1" constant="true"/>
         </listOfProducts>
         <fbc:geneProductAssociation>
-          <fbc:and>
-            <fbc:geneProductRef fbc:geneProduct="G_ACZ81_RS15990"/>
+          <fbc:or>
+            <fbc:geneProductRef fbc:geneProduct="G_ACZ81_RS14055"/>
             <fbc:geneProductRef fbc:geneProduct="G_ACZ81_RS02375"/>
-          </fbc:and>
+          </fbc:or>
         </fbc:geneProductAssociation>
       </reaction>
       <reaction metaid="meta_R_rxn03164_c0" sboTerm="SBO:0000176" id="R_rxn03164_c0" name="UDP-N-acetylmuramoyl-L-alanyl-D-glutamyl-meso-2,6-diaminoheptanedioate:D-alanyl-D-alanine ligase(ADP-forming) [c0]" reversible="false" fast="false" fbc:lowerFluxBound="cobra_0_bound" fbc:upperFluxBound="cobra_default_ub">
@@ -54366,7 +54380,6 @@
         <fbc:geneProductAssociation>
           <fbc:or>
             <fbc:geneProductRef fbc:geneProduct="G_ACZ81_RS02770"/>
-            <fbc:geneProductRef fbc:geneProduct="G_ACZ81_RS01595"/>
             <fbc:geneProductRef fbc:geneProduct="G_ACZ81_RS07000"/>
             <fbc:geneProductRef fbc:geneProduct="G_ACZ81_RS14060"/>
             <fbc:geneProductRef fbc:geneProduct="G_ACZ81_RS12500"/>
@@ -55047,7 +55060,6 @@
         <fbc:geneProductAssociation>
           <fbc:or>
             <fbc:geneProductRef fbc:geneProduct="G_ACZ81_RS02770"/>
-            <fbc:geneProductRef fbc:geneProduct="G_ACZ81_RS01595"/>
             <fbc:geneProductRef fbc:geneProduct="G_ACZ81_RS07000"/>
           </fbc:or>
         </fbc:geneProductAssociation>
@@ -55087,12 +55099,10 @@
         </listOfProducts>
         <fbc:geneProductAssociation>
           <fbc:or>
-            <fbc:geneProductRef fbc:geneProduct="G_ACZ81_RS18260"/>
-            <fbc:and>
-              <fbc:geneProductRef fbc:geneProduct="G_ACZ81_RS02780"/>
-              <fbc:geneProductRef fbc:geneProduct="G_ACZ81_RS18260"/>
-            </fbc:and>
+            <fbc:geneProductRef fbc:geneProduct="G_ACZ81_RS14055"/>
+            <fbc:geneProductRef fbc:geneProduct="G_ACZ81_RS02375"/>
             <fbc:geneProductRef fbc:geneProduct="G_ACZ81_RS15990"/>
+            <fbc:geneProductRef fbc:geneProduct="G_ACZ81_RS02780"/>
           </fbc:or>
         </fbc:geneProductAssociation>
       </reaction>
@@ -55137,7 +55147,10 @@
         <fbc:geneProductAssociation>
           <fbc:and>
             <fbc:geneProductRef fbc:geneProduct="G_ACZ81_RS16285"/>
-            <fbc:geneProductRef fbc:geneProduct="G_ACZ81_RS16290"/>
+            <fbc:or>
+              <fbc:geneProductRef fbc:geneProduct="G_ACZ81_RS16290"/>
+              <fbc:geneProductRef fbc:geneProduct="G_ACZ81_RS17900"/>
+            </fbc:or>
           </fbc:and>
         </fbc:geneProductAssociation>
       </reaction>
@@ -57161,10 +57174,10 @@
           <speciesReference species="M_cpd00223_c0" stoichiometry="1" constant="true"/>
         </listOfProducts>
         <fbc:geneProductAssociation>
-          <fbc:and>
-            <fbc:geneProductRef fbc:geneProduct="G_ACZ81_RS15990"/>
+          <fbc:or>
+            <fbc:geneProductRef fbc:geneProduct="G_ACZ81_RS14055"/>
             <fbc:geneProductRef fbc:geneProduct="G_ACZ81_RS02375"/>
-          </fbc:and>
+          </fbc:or>
         </fbc:geneProductAssociation>
       </reaction>
       <reaction metaid="meta_R_rxn05289_c0" sboTerm="SBO:0000176" id="R_rxn05289_c0" name="NADPH:oxidized-thioredoxin oxidoreductase [c0]" reversible="true" fast="false" fbc:lowerFluxBound="cobra_default_lb" fbc:upperFluxBound="cobra_default_ub">
@@ -59481,7 +59494,10 @@
           <speciesReference species="M_cpd00971_c0" stoichiometry="1" constant="true"/>
         </listOfProducts>
         <fbc:geneProductAssociation>
-          <fbc:geneProductRef fbc:geneProduct="G_ACZ81_RS11680"/>
+          <fbc:or>
+            <fbc:geneProductRef fbc:geneProduct="G_ACZ81_RS07230"/>
+            <fbc:geneProductRef fbc:geneProduct="G_ACZ81_RS11680"/>
+          </fbc:or>
         </fbc:geneProductAssociation>
       </reaction>
       <reaction metaid="meta_R_rxn08234_c0" sboTerm="SBO:0000655" id="R_rxn08234_c0" name="chloride (Cl-1) transport via diffusion (extracellular to periplasm) [c0]" reversible="true" fast="false" fbc:lowerFluxBound="cobra_default_lb" fbc:upperFluxBound="cobra_default_ub">
@@ -59599,10 +59615,10 @@
           <speciesReference species="M_cpd00169_c0" stoichiometry="1" constant="true"/>
         </listOfProducts>
         <fbc:geneProductAssociation>
-          <fbc:and>
-            <fbc:geneProductRef fbc:geneProduct="G_ACZ81_RS15990"/>
+          <fbc:or>
+            <fbc:geneProductRef fbc:geneProduct="G_ACZ81_RS14055"/>
             <fbc:geneProductRef fbc:geneProduct="G_ACZ81_RS02375"/>
-          </fbc:and>
+          </fbc:or>
         </fbc:geneProductAssociation>
       </reaction>
       <reaction metaid="meta_R_rxn40368_c0" sboTerm="SBO:0000176" id="R_rxn40368_c0" name="D-galactose 1-epimerase [c0]" reversible="true" fast="false" fbc:lowerFluxBound="cobra_default_lb" fbc:upperFluxBound="cobra_default_ub">
@@ -61972,7 +61988,10 @@
           <speciesReference species="M_cpd00139_c0" stoichiometry="1" constant="true"/>
         </listOfProducts>
         <fbc:geneProductAssociation>
-          <fbc:geneProductRef fbc:geneProduct="G_ACZ81_RS15990"/>
+          <fbc:or>
+            <fbc:geneProductRef fbc:geneProduct="G_ACZ81_RS14055"/>
+            <fbc:geneProductRef fbc:geneProduct="G_ACZ81_RS02375"/>
+          </fbc:or>
         </fbc:geneProductAssociation>
       </reaction>
       <reaction metaid="meta_R_cpd23538_trans" sboTerm="SBO:0000185" id="R_cpd23538_trans" name="(S)-2,3-dihydroxypropane-1-sulfonate:sodium symport" reversible="true" fast="false" fbc:lowerFluxBound="cobra_default_lb" fbc:upperFluxBound="cobra_default_ub">
@@ -62257,7 +62276,11 @@
           <speciesReference species="M_cpd00067_c0" stoichiometry="2" constant="true"/>
         </listOfProducts>
         <fbc:geneProductAssociation>
-          <fbc:geneProductRef fbc:geneProduct="G_ACZ81_RS15990"/>
+          <fbc:or>
+            <fbc:geneProductRef fbc:geneProduct="G_ACZ81_RS14055"/>
+            <fbc:geneProductRef fbc:geneProduct="G_ACZ81_RS02375"/>
+            <fbc:geneProductRef fbc:geneProduct="G_ACZ81_RS15990"/>
+          </fbc:or>
         </fbc:geneProductAssociation>
       </reaction>
       <reaction metaid="meta_R_rxn01141_c0" sboTerm="SBO:0000176" id="R_rxn01141_c0" name="N,N-Dimethylglycine:oxygen oxidoreductase (demethylating) [c0]" reversible="false" fast="false" fbc:lowerFluxBound="cobra_0_bound" fbc:upperFluxBound="cobra_default_ub">
@@ -62519,7 +62542,10 @@
         </listOfProducts>
         <fbc:geneProductAssociation>
           <fbc:and>
-            <fbc:geneProductRef fbc:geneProduct="G_ACZ81_RS13505"/>
+            <fbc:or>
+              <fbc:geneProductRef fbc:geneProduct="G_ACZ81_RS13505"/>
+              <fbc:geneProductRef fbc:geneProduct="G_ACZ81_RS13510"/>
+            </fbc:or>
             <fbc:geneProductRef fbc:geneProduct="G_ACZ81_RS09280"/>
           </fbc:and>
         </fbc:geneProductAssociation>
@@ -62655,6 +62681,7 @@
         </listOfProducts>
         <fbc:geneProductAssociation>
           <fbc:or>
+            <fbc:geneProductRef fbc:geneProduct="G_ACZ81_RS02770"/>
             <fbc:geneProductRef fbc:geneProduct="G_ACZ81_RS18510"/>
             <fbc:geneProductRef fbc:geneProduct="G_ACZ81_RS07295"/>
           </fbc:or>
@@ -62687,6 +62714,7 @@
         </listOfProducts>
         <fbc:geneProductAssociation>
           <fbc:or>
+            <fbc:geneProductRef fbc:geneProduct="G_ACZ81_RS02770"/>
             <fbc:geneProductRef fbc:geneProduct="G_ACZ81_RS18510"/>
             <fbc:geneProductRef fbc:geneProduct="G_ACZ81_RS07295"/>
           </fbc:or>
@@ -62719,7 +62747,7 @@
           <speciesReference species="M_cpd00006_c0" stoichiometry="1" constant="true"/>
         </listOfProducts>
         <fbc:geneProductAssociation>
-          <fbc:geneProductRef fbc:geneProduct="G_ACZ81_RS18510"/>
+          <fbc:geneProductRef fbc:geneProduct="G_ACZ81_RS06945"/>
         </fbc:geneProductAssociation>
       </reaction>
       <reaction metaid="meta_R_rxn01079_c0" sboTerm="SBO:0000176" id="R_rxn01079_c0" name="L-gulonate:NADP+ 6-oxidoreductase" reversible="true" fast="false" fbc:lowerFluxBound="cobra_default_lb" fbc:upperFluxBound="cobra_default_ub">
@@ -62929,8 +62957,12 @@
         </listOfProducts>
         <fbc:geneProductAssociation>
           <fbc:or>
-            <fbc:geneProductRef fbc:geneProduct="G_ACZ81_RS14595"/>
+            <fbc:geneProductRef fbc:geneProduct="G_ACZ81_RS02770"/>
+            <fbc:geneProductRef fbc:geneProduct="G_ACZ81_RS18510"/>
+            <fbc:geneProductRef fbc:geneProduct="G_ACZ81_RS07295"/>
             <fbc:geneProductRef fbc:geneProduct="G_ACZ81_RS09945"/>
+            <fbc:geneProductRef fbc:geneProduct="G_ACZ81_RS14595"/>
+            <fbc:geneProductRef fbc:geneProduct="G_ACZ81_RS15450"/>
           </fbc:or>
         </fbc:geneProductAssociation>
       </reaction>
@@ -63117,10 +63149,9 @@
         </listOfProducts>
         <fbc:geneProductAssociation>
           <fbc:or>
-            <fbc:geneProductRef fbc:geneProduct="G_ACZ81_RS19665"/>
+            <fbc:geneProductRef fbc:geneProduct="G_ACZ81_RS02770"/>
+            <fbc:geneProductRef fbc:geneProduct="G_ACZ81_RS07000"/>
             <fbc:geneProductRef fbc:geneProduct="G_ACZ81_RS09935"/>
-            <fbc:geneProductRef fbc:geneProduct="G_ACZ81_RS14595"/>
-            <fbc:geneProductRef fbc:geneProduct="G_ACZ81_RS09945"/>
           </fbc:or>
         </fbc:geneProductAssociation>
       </reaction>
@@ -63345,7 +63376,6 @@
         <fbc:geneProductAssociation>
           <fbc:or>
             <fbc:geneProductRef fbc:geneProduct="G_ACZ81_RS02770"/>
-            <fbc:geneProductRef fbc:geneProduct="G_ACZ81_RS01595"/>
             <fbc:geneProductRef fbc:geneProduct="G_ACZ81_RS07000"/>
           </fbc:or>
         </fbc:geneProductAssociation>
@@ -64162,7 +64192,11 @@
           <speciesReference species="M_cpd00599_c0" stoichiometry="1" constant="true"/>
         </listOfProducts>
         <fbc:geneProductAssociation>
-          <fbc:geneProductRef fbc:geneProduct="G_ACZ81_RS18260"/>
+          <fbc:or>
+            <fbc:geneProductRef fbc:geneProduct="G_ACZ81_RS14055"/>
+            <fbc:geneProductRef fbc:geneProduct="G_ACZ81_RS02375"/>
+            <fbc:geneProductRef fbc:geneProduct="G_ACZ81_RS18260"/>
+          </fbc:or>
         </fbc:geneProductAssociation>
       </reaction>
       <reaction metaid="meta_R_rxn02169_c0" sboTerm="SBO:0000176" id="R_rxn02169_c0" name="Glutaconyl-1-CoA carboxy-lyase [c0]" reversible="false" fast="false" fbc:lowerFluxBound="cobra_default_ub" fbc:upperFluxBound="cobra_default_ub">
@@ -64217,7 +64251,10 @@
           <speciesReference species="M_cpd00714_c0" stoichiometry="1" constant="true"/>
         </listOfProducts>
         <fbc:geneProductAssociation>
-          <fbc:geneProductRef fbc:geneProduct="G_ACZ81_RS07000"/>
+          <fbc:or>
+            <fbc:geneProductRef fbc:geneProduct="G_ACZ81_RS02770"/>
+            <fbc:geneProductRef fbc:geneProduct="G_ACZ81_RS07000"/>
+          </fbc:or>
         </fbc:geneProductAssociation>
       </reaction>
       <reaction metaid="meta_R_rxn02319_c0" sboTerm="SBO:0000176" id="R_rxn02319_c0" name="ATP:L-fuculose 1-phosphotransferase [c0]" reversible="false" fast="false" fbc:lowerFluxBound="cobra_default_ub" fbc:upperFluxBound="cobra_default_ub">
@@ -64696,7 +64733,10 @@
           <speciesReference species="M_cpd11408_c0" stoichiometry="1" constant="true"/>
         </listOfProducts>
         <fbc:geneProductAssociation>
-          <fbc:geneProductRef fbc:geneProduct="G_ACZ81_RS14055"/>
+          <fbc:or>
+            <fbc:geneProductRef fbc:geneProduct="G_ACZ81_RS14055"/>
+            <fbc:geneProductRef fbc:geneProduct="G_ACZ81_RS02375"/>
+          </fbc:or>
         </fbc:geneProductAssociation>
       </reaction>
       <reaction metaid="meta_R_rxn05127_c0" sboTerm="SBO:0000176" id="R_rxn05127_c0" name="4-(gamma-L-glutamylamino)butanal:NADP+ oxidoreductase [c0]" reversible="false" fast="false" fbc:lowerFluxBound="cobra_default_ub" fbc:upperFluxBound="cobra_default_ub">
@@ -64861,7 +64901,8 @@
         </listOfProducts>
         <fbc:geneProductAssociation>
           <fbc:or>
-            <fbc:geneProductRef fbc:geneProduct="G_ACZ81_RS14595"/>
+            <fbc:geneProductRef fbc:geneProduct="G_ACZ81_RS02770"/>
+            <fbc:geneProductRef fbc:geneProduct="G_ACZ81_RS07000"/>
             <fbc:geneProductRef fbc:geneProduct="G_ACZ81_RS09935"/>
           </fbc:or>
         </fbc:geneProductAssociation>
@@ -68472,19 +68513,6 @@
           </rdf:RDF>
         </annotation>
       </fbc:geneProduct>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS18645" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS18645" fbc:name="ACZ81_RS18645" fbc:label="G_ACZ81_RS18645">
-        <annotation>
-          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
-            <rdf:Description rdf:about="#meta_G_ACZ81_RS18645">
-              <bqbiol:is>
-                <rdf:Bag>
-                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_061486760.1"/>
-                </rdf:Bag>
-              </bqbiol:is>
-            </rdf:Description>
-          </rdf:RDF>
-        </annotation>
-      </fbc:geneProduct>
       <fbc:geneProduct metaid="meta_G_ACZ81_RS08280" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS08280" fbc:name="ACZ81_RS08280" fbc:label="G_ACZ81_RS08280">
         <annotation>
           <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
@@ -69142,19 +69170,6 @@
               <bqbiol:is>
                 <rdf:Bag>
                   <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014950183.1"/>
-                </rdf:Bag>
-              </bqbiol:is>
-            </rdf:Description>
-          </rdf:RDF>
-        </annotation>
-      </fbc:geneProduct>
-      <fbc:geneProduct metaid="meta_G_ACZ81_RS07450" sboTerm="SBO:0000243" fbc:id="G_ACZ81_RS07450" fbc:name="ACZ81_RS07450" fbc:label="G_ACZ81_RS07450">
-        <annotation>
-          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
-            <rdf:Description rdf:about="#meta_G_ACZ81_RS07450">
-              <bqbiol:is>
-                <rdf:Bag>
-                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_081106073.1"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -78088,6 +78103,10 @@
       <fbc:geneProduct fbc:id="G_ACZ81_RS20345" fbc:name="G_ACZ81_RS20345" fbc:label="G_ACZ81_RS20345"/>
       <fbc:geneProduct fbc:id="G_ACZ81_RS20340" fbc:name="G_ACZ81_RS20340" fbc:label="G_ACZ81_RS20340"/>
       <fbc:geneProduct fbc:id="G_ACZ81_RS20360" fbc:name="G_ACZ81_RS20360" fbc:label="G_ACZ81_RS20360"/>
+      <fbc:geneProduct fbc:id="G_ACZ81_RS18590" fbc:name="G_ACZ81_RS18590" fbc:label="G_ACZ81_RS18590"/>
+      <fbc:geneProduct fbc:id="G_ACZ81_RS18595" fbc:name="G_ACZ81_RS18595" fbc:label="G_ACZ81_RS18595"/>
+      <fbc:geneProduct fbc:id="G_ACZ81_RS17900" fbc:name="G_ACZ81_RS17900" fbc:label="G_ACZ81_RS17900"/>
+      <fbc:geneProduct fbc:id="G_ACZ81_RS18215" fbc:name="G_ACZ81_RS18215" fbc:label="G_ACZ81_RS18215"/>
     </fbc:listOfGeneProducts>
   </model>
 </sbml>


### PR DESCRIPTION
#### Main improvements in this PR:

This pull request:

- Sets the GPRs of `rxn05215_c0` and `rxn08661_c0` to `ACZ81_RS07230 or ACZ81_RS11680`; see [MIT1002 PR #281](https://github.com/C-CoMP-STC/GEM-mit1002/pull/281)
- Sets the GPR of `rxn05221_c0` to `ACZ81_RS09455 or ACZ81_RS06100`; see [MIT1002 PR #281](https://github.com/C-CoMP-STC/GEM-mit1002/pull/281)
- Sets the GPR of `rxn05298_c0` to `ACZ81_RS11460`; see [MIT1002 PR #281](https://github.com/C-CoMP-STC/GEM-mit1002/pull/281)
- Sets the GPR of `lipoyl_synth` to `(ACZ81_RS13505 or ACZ81_RS13510) and ACZ81_RS09280`; see [MIT1002 PR #282](https://github.com/C-CoMP-STC/GEM-mit1002/pull/282)
- Sets the GPR of `rxn05148_c0` to `(ACZ81_RS04635 and ACZ81_RS04625 and ACZ81_RS04620 and ACZ81_RS04630) or (ACZ81_RS18590 and ACZ81_RS18595)`; see [MIT1002 PR #284](https://github.com/C-CoMP-STC/GEM-mit1002/pull/284)
- Sets the GPR of `rxn00324_c0` to `ACZ81_RS02770 or ACZ81_RS18510 or ACZ81_RS07295 or ACZ81_RS09945 or ACZ81_RS14595 or ACZ81_RS15450`; see [MIT1002 PR #285](https://github.com/C-CoMP-STC/GEM-mit1002/pull/285)
- Sets the GPRs of `rxn00500_c0`, `rxn00512_c0`, and `rxn11732_c0` to `ACZ81_RS02770 or ACZ81_RS07000 or ACZ81_RS09935`; see MIT1002 PRs [#285](https://github.com/C-CoMP-STC/GEM-mit1002/pull/285) and [#318](https://github.com/C-CoMP-STC/GEM-mit1002/pull/318)
- Sets the GPRs of `rxn00536_c0`, `rxn00765_c0`, and `rxn01281_c0` to `ACZ81_RS02770 or ACZ81_RS18510 or ACZ81_RS07295`; see [MIT1002 PR #285](https://github.com/C-CoMP-STC/GEM-mit1002/pull/285)
- Sets the GPR of `rxn01043_c0` to `ACZ81_RS06945`; see [MIT1002 PR #285](https://github.com/C-CoMP-STC/GEM-mit1002/pull/285)
- Sets the GPR of `rxn01832_c0` to `ACZ81_RS18510 or ACZ81_RS07295 or ACZ81_RS11975`; see [MIT1002 PR #285](https://github.com/C-CoMP-STC/GEM-mit1002/pull/285)
- Sets the GPRs of `rxn00543_c0`, `rxn00762_c0`, `rxn00763_c0`, `rxn01101_c0`, `rxn01280_c0`, `rxn01710_c0`, `rxn02235_c0` to `ACZ81_RS02770 or ACZ81_RS07000`; see [MIT1002 PR #285](https://github.com/C-CoMP-STC/GEM-mit1002/pull/285)
- Sets the GPR of `rxn01480_c0` to `ACZ81_RS02770 or ACZ81_RS07000 or ACZ81_RS16020` (different from the MIT1002 GPR in [#285](https://github.com/C-CoMP-STC/GEM-mit1002/pull/285) because HOT1A3 has one more isozyme for this reaction than MIT1002)
- Sets the GPR of `rxn10770_c0` to `ACZ81_RS02770 or ACZ81_RS07000 or ACZ81_RS14060 or ACZ81_RS12500`; see [MIT1002 PR #285](https://github.com/C-CoMP-STC/GEM-mit1002/pull/285)
- Sets the GPRs of `aminopent_redox` and `rxn01851_c0` to `ACZ81_RS14055 or ACZ81_RS02375 or ACZ81_RS15990`; see [MIT1002 PR #288](https://github.com/C-CoMP-STC/GEM-mit1002/pull/288)
- Sets the GPR of `rxn00183_c0` to `ACZ81_RS14055 or ACZ81_RS02375 or ACZ81_RS15990 or ACZ81_RS02780`; see [MIT1002 PR #288](https://github.com/C-CoMP-STC/GEM-mit1002/pull/288)
- Sets the GPRs of `rxn00506_c0`, `rxn00508_c0`, `rxn00653_c0`, `rxn00979_c0`, `rxn01286_c0`, `rxn01867_c0`, `rxn02853_c0`, `rxn05126_c0`, `rxn05734_c0`, `rxn05735_c0`, and `rxn23850_c0` to `ACZ81_RS14055 or ACZ81_RS02375`; see [MIT1002 PR #288](https://github.com/C-CoMP-STC/GEM-mit1002/pull/288)
- Sets the GPRs of `rxn00507_c0` and `rxn01459_c0` to `ACZ81_RS14055`; see [MIT1002 PR #288](https://github.com/C-CoMP-STC/GEM-mit1002/pull/288)
- Sets the GPR of `rxn02107_c0` to `ACZ81_RS14055 or ACZ81_RS02375 or ACZ81_RS18260`; see [MIT1002 PR #288](https://github.com/C-CoMP-STC/GEM-mit1002/pull/288)
- Sets the GPR of `rxn00623_c0` to `ACZ81_RS16285 and (ACZ81_RS16290 or ACZ81_RS17900)`; see [MIT1002 PR #302](https://github.com/C-CoMP-STC/GEM-mit1002/pull/302)
- Sets the GPR of `rxn08783_c0` to `ACZ81_RS12895 or ACZ81_RS16060`; see [MIT1002 PR #304](https://github.com/C-CoMP-STC/GEM-mit1002/pull/304)
- Sets the GPR of `rxn00452_c0` to `ACZ81_RS18215`; see [MIT1002 PR #315](https://github.com/C-CoMP-STC/GEM-mit1002/pull/315)
- Removes `ACZ81_RS18645` from the model; see [MIT1002 PR #315](https://github.com/C-CoMP-STC/GEM-mit1002/pull/315)
- Removes `ACZ81_RS07450` from the model; see [MIT1002 PR #281](https://github.com/C-CoMP-STC/GEM-mit1002/pull/281)

All of the genes mentioned above are reciprocal best BLAST hits of MIT1002 genes in mentioned in the linked PRs, except for `ACZ81_RS16020`, whose reciprocal best hit in the MIT1002 genome is a pseudogene.

**I hereby confirm that I have:**
- [X] Made my edits to the model on the XML file
- [ ] Tested my code on my own computer for running the model
- [X] Selected `develop` as a target branch
- [ ] Any removed reactions and metabolites have been moved to the corresponding deprecated identifier lists